### PR TITLE
I2C communication not wotking because of wrong address

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -209,7 +209,7 @@ macro_rules! hal {
                     // START and prepare to send `bytes`
                     self.i2c.cr2.write(|w| {
                         w.sadd()
-                            .bits(u16::from(addr))
+                            .bits(u16::from(addr << 1))
                             .rd_wrn()
                             .clear_bit()
                             .nbytes()
@@ -257,7 +257,7 @@ macro_rules! hal {
                     // START and prepare to send `bytes`
                     self.i2c.cr2.write(|w| {
                         w.sadd()
-                            .bits(u16::from(addr))
+                            .bits(u16::from(addr << 1))
                             .rd_wrn()
                             .clear_bit()
                             .nbytes()
@@ -283,7 +283,7 @@ macro_rules! hal {
                     // reSTART and prepare to receive bytes into `buffer`
                     self.i2c.cr2.write(|w| {
                         w.sadd()
-                            .bits(u16::from(addr))
+                            .bits(u16::from(addr << 1))
                             .rd_wrn()
                             .set_bit()
                             .nbytes()


### PR DESCRIPTION
I2C communications are not working because the address is not correctly written in SADD (CR2).

The address must be shifted because the LSB of SADD is ignore in 7 bits mode and we are only managing 7 bit mode.

_Extract for CR2 register from documentation :_

Bits 7:1 SADD[7:1]: Slave address bit 7:1 (master mode)
In 7-bit addressing mode (ADD10 = 0):
These bits should be written with the 7-bit slave address to be sent
In 10-bit addressing mode (ADD10 = 1):
These bits should be written with bits 7:1 of the slave address to be sent.
Note: Changing these bits when the START bit is set is not allowed.


Bit 0 SADD0: Slave address bit 0 (master mode)
In 7-bit addressing mode (ADD10 = 0):
This bit is don’t care
In 10-bit addressing mode (ADD10 = 1):
This bit should be written with bit 0 of the slave address to be sent
Note: Changing these bits when the START bit is set is not allowed.
