### PR TITLE
Add support for GPIO AF14, bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "0BSD"
 name = "stm32f3xx-hal"
 repository = "https://github.com/stm32-rs/stm32f3xx-hal"
 documentation = "https://docs.rs/stm32f3xx-hal"
-version = "0.1.4"
+version = "0.1.5"
 
 [package.metadata.docs.rs]
 features = ["stm32f303", "rt"]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -98,7 +98,7 @@ macro_rules! gpio {
 
             use crate::rcc::AHB;
             use super::{
-                AF4, AF5, AF6, AF7, Floating, GpioExt, Input, OpenDrain, Output,
+                AF4, AF5, AF6, AF7, AF14, Floating, GpioExt, Input, OpenDrain, Output,
                 PullDown, PullUp, PushPull,
             };
 
@@ -321,6 +321,29 @@ macro_rules! gpio {
                         let af = 7;
                         let offset = 4 * ($i % 8);
 
+                        afr.afr().modify(|r, w| unsafe {
+                            w.bits((r.bits() & !(0b1111 << offset)) | (af << offset))
+                        });
+
+                        $PXi { _mode: PhantomData }
+                    }
+
+                    /// Configures the pin to serve as alternate function 14 (AF14)
+                    pub fn into_af14(
+                        self,
+                        moder: &mut MODER,
+                        afr: &mut $AFR,
+                    ) -> $PXi<AF14> {
+                        let offset = 2 * $i;
+
+                        // alternate function mode
+                        let mode = 0b10;
+                        moder.moder().modify(|r, w| unsafe {
+                            w.bits((r.bits() & !(0b11 << offset)) | (mode << offset))
+                        });
+
+                        let af = 14;
+                        let offset = 4 * ($i % 8);
                         afr.afr().modify(|r, w| unsafe {
                             w.bits((r.bits() & !(0b1111 << offset)) | (af << offset))
                         });


### PR DESCRIPTION
This PR adds support for GPIO configuration with AF14, which is needed for USB peripheral.