### PR TITLE
0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "0BSD"
 name = "stm32f3xx-hal"
 repository = "https://github.com/stm32-rs/stm32f3xx-hal"
 documentation = "https://docs.rs/stm32f3xx-hal"
-version = "0.1.5"
+version = "0.2.0"
 
 [package.metadata.docs.rs]
 features = ["stm32f303", "rt"]


### PR DESCRIPTION
There's breaking changes with the update to `stm32f3@0.7.1` (including correcting the mappings for devices) and using `v2` of `OutputPin` / `InputPin`, so we're changing the minor version.