### PR TITLE
Readd `into_floating_input`

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -464,6 +464,27 @@ macro_rules! gpio {
                             }
                         )*
 
+                        /// Configures the pin to operate as a floating input pin
+                        pub fn into_floating_input(
+                            self,
+                            moder: &mut MODER,
+                            pupdr: &mut PUPDR,
+                        ) -> $PXi<Input<Floating>> {
+                            let offset = 2 * $i;
+
+                            // input mode
+                            moder
+                                .moder()
+                                .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
+
+                            // no pull-up or pull-down
+                            pupdr
+                                .pupdr()
+                                .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
+
+                            $PXi { _mode: PhantomData }
+                        }
+
                         /// Configures the pin to operate as a pulled down input pin
                         pub fn into_pull_down_input(
                             self,


### PR DESCRIPTION
I noticed, that the `into_floating_input` method went missing. My project, which used it before did not compile. Something like this would'nt compile anymore. 

```rust
fn main() -> ! {
    let dp = stm32::Peripherals::take().unwrap();
    let mut gpioa = dp.GPIOA.split(&mut rcc.ahb);

    let user_button = gpioa
        .pa0
        .into_floating_input(&mut gpioa.moder, &mut gpioa.pupdr);

    loop {}
}
```

And when poking around, I saw the implementation was accidentally deleted in this commit:

https://github.com/stm32-rs/stm32f3xx-hal/pull/21/commits/684e7bd8c1a1f037ef3b0a6d63609de06bea043b