### PR TITLE
Restore `into_floating_input`

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -464,6 +464,26 @@ macro_rules! gpio {
                             }
                         )*
 
+                        pub fn into_floating_input(
+                            self,
+                            moder: &mut MODER,
+                            pupdr: &mut PUPDR,
+                        ) -> $PXi<Input<Floating>> {
+                            let offset = 2 * $i;
+
+                            // input mode
+                            moder
+                                .moder()
+                                .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
+
+                            // no pull-up or pull-down
+                            pupdr
+                                .pupdr()
+                                .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
+
+                            $PXi { _mode: PhantomData }
+                        }
+
                         /// Configures the pin to operate as a pulled down input pin
                         pub fn into_pull_down_input(
                             self,


### PR DESCRIPTION
This was removed (seemingly accidentally) by commit:
684e7bd8c1a1f037ef3b0a6d63609de06bea043b