### PR TITLE
Support devices with 2-bit PLLSRC fields

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -342,9 +342,9 @@ impl CFGR {
         if let Some((pllmul_bits, pllsrc)) = pll_options {
             // enable PLL and wait for it to be ready
             rcc.cfgr
-                .write(|w| w.pllmul().bits(pllmul_bits).pllsrc().variant(pllsrc));
+                .modify(|_, w| w.pllmul().bits(pllmul_bits).pllsrc().variant(pllsrc));
 
-            rcc.cr.write(|w| w.pllon().set_bit());
+            rcc.cr.modify(|_, w| w.pllon().set_bit());
 
             while rcc.cr.read().pllrdy().bit_is_clear() {}
         }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -189,7 +189,12 @@ impl CFGR {
     }
 
     /// Returns a tuple of the (pllsrclk frequency, pllmul, and pllsrc).
-    #[cfg(not(any(feature = "stm32f302", feature = "stm32f303")))]
+    #[cfg(not(any(
+        feature = "stm32f302",
+        feature = "stm32f303xd",
+        feature = "stm32f303xe",
+        feature = "stm32f398"
+    )))]
     fn calc_pll(&self) -> (u32, u32, rcc::cfgr::PLLSRCW) {
         let pllsrcclk = self.hse.unwrap_or(HSI / 2);
         let pllmul = self.sysclk.unwrap_or(pllsrcclk) / pllsrcclk;
@@ -203,7 +208,12 @@ impl CFGR {
     }
 
     /// Returns a tuple of the (pllsrclk frequency, pllmul, and pllsrc).
-    #[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
+    #[cfg(any(
+        feature = "stm32f302",
+        feature = "stm32f303xd",
+        feature = "stm32f303xe",
+        feature = "stm32f398",
+    ))]
     fn calc_pll(&self) -> (u32, u32, rcc::cfgr::PLLSRCW) {
         let mut pllsrcclk = self.hse.unwrap_or(HSI / 2);
         let mut pllmul = self.sysclk.unwrap_or(pllsrcclk) / pllsrcclk;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -233,19 +233,16 @@ impl CFGR {
     /// Returns a tuple containing the effective sysclk rate and optional pll settings.
     fn calc_sysclk(&self) -> (u32, Option<(u8, rcc::cfgr::PLLSRCW)>) {
         let (pllsrcclk, pllmul, pllsrc) = self.calc_pll();
+        if pllmul == 1 {
+            return (pllsrcclk, None);
+        }
 
         let pllmul = cmp::min(cmp::max(pllmul, 2), 16);
         let sysclk = pllmul * pllsrcclk;
         assert!(sysclk <= 72_000_000);
 
-        let pll_options = if pllmul == 2 {
-            None
-        } else {
-            let pllmul_bits = pllmul as u8 - 2;
-            Some((pllmul_bits, pllsrc))
-        };
-
-        (sysclk, pll_options)
+        let pllmul_bits = pllmul as u8 - 2;
+        (sysclk, Some((pllmul_bits, pllsrc)))
     }
 
     /// Freezes the clock configuration, making it effective


### PR DESCRIPTION
This allows us to use a 72mhz sysclk on stm32f303.  In the current
version, this is artificially locked to 64mhz by the hal (since the hal will never change pwm sources).

I also think this fixes a bug where we would never actually use the hse as the pll source.