### PR TITLE
Fix spi initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - This allow using 72 MHz `sysclk` on the `stm32f303`
 - Analog gpio trait ([#33](https://github.com/stm32-rs/stm32f3xx-hal/pull/33))
 - Add PWM Channels ([#34](https://github.com/stm32-rs/stm32f3xx-hal/pull/34))
+- SPI embedded hal modes are now public ([#35](https://github.com/stm32-rs/stm32f3xx-hal/pull/18))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `stm32f303` is now split into `stm32f303xd` and `stm32f303xe` as they provide
   different alternate gpio functions. `stm32f303` is still available.
 
+### Fixed
+
+- Fixed wrong initialization of the SPI ([#35](https://github.com/stm32-rs/stm32f3xx-hal/pull/18))
 
 ## [v0.3.0] - 2019-08-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,7 @@ required-features = ["rt", "stm32f303xc"]
 [[example]]
 name = "usb_serial"
 required-features = ["rt", "stm32f303xc", "stm32-usbd"]
+
+[[example]]
+name = "spi"
+required-features = ["stm32f303"]

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -1,0 +1,65 @@
+//! Example of configuring spi.
+//! Target board: STM32F3DISCOVERY
+#![no_std]
+#![no_main]
+
+extern crate panic_semihosting;
+
+use stm32f3xx_hal as hal;
+
+use cortex_m_rt::entry;
+
+use hal::prelude::*;
+use hal::spi::{Mode, Phase, Polarity, Spi};
+use hal::stm32;
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+    let mut gpioa = dp.GPIOA.split(&mut rcc.ahb);
+
+    let clocks = rcc
+        .cfgr
+        .use_hse(8.mhz())
+        .sysclk(48.mhz())
+        .pclk1(24.mhz())
+        .freeze(&mut flash.acr);
+
+    // Configure pins for SPI
+    let sck = gpioa.pa5.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
+    let miso = gpioa.pa6.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
+    let mosi = gpioa.pa7.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
+
+    let spi_mode = Mode {
+        polarity: Polarity::IdleLow,
+        phase: Phase::CaptureOnFirstTransition,
+    };
+
+    let mut spi = Spi::spi1(
+        dp.SPI1,
+        (sck, miso, mosi),
+        spi_mode,
+        3.mhz(),
+        clocks,
+        &mut rcc.apb2,
+    );
+
+    // Create an `u8` array, which can be transfered via SPI.
+    let msg_send: [u8; 8] = [0xD, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF];
+    // Clone the array, as it would be mutually shared in `transfer` while simultaniously would be
+    // immutable shared in `assert_eq`.
+    let mut msg_sending = msg_send.clone();
+    // Transfer the content of the array via SPI and receive it's output.
+    // When MOSI and MISO pins are connected together, `msg_received` should receive the content.
+    // from `msg_sending`
+    let msg_received = spi.transfer(&mut msg_sending).unwrap();
+
+    // Check, if msg_send and msg_received are identical.
+    // This succeeds, when master and slave of the SPI are connected.
+    assert_eq!(msg_send, msg_received);
+
+    loop {}
+}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -175,13 +175,9 @@ macro_rules! hal {
                             .bit(mode.polarity == Polarity::IdleHigh)
                             .mstr()
                             .set_bit()
-                            .br();
-
-                        unsafe {
-                            w.bits(br);
-                        }
-
-                        w.spe()
+                            .br()
+                            .bits(br)
+                            .spe()
                             .set_bit()
                             .lsbfirst()
                             .clear_bit()

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -2,7 +2,8 @@
 
 use core::ptr;
 
-use crate::hal::spi::{FullDuplex, Mode, Phase, Polarity};
+use crate::hal::spi::FullDuplex;
+pub use crate::hal::spi::{Mode, Phase, Polarity};
 use crate::stm32::{SPI1, SPI2, SPI3};
 use nb;
 


### PR DESCRIPTION
I noticed, that the SPI is not working on my STM Discovery Board.
With some debugging, I first found out, that the SPI is for example not initialized as master.

I used [PyCortexMDebug](https://github.com/bnahill/PyCortexMDebug), to see if
the registers are correctly set in combination with the svd file provided by
[stm32-rs](https://github.com/stm32-rs/stm32-rs/blob/master/svd/vendor/en.stm32f3_svd.zip).

I did provide a minimal example, to reproduce these steps. Ideally, this example
should be extended, to be helpful for newcomers and not just a configuration
example, without using the SPI. Something like connecting MOSI and MISO to echo
the output and do `assert_eq!` or similar.

# Reproduction Steps:

`openocd.cfg`:

```cfg
source [find interface/stlink.cfg]
source [find target/stm32f3x.cfg]
```

```bash
openocd -c openocd.cfg
cargo run --example spi --features stm32f303
```

`openocd.gdb`

```gdb
target extended-remote :3333

svd STM32F303.svd

break examples/spi.rs:41
break examples/spi.rs:50

load

c

svd SPI1 CR1

c

svd SPI1 CR1
```

Output:

```gdb
Breakpoint 1, main () at examples/spi.rs:41
41          let _spi = Spi::spi1(
Fields in SPI1 CR1:
        BIDIMODE:  0  Bidirectional data mode enable
        BIDIOE:    0  Output enable in bidirectional mode
        CRCEN:     0  Hardware CRC calculation enable
        CRCNEXT:   0  CRC transfer next
        CRCL:      0  CRC length
        RXONLY:    0  Receive only
        SSM:       0  Software slave management
        SSI:       0  Internal slave select
        LSBFIRST:  0  Frame format
        SPE:       0  SPI enable
        BR:        0  Baud rate control
        MSTR:      0  Master selection
        CPOL:      0  Clock polarity
        CPHA:      0  Clock phase
halted: PC: 0x08000ace

Breakpoint 2, main () at examples/spi.rs:50
50          loop {}
Fields in SPI1 CR1:
        BIDIMODE:  0  Bidirectional data mode enable
        BIDIOE:    0  Output enable in bidirectional mode
        CRCEN:     0  Hardware CRC calculation enable
        CRCNEXT:   0  CRC transfer next
        CRCL:      0  CRC length
        RXONLY:    0  Receive only
        SSM:       1  Software slave management
        SSI:       1  Internal slave select
        LSBFIRST:  0  Frame format
        SPE:       1  SPI enable
        BR:        0  Baud rate control
        MSTR:      0  Master selection
        CPOL:      1  Clock polarity
        CPHA:      1  Clock phase
```

The fixed version outputs:

```gdb
Breakpoint 1, main () at examples/spi.rs:41
41          let _spi = Spi::spi1(
Fields in SPI1 CR1:
        BIDIMODE:  0  Bidirectional data mode enable
        BIDIOE:    0  Output enable in bidirectional mode
        CRCEN:     0  Hardware CRC calculation enable
        CRCNEXT:   0  CRC transfer next
        CRCL:      0  CRC length
        RXONLY:    0  Receive only
        SSM:       0  Software slave management
        SSI:       0  Internal slave select
        LSBFIRST:  0  Frame format
        SPE:       0  SPI enable
        BR:        0  Baud rate control
        MSTR:      0  Master selection
        CPOL:      0  Clock polarity
        CPHA:      0  Clock phase
halted: PC: 0x08000af8

Breakpoint 2, main () at examples/spi.rs:50
50          loop {}
Fields in SPI1 CR1:
        BIDIMODE:  0  Bidirectional data mode enable
        BIDIOE:    0  Output enable in bidirectional mode
        CRCEN:     0  Hardware CRC calculation enable
        CRCNEXT:   0  CRC transfer next
        CRCL:      0  CRC length
        RXONLY:    0  Receive only
        SSM:       1  Software slave management
        SSI:       1  Internal slave select
        LSBFIRST:  0  Frame format
        SPE:       1  SPI enable
        BR:        3  Baud rate control
        MSTR:      1  Master selection
        CPOL:      0  Clock polarity
        CPHA:      0  Clock phase
>>>

```

# Explanation

As we can see, the `mstr` bit is not set.

This is because, the register method was split up in multiple writes in

https://github.com/stm32-rs/stm32f3xx-hal/blob/4fd3ae6cf7bea8840462a2e3883ccac600cca6a7/src/spi.rs#L180

This was introduced in 96a03cd538105706b0dd0fc7bda7a40d8ff78383.

@dfrankland, i can't test if this is introduces a regression for the
`stm32f373`, as i only have the discovery board available.

https://docs.rs/svd2rust/0.16.1/svd2rust/#write

> The write method takes a closure with signature `(&mut W) -> &mut W`. If the
> "identity closure", `|w| w`, is passed then the write method will set the `CR2`
> register to its reset value. Otherwise, the closure specifies how the reset
> value will be modified before it's written to `CR2`.

So, when `w` is split up, every untouched bit is reset. As `MSTR` is set at the
beginning, it will be reset with the following write invocations.
