### PR TITLE
Update stm32f3 to 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#21](https://github.com/stm32-rs/stm32f3xx-hal/pull/21))
 - `stm32f303` is now split into `stm32f303xd` and `stm32f303xe` as they provide
   different alternate gpio functions. `stm32f303` is still available.
+- Bump `stm32f3` dependency to `0.9.0` ([#39](https://github.com/stm32-rs/stm32f3xx-hal/pull/39))
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cortex-m = ">=0.5.8,<0.7"
 cortex-m-rt = "0.6.8"
 embedded-hal = "0.2.3"
 nb = "0.1.2"
-stm32f3 = "0.8.0"
+stm32f3 = "0.9.0"
 
 [dependencies.bare-metal]
 version = "0.2.4"

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -84,15 +84,15 @@ pub struct I2c<I2C, PINS> {
 }
 
 macro_rules! busy_wait {
-    ($i2c:expr, $flag:ident) => {
+    ($i2c:expr, $flag:ident, $variant:ident) => {
         loop {
             let isr = $i2c.isr.read();
 
-            if isr.berr().bit_is_set() {
+            if isr.berr().is_error() {
                 return Err(Error::Bus);
-            } else if isr.arlo().bit_is_set() {
+            } else if isr.arlo().is_lost() {
                 return Err(Error::Arbitration);
-            } else if isr.$flag().bit_is_set() {
+            } else if isr.$flag().$variant() {
                 break;
             } else {
                 // try again
@@ -117,8 +117,8 @@ macro_rules! hal {
                     SCL: SclPin<$I2CX>,
                     SDA: SdaPin<$I2CX>,
                 {
-                    apb1.enr().modify(|_, w| w.$i2cXen().set_bit());
-                    apb1.rstr().modify(|_, w| w.$i2cXrst().set_bit());
+                    apb1.enr().modify(|_, w| w.$i2cXen().enabled());
+                    apb1.rstr().modify(|_, w| w.$i2cXrst().reset());
                     apb1.rstr().modify(|_, w| w.$i2cXrst().clear_bit());
 
                     let freq = freq.into().0;
@@ -196,7 +196,7 @@ macro_rules! hal {
                     });
 
                     // Enable the peripheral
-                    i2c.cr1.write(|w| w.pe().set_bit());
+                    i2c.cr1.write(|w| w.pe().enabled());
 
                     I2c { i2c, pins }
                 }
@@ -219,19 +219,19 @@ macro_rules! hal {
                         w.sadd()
                             .bits(u16::from(addr << 1))
                             .rd_wrn()
-                            .clear_bit()
+                            .write()
                             .nbytes()
                             .bits(bytes.len() as u8)
                             .start()
-                            .set_bit()
+                            .start()
                             .autoend()
-                            .set_bit()
+                            .automatic()
                     });
 
                     for byte in bytes {
                         // Wait until we are allowed to send data (START has been ACKed or last byte
                         // when through)
-                        busy_wait!(self.i2c, txis);
+                        busy_wait!(self.i2c, txis, is_empty);
 
                         // put byte on the wire
                         self.i2c.txdr.write(|w| w.txdata().bits(*byte));
@@ -267,44 +267,44 @@ macro_rules! hal {
                         w.sadd()
                             .bits(u16::from(addr << 1))
                             .rd_wrn()
-                            .clear_bit()
+                            .write()
                             .nbytes()
                             .bits(bytes.len() as u8)
                             .start()
-                            .set_bit()
+                            .start()
                             .autoend()
-                            .clear_bit()
+                            .software()
                     });
 
                     for byte in bytes {
                         // Wait until we are allowed to send data (START has been ACKed or last byte
                         // when through)
-                        busy_wait!(self.i2c, txis);
+                        busy_wait!(self.i2c, txis, is_empty);
 
                         // put byte on the wire
                         self.i2c.txdr.write(|w| w.txdata().bits(*byte));
                     }
 
                     // Wait until the last transmission is finished
-                    busy_wait!(self.i2c, tc);
+                    busy_wait!(self.i2c, tc, is_complete);
 
                     // reSTART and prepare to receive bytes into `buffer`
                     self.i2c.cr2.write(|w| {
                         w.sadd()
                             .bits(u16::from(addr << 1))
                             .rd_wrn()
-                            .set_bit()
+                            .read()
                             .nbytes()
                             .bits(buffer.len() as u8)
                             .start()
-                            .set_bit()
+                            .start()
                             .autoend()
-                            .set_bit()
+                            .automatic()
                     });
 
                     for byte in buffer {
                         // Wait until we have received something
-                        busy_wait!(self.i2c, rxne);
+                        busy_wait!(self.i2c, rxne, is_not_empty);
 
                         *byte = self.i2c.rxdr.read().rxdata().bits();
                     }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -195,14 +195,14 @@ impl CFGR {
         feature = "stm32f303xe",
         feature = "stm32f398"
     )))]
-    fn calc_pll(&self) -> (u32, u32, rcc::cfgr::PLLSRCW) {
+    fn calc_pll(&self) -> (u32, u32, rcc::cfgr::PLLSRC_A) {
         let pllsrcclk = self.hse.unwrap_or(HSI / 2);
         let pllmul = self.sysclk.unwrap_or(pllsrcclk) / pllsrcclk;
 
         let pllsrc = if self.hse.is_some() {
-            rcc::cfgr::PLLSRCW::HSE_DIV_PREDIV
+            rcc::cfgr::PLLSRC_A::HSE_DIV_PREDIV
         } else {
-            rcc::cfgr::PLLSRCW::HSI_DIV2
+            rcc::cfgr::PLLSRC_A::HSI_DIV2
         };
         (pllsrcclk, pllmul, pllsrc)
     }
@@ -214,24 +214,24 @@ impl CFGR {
         feature = "stm32f303xe",
         feature = "stm32f398",
     ))]
-    fn calc_pll(&self) -> (u32, u32, rcc::cfgr::PLLSRCW) {
+    fn calc_pll(&self) -> (u32, u32, rcc::cfgr::PLLSRC_A) {
         let mut pllsrcclk = self.hse.unwrap_or(HSI / 2);
         let mut pllmul = self.sysclk.unwrap_or(pllsrcclk) / pllsrcclk;
 
         let pllsrc = if self.hse.is_some() {
-            rcc::cfgr::PLLSRCW::HSE_DIV_PREDIV
+            rcc::cfgr::PLLSRC_A::HSE_DIV_PREDIV
         } else if pllmul > 16 {
             pllmul /= 2;
             pllsrcclk *= 2;
-            rcc::cfgr::PLLSRCW::HSI_DIV_PREDIV
+            rcc::cfgr::PLLSRC_A::HSI_DIV_PREDIV
         } else {
-            rcc::cfgr::PLLSRCW::HSI_DIV2
+            rcc::cfgr::PLLSRC_A::HSI_DIV2
         };
         (pllsrcclk, pllmul, pllsrc)
     }
 
     /// Returns a tuple containing the effective sysclk rate and optional pll settings.
-    fn calc_sysclk(&self) -> (u32, Option<(u8, rcc::cfgr::PLLSRCW)>) {
+    fn calc_sysclk(&self) -> (u32, Option<(u8, rcc::cfgr::PLLSRC_A)>) {
         let (pllsrcclk, pllmul, pllsrc) = self.calc_pll();
         if pllmul == 1 {
             return (pllsrcclk, None);

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -134,30 +134,15 @@ macro_rules! hal {
                     MOSI: MosiPin<$SPIX>,
                 {
                     // enable or reset $SPIX
-                    apb2.enr().modify(|_, w| w.$spiXen().set_bit());
-                    apb2.rstr().modify(|_, w| w.$spiXrst().set_bit());
+                    apb2.enr().modify(|_, w| w.$spiXen().enabled());
+                    apb2.rstr().modify(|_, w| w.$spiXrst().reset());
                     apb2.rstr().modify(|_, w| w.$spiXrst().clear_bit());
 
                     // FRXTH: RXNE event is generated if the FIFO level is greater than or equal to
                     //        8-bit
                     // DS: 8-bit data size
                     // SSOE: Slave Select output disabled
-                    spi.cr2
-                        .write(|w| unsafe {
-                            w.frxth().set_bit().ds().bits(0b111).ssoe().clear_bit()
-                        });
-
-                    let br = match clocks.$pclkX().0 / freq.into().0 {
-                        0 => unreachable!(),
-                        1..=2 => 0b000,
-                        3..=5 => 0b001,
-                        6..=11 => 0b010,
-                        12..=23 => 0b011,
-                        24..=39 => 0b100,
-                        40..=95 => 0b101,
-                        96..=191 => 0b110,
-                        _ => 0b111,
-                    };
+                    spi.cr2.write(|w| w.frxth().quarter().ds().eight_bit().ssoe().disabled());
 
                     // CPHA: phase
                     // CPOL: polarity
@@ -170,26 +155,42 @@ macro_rules! hal {
                     // CRCEN: hardware CRC calculation disabled
                     // BIDIMODE: 2 line unidirectional (full duplex)
                     spi.cr1.write(|w| {
-                        w.cpha()
-                            .bit(mode.phase == Phase::CaptureOnSecondTransition)
-                            .cpol()
-                            .bit(mode.polarity == Polarity::IdleHigh)
-                            .mstr()
-                            .set_bit()
-                            .br()
-                            .bits(br)
-                            .spe()
-                            .set_bit()
+                        w.mstr().master();
+
+                        match mode.phase {
+                            Phase::CaptureOnFirstTransition => w.cpha().first_edge(),
+                            Phase::CaptureOnSecondTransition => w.cpha().second_edge(),
+                        };
+
+                        match mode.polarity {
+                            Polarity::IdleLow => w.cpol().idle_low(),
+                            Polarity::IdleHigh => w.cpol().idle_high(),
+                        };
+
+                        match clocks.$pclkX().0 / freq.into().0 {
+                            0 => unreachable!(),
+                            1..=2 => w.br().div2(),
+                            3..=5 => w.br().div4(),
+                            6..=11 => w.br().div8(),
+                            12..=23 => w.br().div16(),
+                            24..=39 => w.br().div32(),
+                            40..=95 => w.br().div64(),
+                            96..=191 => w.br().div128(),
+                            _ => w.br().div256(),
+                        };
+
+                        w.spe()
+                            .enabled()
                             .lsbfirst()
-                            .clear_bit()
+                            .lsbfirst()
                             .ssi()
-                            .set_bit()
+                            .slave_not_selected()
                             .ssm()
-                            .set_bit()
+                            .enabled()
                             .crcen()
-                            .clear_bit()
+                            .disabled()
                             .bidimode()
-                            .clear_bit()
+                            .unidirectional()
                     });
 
                     Spi { spi, pins }
@@ -207,13 +208,13 @@ macro_rules! hal {
                 fn read(&mut self) -> nb::Result<u8, Error> {
                     let sr = self.spi.sr.read();
 
-                    Err(if sr.ovr().bit_is_set() {
+                    Err(if sr.ovr().is_overrun() {
                         nb::Error::Other(Error::Overrun)
-                    } else if sr.modf().bit_is_set() {
+                    } else if sr.modf().is_fault() {
                         nb::Error::Other(Error::ModeFault)
-                    } else if sr.crcerr().bit_is_set() {
+                    } else if sr.crcerr().is_no_match() {
                         nb::Error::Other(Error::Crc)
-                    } else if sr.rxne().bit_is_set() {
+                    } else if sr.rxne().is_not_empty() {
                         // NOTE(read_volatile) read only 1 byte (the svd2rust API only allows
                         // reading a half-word)
                         return Ok(unsafe {
@@ -227,13 +228,13 @@ macro_rules! hal {
                 fn send(&mut self, byte: u8) -> nb::Result<(), Error> {
                     let sr = self.spi.sr.read();
 
-                    Err(if sr.ovr().bit_is_set() {
+                    Err(if sr.ovr().is_overrun() {
                         nb::Error::Other(Error::Overrun)
-                    } else if sr.modf().bit_is_set() {
+                    } else if sr.modf().is_fault() {
                         nb::Error::Other(Error::ModeFault)
-                    } else if sr.crcerr().bit_is_set() {
+                    } else if sr.crcerr().is_no_match() {
                         nb::Error::Other(Error::Crc)
-                    } else if sr.txe().bit_is_set() {
+                    } else if sr.txe().is_empty() {
                         // NOTE(write_volatile) see note above
                         unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte) }
                         return Ok(());

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -34,10 +34,10 @@ unsafe impl UsbPeripheral for Peripheral {
 
         cortex_m::interrupt::free(|_| {
             // Enable USB peripheral
-            rcc.apb1enr.modify(|_, w| w.usben().set_bit());
+            rcc.apb1enr.modify(|_, w| w.usben().enabled());
 
             // Reset USB peripheral
-            rcc.apb1rstr.modify(|_, w| w.usbrst().set_bit());
+            rcc.apb1rstr.modify(|_, w| w.usbrst().reset());
             rcc.apb1rstr.modify(|_, w| w.usbrst().clear_bit());
         });
     }


### PR DESCRIPTION
This PR updates to `stm32f3 v0.9`.

Also, register access methods where upgraded to use the variant based methods, introduced in the svd2rust version 16 (see the [CHANGELOG](https://github.com/rust-embedded/svd2rust/blob/master/CHANGELOG.md#added)).

I reduced the scope to change only the peripherals, where it worked seamless.

I've prepared PR's for the missing peripheral modules, but I did'nt include them, as `stm32f3` does not provide the variant methods for all stm32f3 devices, because they are'nt documented yet.