### PR TITLE
Add rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: rust
+
 rust:
   - stable
   - nightly
+
 cache: cargo
+
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
-script:
+
+install:
   - rustup target add thumbv7em-none-eabihf
+
+script:
   - ci/build.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
 
 install:
   - rustup target add thumbv7em-none-eabihf
+  - rustup component add rustfmt
 
 script:
   - ci/build.py
+  - cargo fmt -- --check

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,9 +3,9 @@
 pub use crate::flash::FlashExt as _stm32f3xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32f3xx_hal_gpio_GpioExt;
 #[cfg(feature = "unproven")]
-pub use crate::hal::digital::v2::OutputPin as _embedded_hal_digital_OutputPin;
-#[cfg(feature = "unproven")]
 pub use crate::hal::digital::v2::InputPin as _embedded_hal_digital_InputPin;
+#[cfg(feature = "unproven")]
+pub use crate::hal::digital::v2::OutputPin as _embedded_hal_digital_OutputPin;
 #[cfg(feature = "unproven")]
 pub use crate::hal::digital::v2::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin;
 #[cfg(feature = "unproven")]

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -368,7 +368,6 @@ impl CFGR {
                 })
         });
 
-
         Clocks {
             hclk: Hertz(hclk),
             pclk1: Hertz(pclk1),
@@ -379,8 +378,6 @@ impl CFGR {
             usbclk_valid,
         }
     }
-
-
 }
 
 /// Frozen clock frequencies


### PR DESCRIPTION
As this crate is almost rustfmt compatible, why don't we add it to the CI?

Also, this moves the rustup invocations to `install` which travis provides.
This make no difference now, but if we add more ci jobs with `matrix`, rustup wouldn't be called for every job.