### PR TITLE
Add rcc variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Wrong frequency reported by `MonoTimer` ([#56](https://github.com/stm32-rs/stm32f3xx-hal/pull/56))
 - Use automatic mode with I2C autoend on `Read` ([#72](https://github.com/stm32-rs/stm32f3xx-hal/pull/72))
+- Wrong calculation of HCLK prescaler, if using a prescaler value equal or
+  higher than 64 ([#42](https://github.com/stm32-rs/stm32f3xx-hal/pull/42))
 
 ### Changed
 


### PR DESCRIPTION
This PR updates all register accesses to variants in the rcc and similar modules.

I took the opportunity to reorganize the usb rcc initialization to play nicer with variants.

~~I'm not really happy about:~~

https://github.com/stm32-rs/stm32f3xx-hal/blob/e09a86622c9dc9d421bd53f24f7ebc982505417a/src/rcc.rs#L292

~~but it works.~~

~~I wish [stm32rs](https://github.com/stm32-rs/stm32-rs) would implement `From<HPRE_A> -> u8`. I guess this is a [svd2rust](https://github.com/rust-embedded/svd2rust) thing.~~

Now using `u8::from()` for casting.
