### PR TITLE
Fix MonoTimer's frequency

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -86,7 +86,7 @@ impl MonoTimer {
         drop(dwt);
 
         MonoTimer {
-            frequency: clocks.sysclk(),
+            frequency: clocks.hclk(),
         }
     }
 


### PR DESCRIPTION
The `MonoTimer` internally counts the cycles of the Cortex core. So unless I am missing something, its frequency is HCLK, not SYSCLK, according to the reference manual. I also verified this as true on an STM32F303VC.

Without this fix `MonoTimer` is only usable for timing measurements if HCLK equals SYSCLK.