### PR TITLE
Fix SPI initialization to be MSB first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ rust:
   - stable
   - nightly
 
-cache: cargo
-
 matrix:
   allow_failures:
     - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implement blocking Write for UART
 - Implement blocking Read for I2C
 
+### Fixed
+- Regression in v0.4.0 that set SPI to LSB-first ordering
+
 ## [v0.4.0] - 2019-12-27
 
 ### Added

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -182,7 +182,7 @@ macro_rules! hal {
                         w.spe()
                             .enabled()
                             .lsbfirst()
-                            .lsbfirst()
+                            .msbfirst()
                             .ssi()
                             .slave_not_selected()
                             .ssm()


### PR DESCRIPTION
The comments indicate that the code is attempting to set the SPI order to MSB first, however it actually sets it to LSB first. Since most devices are MSB first, this is the correct choice.

Closes #59.