### PR TITLE
Fix docsrs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.4.0"
 
 [package.metadata.docs.rs]
 features = ["stm32f303xc", "rt", "stm32-usbd"]
+default-target = "x86_64-unknown-linux-gnu"
 
 [badges]
 travis-ci = { repository = "stm32-rs/stm32f3xx-hal" }


### PR DESCRIPTION
With the last release, the documentation would not build on docs.rs

Setting the `default-target` to `"x86_64-unknown-linux-gnu"` should fix this. 

Can be reverted, when https://github.com/rust-lang/docs.rs/issues/563 is resolved.

Fixes https://github.com/stm32-rs/stm32f3xx-hal/issues/46