### PR TITLE
Update stm32f3 to v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Wrong frequency reported by `MonoTimer` ([#56](https://github.com/stm32-rs/stm32f3xx-hal/pull/56))
 
+### Changed
+
+- Bump `stm32f3` dependency to `0.10.0` ([#42](https://github.com/stm32-rs/stm32f3xx-hal/pull/42))
+
 ## [v0.4.1] - 2020-03-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cortex-m = ">=0.5.8,<0.7"
 cortex-m-rt = "0.6.8"
 embedded-hal = "0.2.3"
 nb = "0.1.2"
-stm32f3 = "0.9.0"
+stm32f3 = "0.10.0"
 
 [dependencies.bare-metal]
 version = "0.2.4"


### PR DESCRIPTION
Some PR's could benefit from this change

And I do think, that it does more sense to split this out of #42. #42 could introduce bugs and it is a higher risk to merge it, just for the sake of updating stm32f3. 

This PR should have no risk, because it does not touch any of the existing code. 