### PR TITLE
Fixes for i2c Read 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Wrong frequency reported by `MonoTimer` ([#56](https://github.com/stm32-rs/stm32f3xx-hal/pull/56))
+- Use automatic mode with I2C autoend on `Read` ([#72](https://github.com/stm32-rs/stm32f3xx-hal/pull/72/))
 
 ### Changed
 


### PR DESCRIPTION
- Use automatic mode for autoend with `Read`
- Check for variant success first in `busy_wait` macro

Tested with the following embedded hal i2c drivers:
- bmp280 (barometer)
- em7180 (imu/ahrs)
- bno080 (ahrs wip)

