### PR TITLE
Change Into trait to From trait

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -53,21 +53,21 @@ impl U32Ext for u32 {
     }
 }
 
-impl Into<Hertz> for KiloHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000)
+impl From<KiloHertz> for Hertz {
+    fn from(val: KiloHertz) -> Self {
+        Self(val.0 * 1_000)
     }
 }
 
-impl Into<Hertz> for MegaHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000_000)
+impl From<MegaHertz> for Hertz {
+    fn from(val: MegaHertz) -> Self {
+        Self(val.0 * 1_000_000)
     }
 }
 
-impl Into<KiloHertz> for MegaHertz {
-    fn into(self) -> KiloHertz {
-        KiloHertz(self.0 * 1_000)
+impl From<MegaHertz> for KiloHertz {
+    fn from(val: MegaHertz) -> Self {
+        Self(val.0 * 1_000)
     }
 }
 


### PR DESCRIPTION
Change the `Into` traits to `From` traits, as `Into` is automatically available if `From` is implemented. `Into` should only be used if  `From` can not be implemented due to the orphan rule. 