### PR TITLE
Remove "extern crate" in favor "use"

### DIFF
--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use cortex_m_rt::entry;
 //use cortex_m_semihosting::hprintln;

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use stm32f3xx_hal as hal;
 

--- a/examples/toggle.rs
+++ b/examples/toggle.rs
@@ -6,7 +6,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use cortex_m_rt::entry;
 use stm32f3xx_hal::prelude::*;

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use cortex_m::asm::delay;
 use cortex_m_rt::entry;


### PR DESCRIPTION
`use panic_semihost as _` is more in line with 2018 edition.