### PR TITLE
Fix docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.4.1"
 
 [package.metadata.docs.rs]
 features = ["stm32f303xc", "rt", "stm32-usbd"]
-default-target = "x86_64-unknown-linux-gnu"
+targets = ["thumbv7em-none-eabihf"]
 
 [badges]
 travis-ci = { repository = "stm32-rs/stm32f3xx-hal" }


### PR DESCRIPTION
There was recently a change to docs.rs to allow tier 2 targets, such as thumbv7em-none-eabihf. In the process, the “set default target to x86_64” trick broke.