### PR TITLE
Clean up dependency versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,32 +19,32 @@ targets = ["thumbv7em-none-eabihf"]
 travis-ci = { repository = "stm32-rs/stm32f3xx-hal" }
 
 [dependencies]
-cortex-m = ">=0.5.8,<0.7"
-cortex-m-rt = "0.6.8"
-embedded-hal = "0.2.3"
-nb = "0.1.2"
-stm32f3 = "0.10.0"
+cortex-m = "0.6"
+cortex-m-rt = "0.6"
+embedded-hal = "0.2"
+nb = "0.1"
+stm32f3 = "0.10"
 
 [dependencies.bare-metal]
-version = "0.2.4"
+version = "0.2"
 features = ["const-fn"]
 
 [dependencies.cast]
 default-features = false
-version = "0.2.2"
+version = "0.2"
 
 [dependencies.void]
 default-features = false
-version = "1.0.2"
+version = "1"
 
 [dependencies.stm32-usbd]
-version = "0.5.0"
+version = "0.5"
 optional = true
 
 [dev-dependencies]
-panic-semihosting = "0.5.2"
-usb-device = "0.2.3"
-usbd-serial = "0.1.0"
+panic-semihosting = "0.5"
+usb-device = "0.2"
+usbd-serial = "0.1"
 
 [features]
 default = ["unproven"]


### PR DESCRIPTION
This PR changes the version specifications in the Cargo.toml:
 - `"0.y.z"` -> `"0.y"`
 - `"x.y.z"` -> `"x"`

This does not functionally change anything, since version strings
without any operators default to the caret requirement anyway ([see Cargo docs][1]).
This changes just makes it obvious.

[1]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html