### PR TITLE
Initial DMA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support for safe one-shot DMA transfers ([#86](https://github.com/stm32-rs/stm32f3xx-hal/pull/86))
+- DMA support for serial reception and transmission ([#86](https://github.com/stm32-rs/stm32f3xx-hal/pull/86))
+
 ### Fixed
 
 - `PLL` was calculated wrong for devices, which do not divide `HSI` ([#67](https://github.com/stm32-rs/stm32f3xx-hal/pull/67))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ targets = ["thumbv7em-none-eabihf"]
 travis-ci = { repository = "stm32-rs/stm32f3xx-hal" }
 
 [dependencies]
-as-slice = "0.1"
 cortex-m = "0.6"
 cortex-m-rt = "0.6"
 embedded-hal = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,3 +103,7 @@ required-features = ["rt", "stm32f303xc", "stm32-usbd"]
 [[example]]
 name = "spi"
 required-features = ["stm32f303"]
+
+[[example]]
+name = "serial_dma"
+required-features = ["stm32f303"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ targets = ["thumbv7em-none-eabihf"]
 travis-ci = { repository = "stm32-rs/stm32f3xx-hal" }
 
 [dependencies]
+as-slice = "0.1"
 cortex-m = "0.6"
 cortex-m-rt = "0.6"
 embedded-hal = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,16 +31,20 @@ version = "0.2"
 features = ["const-fn"]
 
 [dependencies.cast]
-default-features = false
 version = "0.2"
-
-[dependencies.void]
 default-features = false
+
+[dependencies.stable_deref_trait]
 version = "1"
+default-features = false
 
 [dependencies.stm32-usbd]
 version = "0.5"
 optional = true
+
+[dependencies.void]
+version = "1"
+default-features = false
 
 [dev-dependencies]
 panic-semihosting = "0.5"

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -9,11 +9,11 @@ use panic_semihosting as _;
 
 use cortex_m::singleton;
 use cortex_m_rt::entry;
-use stm32f3xx_hal::{prelude::*, serial::Serial, stm32};
+use stm32f3xx_hal::{pac, prelude::*, serial::Serial};
 
 #[entry]
 fn main() -> ! {
-    let dp = stm32::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -7,7 +7,6 @@
 
 use panic_semihosting as _;
 
-use core::pin::Pin;
 use cortex_m::singleton;
 use cortex_m_rt::entry;
 use stm32f3xx_hal::{prelude::*, serial::Serial, stm32};
@@ -43,11 +42,11 @@ fn main() -> ! {
     let (tx_channel, rx_channel) = (dma1.ch4, dma1.ch5);
 
     // start separate DMAs for sending and receiving the data
-    let sending = tx.write_all(Pin::new(tx_buf), tx_channel);
-    let receiving = rx.read_exact(Pin::new(rx_buf), rx_channel);
+    let sending = tx.write_all(tx_buf, tx_channel);
+    let receiving = rx.read_exact(rx_buf, rx_channel);
 
     // block until all data was transmitted and received
-    let (mut tx_buf, tx_channel, tx) = sending.wait();
+    let (tx_buf, tx_channel, tx) = sending.wait();
     let (rx_buf, rx_channel, rx) = receiving.wait();
 
     assert_eq!(tx_buf, rx_buf);

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -1,0 +1,69 @@
+//! Example of transmitting data over serial interface using DMA.
+//! For this to work, the PA9 and PA10 pins must be connected.
+//! Target board: STM32F3DISCOVERY
+
+#![no_std]
+#![no_main]
+
+use panic_semihosting as _;
+
+use core::pin::Pin;
+use cortex_m::singleton;
+use cortex_m_rt::entry;
+use stm32f3xx_hal::{prelude::*, serial::Serial, stm32};
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut gpioa = dp.GPIOA.split(&mut rcc.ahb);
+
+    let pins = (
+        gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh),
+        gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh),
+    );
+    let serial = Serial::usart1(dp.USART1, pins, 9600.bps(), clocks, &mut rcc.apb2);
+    let (tx, rx) = serial.split();
+
+    let dma1 = dp.DMA1.split(&mut rcc.ahb);
+
+    // the data we are going to send over serial
+    let tx_buf = singleton!(: [u8; 9] = *b"hello DMA").unwrap();
+    // the buffer we are going to receive the transmitted data in
+    let rx_buf = singleton!(: [u8; 9] = [0; 9]).unwrap();
+
+    // DMA channel selection depends on the peripheral:
+    // - USART1: TX = 4, RX = 5
+    // - USART2: TX = 6, RX = 7
+    // - USART3: TX = 3, RX = 2
+    let (tx_channel, rx_channel) = (dma1.ch4, dma1.ch5);
+
+    // start separate DMAs for sending and receiving the data
+    let sending = tx.write_all(Pin::new(tx_buf), tx_channel);
+    let receiving = rx.read_all(Pin::new(rx_buf), rx_channel);
+
+    // block until all data was transmitted and received
+    let (mut tx_buf, tx_channel, tx) = sending.wait();
+    let (rx_buf, rx_channel, rx) = receiving.wait();
+
+    assert_eq!(tx_buf, rx_buf);
+
+    // After a transfer is finished its parts can be re-used for another one.
+    tx_buf.copy_from_slice(b"hi again!");
+
+    let sending = tx.write_all(tx_buf, tx_channel);
+    let receiving = rx.read_all(rx_buf, rx_channel);
+
+    let (tx_buf, ..) = sending.wait();
+    let (rx_buf, ..) = receiving.wait();
+
+    assert_eq!(tx_buf, rx_buf);
+
+    loop {
+        continue;
+    }
+}

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
 
     // start separate DMAs for sending and receiving the data
     let sending = tx.write_all(Pin::new(tx_buf), tx_channel);
-    let receiving = rx.read_all(Pin::new(rx_buf), rx_channel);
+    let receiving = rx.read_exact(Pin::new(rx_buf), rx_channel);
 
     // block until all data was transmitted and received
     let (mut tx_buf, tx_channel, tx) = sending.wait();
@@ -56,7 +56,7 @@ fn main() -> ! {
     tx_buf.copy_from_slice(b"hi again!");
 
     let sending = tx.write_all(tx_buf, tx_channel);
-    let receiving = rx.read_all(rx_buf, rx_channel);
+    let receiving = rx.read_exact(rx_buf, rx_channel);
 
     let (tx_buf, ..) = sending.wait();
     let (rx_buf, ..) = receiving.wait();

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -1,8 +1,6 @@
 //! Direct memory access (DMA) controller
-
-// Currently DMA is only supported for STM32F303 MCUs.
-// Remove these `allow`s once all models have support.
-#![cfg_attr(not(feature = "stm32f303"), allow(unused_imports, unused_macros))]
+//!
+//! Currently DMA is only supported for STM32F303 MCUs.
 
 use crate::{
     rcc::AHB,

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -1,0 +1,473 @@
+//! Direct memory access (DMA) controller
+
+// Currently DMA is only supported for STM32F303 MCUs.
+// Remove these `allow`s once all models have support.
+#![cfg_attr(not(feature = "stm32f303"), allow(unused_imports, unused_macros))]
+
+use crate::{
+    rcc::AHB,
+    serial,
+    stm32::{self, dma1::ch::cr},
+};
+use cast::u16;
+use core::{
+    pin::Pin,
+    sync::atomic::{self, Ordering},
+};
+
+/// Extension trait to split a DMA peripheral into independent channels
+pub trait DmaExt {
+    /// The type to split the DMA into
+    type Channels;
+
+    /// Split the DMA into independent channels
+    fn split(self, ahb: &mut AHB) -> Self::Channels;
+}
+
+/// An in-progress one-shot DMA transfer
+pub struct Transfer<B, C: Channel, T> {
+    // This is always a `Some` outside of `drop`.
+    inner: Option<TransferInner<B, C, T>>,
+}
+
+impl<B, C: Channel, T> Transfer<B, C, T> {
+    /// Start a DMA transfer.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the DMA channel is configured correctly for
+    /// the given target and buffer.
+    pub unsafe fn start(buffer: Pin<B>, mut channel: C, target: T) -> Self
+    where
+        B: 'static,
+        T: Target<C>,
+    {
+        assert!(!channel.is_enabled());
+
+        atomic::compiler_fence(Ordering::Release);
+
+        channel.enable();
+
+        Self {
+            inner: Some(TransferInner {
+                buffer,
+                channel,
+                target,
+            }),
+        }
+    }
+
+    /// Is this transfer complete?
+    pub fn is_complete(&self) -> bool {
+        let inner = self.inner.as_ref().unwrap();
+        inner.channel.event_occured(Event::TransferComplete)
+    }
+
+    /// Stop this transfer and return ownership over its parts
+    pub fn stop(mut self) -> (Pin<B>, C, T) {
+        let mut inner = self.inner.take().unwrap();
+        inner.stop();
+
+        (inner.buffer, inner.channel, inner.target)
+    }
+
+    /// Block until this transfer is done and return ownership over its parts
+    pub fn wait(self) -> (Pin<B>, C, T) {
+        while !self.is_complete() {}
+
+        self.stop()
+    }
+}
+
+impl<B, C: Channel, T> Drop for Transfer<B, C, T> {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.as_mut() {
+            inner.stop();
+        }
+    }
+}
+
+/// This only exists so we can implement `Drop` for `Transfer`.
+struct TransferInner<B, C, T> {
+    buffer: Pin<B>,
+    channel: C,
+    target: T,
+}
+
+impl<B, C: Channel, T> TransferInner<B, C, T> {
+    /// Stop this transfer
+    fn stop(&mut self) {
+        self.channel.disable();
+        atomic::compiler_fence(Ordering::Acquire);
+    }
+}
+
+/// DMA address increment mode
+pub enum Increment {
+    /// Enable increment
+    Enable,
+    /// Disable increment
+    Disable,
+}
+
+impl From<Increment> for cr::PINC_A {
+    fn from(inc: Increment) -> Self {
+        match inc {
+            Increment::Enable => cr::PINC_A::ENABLED,
+            Increment::Disable => cr::PINC_A::DISABLED,
+        }
+    }
+}
+
+/// DMA word size
+pub enum WordSize {
+    /// 8 bits
+    Bits8,
+    /// 16 bits
+    Bits16,
+    /// 32 bits
+    Bits32,
+}
+
+impl From<WordSize> for cr::PSIZE_A {
+    fn from(size: WordSize) -> Self {
+        match size {
+            WordSize::Bits8 => cr::PSIZE_A::BITS8,
+            WordSize::Bits16 => cr::PSIZE_A::BITS16,
+            WordSize::Bits32 => cr::PSIZE_A::BITS32,
+        }
+    }
+}
+
+/// Channel priority level
+pub enum Priority {
+    /// Low
+    Low,
+    /// Medium
+    Medium,
+    /// High
+    High,
+    /// Very high
+    VeryHigh,
+}
+
+impl From<Priority> for cr::PL_A {
+    fn from(prio: Priority) -> Self {
+        match prio {
+            Priority::Low => cr::PL_A::LOW,
+            Priority::Medium => cr::PL_A::MEDIUM,
+            Priority::High => cr::PL_A::HIGH,
+            Priority::VeryHigh => cr::PL_A::VERYHIGH,
+        }
+    }
+}
+
+/// DMA transfer direction
+pub enum Direction {
+    /// From memory to peripheral
+    FromMemory,
+    /// From peripheral to memory
+    FromPeripheral,
+}
+
+impl From<Direction> for cr::DIR_A {
+    fn from(dir: Direction) -> Self {
+        match dir {
+            Direction::FromMemory => cr::DIR_A::FROMMEMORY,
+            Direction::FromPeripheral => cr::DIR_A::FROMPERIPHERAL,
+        }
+    }
+}
+
+/// DMA events
+pub enum Event {
+    /// First half of a transfer is done
+    HalfTransfer,
+    /// Transfer is complete
+    TransferComplete,
+    /// A transfer error occurred
+    TransferError,
+    /// Any of the above events occurred
+    Any,
+}
+
+/// Trait implemented by all DMA channels
+pub trait Channel: private::Channel {
+    /// Is the interrupt flag for the given event set?
+    fn event_occured(&self, event: Event) -> bool;
+    /// Clear the interrupt flag for the given event
+    fn clear_event(&mut self, event: Event);
+
+    /// Reset the control registers of this channel.
+    /// This stops any ongoing transfers.
+    fn reset(&mut self) {
+        self.ch().cr.reset();
+        self.ch().ndtr.reset();
+        self.ch().par.reset();
+        self.ch().mar.reset();
+        self.clear_event(Event::Any);
+    }
+
+    /// Set the base address of the peripheral data register from/to which the
+    /// data will be read/written.
+    ///
+    /// Only call this method on disabled channels.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this channel is enabled.
+    fn set_peripheral_address(&mut self, address: u32, inc: Increment) {
+        assert!(!self.is_enabled());
+
+        self.ch().par.write(|w| w.pa().bits(address));
+        self.ch().cr.modify(|_, w| w.pinc().variant(inc.into()));
+    }
+
+    /// Set the base address of the memory area from/to which
+    /// the data will be read/written.
+    ///
+    /// Only call this method on disabled channels.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this channel is enabled.
+    fn set_memory_address(&mut self, address: u32, inc: Increment) {
+        assert!(!self.is_enabled());
+
+        self.ch().mar.write(|w| w.ma().bits(address));
+        self.ch().cr.modify(|_, w| w.minc().variant(inc.into()));
+    }
+
+    /// Set the number of words to transfer.
+    ///
+    /// Only call this method on disabled channels.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this channel is enabled.
+    fn set_transfer_length(&mut self, len: usize) {
+        assert!(!self.is_enabled());
+
+        let len = u16(len).expect("DMA transfer length too large");
+        self.ch().ndtr.write(|w| w.ndt().bits(len));
+    }
+
+    /// Set the word size
+    fn set_word_size(&mut self, size: WordSize) {
+        let psize = size.into();
+        self.ch().cr.modify(|_, w| {
+            w.psize().variant(psize);
+            w.msize().variant(psize)
+        });
+    }
+
+    /// Set the priority level of this channel
+    fn set_priority_level(&mut self, priority: Priority) {
+        let pl = priority.into();
+        self.ch().cr.modify(|_, w| w.pl().variant(pl));
+    }
+
+    /// Set the transfer direction
+    fn set_direction(&mut self, direction: Direction) {
+        let dir = direction.into();
+        self.ch().cr.modify(|_, w| w.dir().variant(dir));
+    }
+
+    /// Enable the interrupt for the given event
+    fn listen(&mut self, event: Event) {
+        use Event::*;
+        match event {
+            HalfTransfer => self.ch().cr.modify(|_, w| w.htie().enabled()),
+            TransferComplete => self.ch().cr.modify(|_, w| w.tcie().enabled()),
+            TransferError => self.ch().cr.modify(|_, w| w.teie().enabled()),
+            Any => self.ch().cr.modify(|_, w| {
+                w.htie().enabled();
+                w.tcie().enabled();
+                w.teie().enabled()
+            }),
+        }
+    }
+
+    /// Disable the interrupt for the given event
+    fn unlisten(&mut self, event: Event) {
+        use Event::*;
+        match event {
+            HalfTransfer => self.ch().cr.modify(|_, w| w.htie().disabled()),
+            TransferComplete => self.ch().cr.modify(|_, w| w.tcie().disabled()),
+            TransferError => self.ch().cr.modify(|_, w| w.teie().disabled()),
+            Any => self.ch().cr.modify(|_, w| {
+                w.htie().disabled();
+                w.tcie().disabled();
+                w.teie().disabled()
+            }),
+        }
+    }
+
+    /// Start a transfer
+    fn enable(&mut self) {
+        self.clear_event(Event::Any);
+        self.ch().cr.modify(|_, w| w.en().enabled());
+    }
+
+    /// Stop the current transfer
+    fn disable(&mut self) {
+        self.ch().cr.modify(|_, w| w.en().disabled());
+    }
+
+    /// Is there a transfer in progress on this channel?
+    fn is_enabled(&self) -> bool {
+        self.ch().cr.read().en().is_enabled()
+    }
+}
+
+mod private {
+    use crate::stm32;
+
+    /// Channel methods private to this module
+    pub trait Channel {
+        /// Return the register block for this channel
+        fn ch(&self) -> &stm32::dma1::CH;
+    }
+}
+
+macro_rules! dma {
+    (
+        $DMAx:ident, $dmax:ident, $dmaxen:ident,
+        channels: {
+            $( $Ci:ident: (
+                $chi:ident,
+                $htifi:ident, $tcifi:ident, $teifi:ident, $gifi:ident,
+                $chtifi:ident, $ctcifi:ident, $cteifi:ident, $cgifi:ident
+            ), )+
+        },
+    ) => {
+        pub mod $dmax {
+            use super::*;
+            use crate::stm32::$DMAx;
+
+            impl DmaExt for $DMAx {
+                type Channels = Channels;
+
+                fn split(self, ahb: &mut AHB) -> Channels {
+                    ahb.enr().modify(|_, w| w.$dmaxen().set_bit());
+
+                    let mut channels = Channels {
+                        $( $chi: $Ci { _0: () }, )+
+                    };
+
+                    channels.reset();
+                    channels
+                }
+            }
+
+            /// DMA channels
+            pub struct Channels {
+                $( pub $chi: $Ci, )+
+            }
+
+            impl Channels {
+                /// Reset the control registers of all channels.
+                /// This stops any ongoing transfers.
+                fn reset(&mut self) {
+                    $( self.$chi.reset(); )+
+                }
+            }
+
+            $(
+                /// Singleton that represents a DMA channel
+                pub struct $Ci {
+                    _0: (),
+                }
+
+                impl private::Channel for $Ci {
+                    fn ch(&self) -> &stm32::dma1::CH {
+                        // NOTE(unsafe) $Ci grants exclusive access to this register
+                        unsafe { &(*$DMAx::ptr()).$chi }
+                    }
+                }
+
+                impl Channel for $Ci {
+                    fn event_occured(&self, event: Event) -> bool {
+                        use Event::*;
+
+                        // NOTE(unsafe) atomic read
+                        let flags = unsafe { (*$DMAx::ptr()).isr.read() };
+                        match event {
+                            HalfTransfer => flags.$htifi().bit_is_set(),
+                            TransferComplete => flags.$tcifi().bit_is_set(),
+                            TransferError => flags.$teifi().bit_is_set(),
+                            Any => flags.$gifi().bit_is_set(),
+                        }
+                    }
+
+                    fn clear_event(&mut self, event: Event) {
+                        use Event::*;
+
+                        // NOTE(unsafe) atomic write to a stateless register
+                        unsafe {
+                            &(*$DMAx::ptr()).ifcr.write(|w| match event {
+                                HalfTransfer => w.$chtifi().set_bit(),
+                                TransferComplete => w.$ctcifi().set_bit(),
+                                TransferError => w.$cteifi().set_bit(),
+                                Any => w.$cgifi().set_bit(),
+                            });
+                        }
+                    }
+                }
+            )+
+        }
+    };
+}
+
+#[cfg(feature = "stm32f303")]
+dma!(
+    DMA1, dma1, dma1en,
+    channels: {
+        C1: (ch1, htif1, tcif1, teif1, gif1, chtif1, ctcif1, cteif1, cgif1),
+        C2: (ch2, htif2, tcif2, teif2, gif2, chtif2, ctcif2, cteif2, cgif2),
+        C3: (ch3, htif3, tcif3, teif3, gif3, chtif3, ctcif3, cteif3, cgif3),
+        C4: (ch4, htif4, tcif4, teif4, gif4, chtif4, ctcif4, cteif4, cgif4),
+        C5: (ch5, htif5, tcif5, teif5, gif5, chtif5, ctcif5, cteif5, cgif5),
+        C6: (ch6, htif6, tcif6, teif6, gif6, chtif6, ctcif6, cteif6, cgif6),
+        C7: (ch7, htif7, tcif7, teif7, gif7, chtif7, ctcif7, cteif7, cgif7),
+    },
+);
+
+#[cfg(any(
+    feature = "stm32f303xb",
+    feature = "stm32f303xc",
+    feature = "stm32f303xd",
+    feature = "stm32f303xe"
+))]
+dma!(
+    DMA2, dma2, dma2en,
+    channels: {
+        C1: (ch1, htif1, tcif1, teif1, gif1, chtif1, ctcif1, cteif1, cgif1),
+        C2: (ch2, htif2, tcif2, teif2, gif2, chtif2, ctcif2, cteif2, cgif2),
+        C3: (ch3, htif3, tcif3, teif3, gif3, chtif3, ctcif3, cteif3, cgif3),
+        C4: (ch4, htif4, tcif4, teif4, gif4, chtif4, ctcif4, cteif4, cgif4),
+        C5: (ch5, htif5, tcif5, teif5, gif5, chtif5, ctcif5, cteif5, cgif5),
+    },
+);
+
+/// Marker trait for DMA targets and their channels
+pub unsafe trait Target<C: Channel> {}
+
+macro_rules! targets {
+    (
+        $dma:ident,
+        $( $target:ty => $C:ident, )+
+    ) => {
+        $( unsafe impl Target<$dma::$C> for $target {} )+
+    };
+}
+
+#[cfg(feature = "stm32f303")]
+targets!(dma1,
+    serial::Rx<stm32::USART1> => C5,
+    serial::Tx<stm32::USART1> => C4,
+    serial::Rx<stm32::USART2> => C6,
+    serial::Tx<stm32::USART2> => C7,
+    serial::Rx<stm32::USART3> => C3,
+    serial::Tx<stm32::USART3> => C2,
+);

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -3,9 +3,9 @@
 //! Currently DMA is only supported for STM32F303 MCUs.
 
 use crate::{
+    pac::{self, dma1::ch::cr},
     rcc::AHB,
     serial,
-    stm32::{self, dma1::ch::cr},
 };
 use cast::u16;
 use core::{
@@ -566,12 +566,12 @@ pub trait Channel: private::Channel {
 }
 
 mod private {
-    use crate::stm32;
+    use crate::pac;
 
     /// Channel methods private to this module
     pub trait Channel {
         /// Return the register block for this channel
-        fn ch(&self) -> &stm32::dma1::CH;
+        fn ch(&self) -> &pac::dma1::CH;
     }
 }
 
@@ -588,7 +588,7 @@ macro_rules! dma {
     ) => {
         pub mod $dmax {
             use super::*;
-            use crate::stm32::$DMAx;
+            use crate::pac::$DMAx;
 
             impl DmaExt for $DMAx {
                 type Channels = Channels;
@@ -625,7 +625,7 @@ macro_rules! dma {
                 }
 
                 impl private::Channel for $Ci {
-                    fn ch(&self) -> &stm32::dma1::CH {
+                    fn ch(&self) -> &pac::dma1::CH {
                         // NOTE(unsafe) $Ci grants exclusive access to this register
                         unsafe { &(*$DMAx::ptr()).$chi }
                     }
@@ -709,10 +709,10 @@ macro_rules! targets {
 
 #[cfg(feature = "stm32f303")]
 targets!(dma1,
-    serial::Rx<stm32::USART1> => C5,
-    serial::Tx<stm32::USART1> => C4,
-    serial::Rx<stm32::USART2> => C6,
-    serial::Tx<stm32::USART2> => C7,
-    serial::Rx<stm32::USART3> => C3,
-    serial::Tx<stm32::USART3> => C2,
+    serial::Rx<pac::USART1> => C5,
+    serial::Tx<pac::USART1> => C4,
+    serial::Rx<pac::USART2> => C6,
+    serial::Tx<pac::USART2> => C7,
+    serial::Rx<pac::USART3> => C3,
+    serial::Tx<pac::USART3> => C2,
 );

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -146,7 +146,7 @@ impl<B, C: Channel, T> TransferInner<B, C, T> {
     /// Stop this transfer
     fn stop(&mut self) {
         self.channel.disable();
-        atomic::compiler_fence(Ordering::Acquire);
+        atomic::compiler_fence(Ordering::SeqCst);
     }
 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -2,6 +2,9 @@
 //!
 //! Currently DMA is only supported for STM32F303 MCUs.
 
+// To learn about most of the ideas implemented here, check out the DMA section
+// of the Embedonomicon: https://docs.rust-embedded.org/embedonomicon/dma.html
+
 use crate::{
     pac::{self, dma1::ch::cr},
     rcc::AHB,
@@ -429,7 +432,14 @@ pub enum Event {
 pub trait Channel: private::Channel {
     /// Is the interrupt flag for the given event set?
     fn event_occurred(&self, event: Event) -> bool;
-    /// Clear the interrupt flag for the given event
+
+    /// Clear the interrupt flag for the given event.
+    ///
+    /// Passing `Event::Any` clears all interrupt flags.
+    ///
+    /// Note that the the global interrupt flag is not automatically cleared
+    /// even when all other flags are cleared. The only way to clear it is to
+    /// call this method with `Event::Any`.
     fn clear_event(&mut self, event: Event);
 
     /// Reset the control registers of this channel.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ pub use crate::pac::interrupt;
 #[cfg(feature = "device-selected")]
 pub mod delay;
 #[cfg(feature = "device-selected")]
+pub mod dma;
+#[cfg(feature = "device-selected")]
 pub mod flash;
 #[cfg(feature = "device-selected")]
 pub mod gpio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub use crate::pac::interrupt;
 
 #[cfg(feature = "device-selected")]
 pub mod delay;
-#[cfg(feature = "device-selected")]
+#[cfg(feature = "stm32f303")]
 pub mod dma;
 #[cfg(feature = "device-selected")]
 pub mod flash;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 //! Prelude
 
+pub use crate::dma::DmaExt as _stm32f3xx_hal_dma_DmaExt;
 pub use crate::flash::FlashExt as _stm32f3xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32f3xx_hal_gpio_GpioExt;
 pub use crate::hal::prelude::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 //! Prelude
 
+#[cfg(feature = "stm32f303")]
 pub use crate::dma::DmaExt as _stm32f3xx_hal_dma_DmaExt;
 pub use crate::flash::FlashExt as _stm32f3xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32f3xx_hal_gpio_GpioExt;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,28 +1,15 @@
 //! Serial
 
-use core::convert::Infallible;
-use core::marker::PhantomData;
-use core::ptr;
-
-use crate::hal::blocking::serial::write::Default;
-use crate::hal::serial;
-use crate::pac::{USART1, USART2, USART3};
+use crate::{
+    gpio::{gpioa, gpiob, gpioc, AF7},
+    hal::{blocking, serial},
+    pac::{USART1, USART2, USART3},
+    rcc::{Clocks, APB1, APB2},
+    time::Bps,
+};
+use core::{convert::Infallible, marker::PhantomData, ptr};
 use nb;
 
-use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
-#[cfg(any(
-    feature = "stm32f301",
-    feature = "stm32f318",
-    feature = "stm32f302",
-    feature = "stm32f303",
-    feature = "stm32f334",
-    feature = "stm32f328",
-    feature = "stm32f358",
-    feature = "stm32f398"
-))]
-use crate::gpio::gpiob::PB11;
-use crate::gpio::gpiob::{PB10, PB6, PB7};
-use crate::gpio::gpioc::{PC10, PC11, PC4, PC5};
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xb",
@@ -36,24 +23,20 @@ use crate::gpio::gpioc::{PC10, PC11, PC4, PC5};
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-use crate::gpio::gpiod::{PD5, PD6, PD8, PD9};
-#[cfg(any(
-    feature = "stm32f302",
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f328",
-    feature = "stm32f358",
-    feature = "stm32f398"
-))]
-use crate::gpio::gpioe::{PE0, PE1, PE15};
+use crate::gpio::{gpiod, gpioe};
 
-use crate::gpio::AF7;
-use crate::rcc::{Clocks, APB1, APB2};
-use crate::time::Bps;
+#[cfg(feature = "stm32f303")]
+mod dma_imports {
+    pub use crate::dma;
+    pub use as_slice::{AsMutSlice, AsSlice};
+    pub use core::{
+        ops::{Deref, DerefMut},
+        pin::Pin,
+    };
+}
+
+#[cfg(feature = "stm32f303")]
+use dma_imports::*;
 
 /// Interrupt event
 pub enum Event {
@@ -85,9 +68,9 @@ pub unsafe trait TxPin<USART> {}
 /// RX pin - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait RxPin<USART> {}
 
-unsafe impl TxPin<USART1> for PA9<AF7> {}
-unsafe impl TxPin<USART1> for PB6<AF7> {}
-unsafe impl TxPin<USART1> for PC4<AF7> {}
+unsafe impl TxPin<USART1> for gpioa::PA9<AF7> {}
+unsafe impl TxPin<USART1> for gpiob::PB6<AF7> {}
+unsafe impl TxPin<USART1> for gpioc::PC4<AF7> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xb",
@@ -100,11 +83,11 @@ unsafe impl TxPin<USART1> for PC4<AF7> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl TxPin<USART1> for PE0<AF7> {}
+unsafe impl TxPin<USART1> for gpioe::PE0<AF7> {}
 
-unsafe impl RxPin<USART1> for PA10<AF7> {}
-unsafe impl RxPin<USART1> for PB7<AF7> {}
-unsafe impl RxPin<USART1> for PC5<AF7> {}
+unsafe impl RxPin<USART1> for gpioa::PA10<AF7> {}
+unsafe impl RxPin<USART1> for gpiob::PB7<AF7> {}
+unsafe impl RxPin<USART1> for gpioc::PC5<AF7> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xb",
@@ -117,11 +100,11 @@ unsafe impl RxPin<USART1> for PC5<AF7> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl RxPin<USART1> for PE1<AF7> {}
+unsafe impl RxPin<USART1> for gpioe::PE1<AF7> {}
 
-unsafe impl TxPin<USART2> for PA2<AF7> {}
-// unsafe impl TxPin<USART2> for PA14<AF7> {}
-// unsafe impl TxPin<USART2> for PB3<AF7> {}
+unsafe impl TxPin<USART2> for gpioa::PA2<AF7> {}
+// unsafe impl TxPin<USART2> for gpioa::PA14<AF7> {}
+// unsafe impl TxPin<USART2> for gpiob::PB3<AF7> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xb",
@@ -135,11 +118,11 @@ unsafe impl TxPin<USART2> for PA2<AF7> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl TxPin<USART2> for PD5<AF7> {}
+unsafe impl TxPin<USART2> for gpiod::PD5<AF7> {}
 
-unsafe impl RxPin<USART2> for PA3<AF7> {}
-// unsafe impl RxPin<USART2> for PA15<AF7> {}
-// unsafe impl RxPin<USART2> for PB4<AF7> {}
+unsafe impl RxPin<USART2> for gpioa::PA3<AF7> {}
+// unsafe impl RxPin<USART2> for gpioa::PA15<AF7> {}
+// unsafe impl RxPin<USART2> for gpiob::PB4<AF7> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xb",
@@ -153,10 +136,10 @@ unsafe impl RxPin<USART2> for PA3<AF7> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl RxPin<USART2> for PD6<AF7> {}
+unsafe impl RxPin<USART2> for gpiod::PD6<AF7> {}
 
-unsafe impl TxPin<USART3> for PB10<AF7> {}
-unsafe impl TxPin<USART3> for PC10<AF7> {}
+unsafe impl TxPin<USART3> for gpiob::PB10<AF7> {}
+unsafe impl TxPin<USART3> for gpioc::PC10<AF7> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xb",
@@ -170,7 +153,7 @@ unsafe impl TxPin<USART3> for PC10<AF7> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl TxPin<USART3> for PD8<AF7> {}
+unsafe impl TxPin<USART3> for gpiod::PD8<AF7> {}
 
 #[cfg(any(
     feature = "stm32f301",
@@ -182,8 +165,8 @@ unsafe impl TxPin<USART3> for PD8<AF7> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl RxPin<USART3> for PB11<AF7> {}
-unsafe impl RxPin<USART3> for PC11<AF7> {}
+unsafe impl RxPin<USART3> for gpiob::PB11<AF7> {}
+unsafe impl RxPin<USART3> for gpioc::PC11<AF7> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xb",
@@ -197,7 +180,7 @@ unsafe impl RxPin<USART3> for PC11<AF7> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl RxPin<USART3> for PD9<AF7> {}
+unsafe impl RxPin<USART3> for gpiod::PD9<AF7> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xb",
@@ -210,7 +193,7 @@ unsafe impl RxPin<USART3> for PD9<AF7> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl RxPin<USART3> for PE15<AF7> {}
+unsafe impl RxPin<USART3> for gpioe::PE15<AF7> {}
 
 /// Serial abstraction
 pub struct Serial<USART, PINS> {
@@ -251,21 +234,21 @@ macro_rules! hal {
                     apb.rstr().modify(|_, w| w.$usartXrst().set_bit());
                     apb.rstr().modify(|_, w| w.$usartXrst().clear_bit());
 
-                    // disable hardware flow control
-                    // TODO enable DMA
-                    // usart.cr3.write(|w| w.rtse().clear_bit().ctse().clear_bit());
-
                     let brr = clocks.$pclkX().0 / baud_rate.0;
                     assert!(brr >= 16, "impossible baud rate");
                     // NOTE(write): uses all bits of this register.
                     usart.brr.write(|w| unsafe { w.bits(brr) });
 
-                    // UE: enable USART
-                    // RE: enable receiver
-                    // TE: enable transceiver
-                    usart
-                        .cr1
-                        .modify(|_, w| w.ue().set_bit().re().set_bit().te().set_bit());
+                    usart.cr3.modify(|_, w| {
+                        w.dmar().enabled();  // enable DMA for reception
+                        w.dmat().enabled()   // enable DMA for transmission
+                    });
+
+                    usart.cr1.modify(|_, w| {
+                        w.ue().enabled();  // enable USART
+                        w.re().enabled();  // enable receiver
+                        w.te().enabled()   // enable transmitter
+                    });
 
                     Serial { usart, pins }
                 }
@@ -380,7 +363,67 @@ macro_rules! hal {
                 }
             }
 
-            impl Default<u8> for Tx<$USARTX> {}
+            impl blocking::serial::write::Default<u8> for Tx<$USARTX> {}
+
+            #[cfg(feature = "stm32f303")]
+            impl Rx<$USARTX> {
+                /// Fill the buffer with received data using DMA.
+                pub fn read_all<B, C>(
+                    self,
+                    mut buffer: Pin<B>,
+                    mut channel: C
+                ) -> dma::Transfer<B, C, Self>
+                where
+                    Self: dma::Target<C>,
+                    B: DerefMut + 'static,
+                    B::Target: AsMutSlice<Element = u8> + Unpin,
+                    C: dma::Channel,
+                {
+                    // NOTE(unsafe) taking the address of a register
+                    let pa = unsafe { &(*$USARTX::ptr()).rdr } as *const _ as u32;
+                    channel.set_peripheral_address(pa, dma::Increment::Disable);
+
+                    let slice = buffer.as_mut_slice();
+                    let (ma, len) = (slice.as_mut_ptr() as u32, slice.len());
+                    channel.set_memory_address(ma, dma::Increment::Enable);
+                    channel.set_transfer_length(len);
+                    channel.set_word_size(dma::WordSize::Bits8);
+
+                    channel.set_direction(dma::Direction::FromPeripheral);
+
+                    unsafe { dma::Transfer::start(buffer, channel, self) }
+                }
+            }
+
+            #[cfg(feature = "stm32f303")]
+            impl Tx<$USARTX> {
+                /// Transmit all data in the buffer using DMA.
+                pub fn write_all<B, C>(
+                    self,
+                    buffer: Pin<B>,
+                    mut channel: C
+                ) -> dma::Transfer<B, C, Self>
+                where
+                    Self: dma::Target<C>,
+                    B: Deref + 'static,
+                    B::Target: AsSlice<Element = u8>,
+                    C: dma::Channel,
+                {
+                    // NOTE(unsafe) taking the address of a register
+                    let pa = unsafe { &(*$USARTX::ptr()).tdr } as *const _ as u32;
+                    channel.set_peripheral_address(pa, dma::Increment::Disable);
+
+                    let slice = buffer.as_slice();
+                    let (ma, len) = (slice.as_ptr() as u32, slice.len());
+                    channel.set_memory_address(ma, dma::Increment::Enable);
+                    channel.set_transfer_length(len);
+                    channel.set_word_size(dma::WordSize::Bits8);
+
+                    channel.set_direction(dma::Direction::FromMemory);
+
+                    unsafe { dma::Transfer::start(buffer, channel, self) }
+                }
+            }
         )+
     }
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -381,7 +381,7 @@ macro_rules! hal {
             #[cfg(feature = "stm32f303")]
             impl Rx<$USARTX> {
                 /// Fill the buffer with received data using DMA.
-                pub fn read_all<B, C>(
+                pub fn read_exact<B, C>(
                     self,
                     mut buffer: Pin<B>,
                     mut channel: C

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -23,7 +23,20 @@ use nb;
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-use crate::gpio::{gpiod, gpioe};
+use crate::gpio::gpiod;
+#[cfg(any(
+    feature = "stm32f302",
+    feature = "stm32f303xb",
+    feature = "stm32f303xc",
+    feature = "stm32f303xd",
+    feature = "stm32f303xe",
+    feature = "stm32f373",
+    feature = "stm32f378",
+    feature = "stm32f328",
+    feature = "stm32f358",
+    feature = "stm32f398"
+))]
+use crate::gpio::gpioe;
 
 #[cfg(feature = "stm32f303")]
 mod dma_imports {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -42,10 +42,8 @@ use crate::gpio::gpioe;
 mod dma_imports {
     pub use crate::dma;
     pub use as_slice::{AsMutSlice, AsSlice};
-    pub use core::{
-        ops::{Deref, DerefMut},
-        pin::Pin,
-    };
+    pub use core::ops::{Deref, DerefMut};
+    pub use stable_deref_trait::StableDeref;
 }
 
 #[cfg(feature = "stm32f303")]
@@ -383,13 +381,13 @@ macro_rules! hal {
                 /// Fill the buffer with received data using DMA.
                 pub fn read_exact<B, C>(
                     self,
-                    mut buffer: Pin<B>,
+                    mut buffer: B,
                     mut channel: C
                 ) -> dma::Transfer<B, C, Self>
                 where
                     Self: dma::Target<C>,
-                    B: DerefMut + 'static,
-                    B::Target: AsMutSlice<Element = u8> + Unpin,
+                    B: DerefMut + StableDeref + 'static,
+                    B::Target: AsMutSlice<Element = u8>,
                     C: dma::Channel,
                 {
                     // NOTE(unsafe) taking the address of a register
@@ -413,12 +411,12 @@ macro_rules! hal {
                 /// Transmit all data in the buffer using DMA.
                 pub fn write_all<B, C>(
                     self,
-                    buffer: Pin<B>,
+                    buffer: B,
                     mut channel: C
                 ) -> dma::Transfer<B, C, Self>
                 where
                     Self: dma::Target<C>,
-                    B: Deref + 'static,
+                    B: Deref + StableDeref + 'static,
                     B::Target: AsSlice<Element = u8>,
                     C: dma::Channel,
                 {


### PR DESCRIPTION
This PR is the first part of an effort to add DMA support to this crate (see issue #66). It adds initial support for DMA, including:

- A `DmaExt` extension trait that splits a DMA peripheral into individual channels
- A `Transfer` abstraction that provides memory-safe one-shot DMA transfers
- New methods on serial receivers and transmitters to read/write data via DMA

This works only on STM32F303 devices for now.



