### PR TITLE
Update stm32f3 to v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ let clocks = rcc
   This is possible through utilizing the divider, which can devide the
   external oscillator clock on most devices. Some devices have even the
   possibility to divide the internal oscillator clock.
+- Bump `stm32f3` dependency to `0.11.0` ([#97](https://github.com/stm32-rs/stm32f3xx-hal/pull/97))
 
 ## [v0.4.3] - 2020-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- **Breaking** The feature gate requires you to select a subvaraint if possible. ([#67](https://github.com/stm32-rs/stm32f3xx-hal/pull/67))
-- **Breaking** Split up `stm32f302` into sub-targets `stm32f302xb`,`stm32f302xc`,`stm32f302xd`,`stm32f302xe`
 - The system clock calculation is more fine grained now. ([#67](https://github.com/stm32-rs/stm32f3xx-hal/pull/67))
   Now the system clock can be some value, like 14 MHz, which can not a
   be represented as a multiple of the oscillator clock:
@@ -33,6 +31,11 @@ let clocks = rcc
   This is possible through utilizing the divider, which can devide the
   external oscillator clock on most devices. Some devices have even the
   possibility to divide the internal oscillator clock.
+
+### Breaking changes
+
+- The feature gate requires you to select a subvariant if possible. ([#75](https://github.com/stm32-rs/stm32f3xx-hal/pull/75))
+- Split up `stm32f302` into sub-targets `stm32f302xb`,`stm32f302xc`,`stm32f302xd`,`stm32f302xe`
 - Bump `stm32f3` dependency to `0.11.0` ([#97](https://github.com/stm32-rs/stm32f3xx-hal/pull/97))
 
 ## [v0.4.3] - 2020-04-11
@@ -135,7 +138,7 @@ let clocks = rcc
 
 - Various peripheral mappings for some devices ([#12](https://github.com/stm32-rs/stm32f3xx-hal/pull/12))
 
-### Breaking changers
+### Breaking changes
 
 - Switch to the `embedded-hal` v2 digital pin trait.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m = "0.6"
 cortex-m-rt = "0.6"
 embedded-hal = "0.2"
 nb = "0.1"
-stm32f3 = "0.10"
+stm32f3 = "0.11"
 
 [dependencies.bare-metal]
 version = "0.2"

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -524,18 +524,17 @@ impl CFGR {
 
         assert!(pclk2 <= 72_000_000);
 
-        // adjust flash wait states
-        unsafe {
-            acr.acr().modify(|_, w| {
-                w.latency().bits(if sysclk <= 24_000_000 {
-                    0b000
-                } else if sysclk <= 48_000_000 {
-                    0b001
-                } else {
-                    0b010
-                })
-            })
-        }
+        // Adjust flash wait states according to the
+        // HCLK frequency (cpu core clock)
+        acr.acr().modify(|_, w| {
+            if hclk <= 24_000_000 {
+                w.latency().ws0()
+            } else if hclk <= 48_000_000 {
+                w.latency().ws1()
+            } else {
+                w.latency().ws2()
+            }
+        });
 
         let (usbpre, usbclk_valid) = usb_clocking::is_valid(sysclk, self.hse, pclk1, &pll_config);
 


### PR DESCRIPTION
Remove now unneeded unsafe from the flash state configuration in `src/rcc.rs` and use `HCLK` instead of `SYSCLK` as the reference manual suggests. 