### PR TITLE
Add reclock functionality for SPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- SPI support for reclock after initialization ([#98](https://github.com/stm32-rs/stm32f3xx-hal/pull/98))
+
 ## [v0.5.0] - 2020-07-21
 
 ### Added


### PR DESCRIPTION
Some devices (eg SD cards) require the initialization to be done a at a lower frequency and allow the frequency to be later increased. Thus a re-clock functionality has been added. The tm4c123x-hal also does this.