### PR TITLE
Rename stm32 to pac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ let clocks = rcc
 - The feature gate requires you to select a subvariant if possible. ([#75](https://github.com/stm32-rs/stm32f3xx-hal/pull/75))
 - Split up `stm32f302` into sub-targets `stm32f302xb`,`stm32f302xc`,`stm32f302xd`,`stm32f302xe`
 - Bump `stm32f3` dependency to `0.11.0` ([#97](https://github.com/stm32-rs/stm32f3xx-hal/pull/97))
+- The `stm32f3` reexport is now renamed from `stm32` to `pac` ([#101](https://github.com/stm32-rs/stm32f3xx-hal/pull/101))
 
 ## [v0.4.3] - 2020-04-11
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -5,20 +5,24 @@
 
 use panic_semihosting as _;
 
+use stm32f3xx_hal as hal;
+
 use cortex_m_rt::entry;
+
 //use cortex_m_semihosting::hprintln;
-use embedded_hal::PwmPin;
-use stm32f3::stm32f303;
-use stm32f3xx_hal::flash::FlashExt;
-use stm32f3xx_hal::gpio::GpioExt;
-use stm32f3xx_hal::pwm::{tim16, tim2, tim3, tim8};
-use stm32f3xx_hal::rcc::RccExt;
-use stm32f3xx_hal::time::U32Ext;
+use hal::hal::PwmPin;
+
+use hal::flash::FlashExt;
+use hal::gpio::GpioExt;
+use hal::pac;
+use hal::pwm::{tim16, tim2, tim3, tim8};
+use hal::rcc::RccExt;
+use hal::time::U32Ext;
 
 #[entry]
 fn main() -> ! {
     // Get our peripherals
-    let dp = stm32f303::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
 
     // Configure our clocks
     let mut flash = dp.FLASH.constrain();

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -9,13 +9,13 @@ use stm32f3xx_hal as hal;
 
 use cortex_m_rt::entry;
 
+use hal::pac;
 use hal::prelude::*;
 use hal::spi::{Mode, Phase, Polarity, Spi};
-use hal::stm32;
 
 #[entry]
 fn main() -> ! {
-    let dp = stm32::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();

--- a/examples/toggle.rs
+++ b/examples/toggle.rs
@@ -8,13 +8,15 @@
 
 use panic_semihosting as _;
 
+use stm32f3xx_hal as hal;
+
 use cortex_m_rt::entry;
-use stm32f3xx_hal::prelude::*;
-use stm32f3xx_hal::stm32;
+use hal::pac;
+use hal::prelude::*;
 
 #[entry]
 fn main() -> ! {
-    let dp = stm32::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
 
     let mut rcc = dp.RCC.constrain();
     let mut gpioe = dp.GPIOE.split(&mut rcc.ahb);

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -1,6 +1,6 @@
 //! Flash memory
 
-use crate::stm32::{flash, FLASH};
+use crate::pac::{flash, FLASH};
 
 /// Extension trait to constrain the FLASH peripheral
 pub trait FlashExt {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -121,7 +121,7 @@ macro_rules! gpio {
             ), not(any(
                 $(feature = $device_except,)*
             ))))]
-            use crate::stm32::$GPIOX;
+            use crate::pac::$GPIOX;
         )+
 
         pub enum Gpio {
@@ -249,7 +249,7 @@ macro_rules! gpio {
                 use crate::hal::digital::v2::StatefulOutputPin;
                 #[cfg(feature = "unproven")]
                 use crate::hal::digital::v2::toggleable;
-                use crate::stm32::{$gpioy, $GPIOX};
+                use crate::pac::{$gpioy, $GPIOX};
 
                 use crate::rcc::AHB;
                 #[allow(unused_imports)]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,6 @@
 //! Inter-Integrated Circuit (I2C) bus
 
-use crate::stm32::{I2C1, I2C2};
+use crate::pac::{I2C1, I2C2};
 use cast::u8;
 
 use crate::gpio::gpioa::{PA10, PA9};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,19 +89,19 @@ pub use nb;
 pub use nb::block;
 
 #[cfg(feature = "stm32f301")]
-pub use stm32f3::stm32f301 as stm32;
+pub use stm32f3::stm32f301 as pac;
 
 #[cfg(feature = "stm32f302")]
-pub use stm32f3::stm32f302 as stm32;
+pub use stm32f3::stm32f302 as pac;
 
 #[cfg(feature = "stm32f303")]
-pub use stm32f3::stm32f303 as stm32;
+pub use stm32f3::stm32f303 as pac;
 
 #[cfg(feature = "stm32f373")]
-pub use stm32f3::stm32f373 as stm32;
+pub use stm32f3::stm32f373 as pac;
 
 #[cfg(feature = "stm32f334")]
-pub use stm32f3::stm32f3x4 as stm32;
+pub use stm32f3::stm32f3x4 as pac;
 
 #[cfg(any(
     feature = "stm32f318",
@@ -110,11 +110,15 @@ pub use stm32f3::stm32f3x4 as stm32;
     feature = "stm32f378",
     feature = "stm32f398"
 ))]
-pub use stm32f3::stm32f3x8 as stm32;
+pub use stm32f3::stm32f3x8 as pac;
+
+#[cfg(feature = "device-selected")]
+#[deprecated(since = "0.5.0", note = "please use `pac` instead")]
+pub use crate::pac as stm32;
 
 // Enable use of interrupt macro
 #[cfg(feature = "rt")]
-pub use crate::stm32::interrupt;
+pub use crate::pac::interrupt;
 
 #[cfg(feature = "device-selected")]
 pub mod delay;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,14 +2,13 @@
 
 pub use crate::flash::FlashExt as _stm32f3xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32f3xx_hal_gpio_GpioExt;
-#[cfg(feature = "unproven")]
-pub use crate::hal::digital::v2::InputPin as _embedded_hal_digital_InputPin;
-#[cfg(feature = "unproven")]
-pub use crate::hal::digital::v2::OutputPin as _embedded_hal_digital_OutputPin;
-#[cfg(feature = "unproven")]
-pub use crate::hal::digital::v2::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin;
-#[cfg(feature = "unproven")]
-pub use crate::hal::digital::v2::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
 pub use crate::hal::prelude::*;
 pub use crate::rcc::RccExt as _stm32f3xx_hal_rcc_RccExt;
 pub use crate::time::U32Ext as _stm32f3xx_hal_time_U32Ext;
+#[cfg(feature = "unproven")]
+pub use crate::{
+    hal::digital::v2::InputPin as _embedded_hal_digital_InputPin,
+    hal::digital::v2::OutputPin as _embedded_hal_digital_OutputPin,
+    hal::digital::v2::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin,
+    hal::digital::v2::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin,
+};

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -151,7 +151,7 @@
   we have no pins in use, but it cannot be used once we've used PA7.
 */
 
-use crate::stm32::{TIM15, TIM16, TIM17, TIM2};
+use crate::pac::{TIM15, TIM16, TIM17, TIM2};
 use core::marker::PhantomData;
 use embedded_hal::PwmPin;
 
@@ -381,8 +381,8 @@ use crate::gpio::gpiof::PF6;
 ))]
 use crate::gpio::gpiof::PF9;
 
+use crate::pac::RCC;
 use crate::rcc::Clocks;
-use crate::stm32::RCC;
 use crate::time::Hertz;
 
 /// Output Compare Channel 1 of Timer 1 (type state)
@@ -754,7 +754,7 @@ macro_rules! pwm_pin_for_pwm_n_channel {
 ))]
 macro_rules! tim1_common {
     () => {
-        use crate::stm32::TIM1;
+        use crate::pac::TIM1;
 
         /// Output Compare Channel 1 of Timer 1 (type state)
         pub struct TIM1_CH1 {}
@@ -964,7 +964,7 @@ pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pd6, PD6, AF2);
 ))]
 macro_rules! tim3_common {
     () => {
-        use crate::stm32::TIM3;
+        use crate::pac::TIM3;
 
         /// Output Compare Channel 1 of Timer 3 (type state)
         pub struct TIM3_CH1 {}
@@ -1103,7 +1103,7 @@ pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pb6, PB6, AF10);
 ))]
 macro_rules! tim4_common {
     () => {
-        use crate::stm32::TIM4;
+        use crate::pac::TIM4;
 
         /// Output Compare Channel 1 of Timer 4 (type state)
         pub struct TIM4_CH1 {}
@@ -1199,7 +1199,7 @@ tim4_ext!();
 #[cfg(feature = "stm32f373")]
 macro_rules! tim5 {
     () => {
-        use crate::stm32::TIM5;
+        use crate::pac::TIM5;
 
         /// Output Compare Channel 1 of Timer 5 (type state)
         pub struct TIM5_CH1 {}
@@ -1257,7 +1257,7 @@ tim5!();
 #[cfg(any(feature = "stm32f303", feature = "stm32f358", feature = "stm32f398"))]
 macro_rules! tim8 {
     () => {
-        use crate::stm32::TIM8;
+        use crate::pac::TIM8;
 
         /// Output Compare Channel 1 of Timer 8 (type state)
         pub struct TIM8_CH1 {}
@@ -1333,7 +1333,7 @@ pwm_channel4_pin!(TIM8, TIM8_CH4, output_to_pd1, PD1, AF4);
 #[cfg(feature = "stm32f373")]
 macro_rules! tim12 {
     () => {
-        use crate::stm32::TIM12;
+        use crate::pac::TIM12;
 
         /// Output Compare Channel 1 of Timer 12 (type state)
         pub struct TIM12_CH1 {}
@@ -1381,7 +1381,7 @@ tim12!();
 #[cfg(feature = "stm32f373")]
 macro_rules! tim13 {
     () => {
-        use crate::stm32::TIM13;
+        use crate::pac::TIM13;
 
         /// Output Compare Channel 1 of Timer 13 (type state)
         pub struct TIM13_CH1 {}
@@ -1424,7 +1424,7 @@ tim13!();
 #[cfg(feature = "stm32f373")]
 macro_rules! tim14 {
     () => {
-        use crate::stm32::TIM14;
+        use crate::pac::TIM14;
 
         /// Output Compare Channel 1 of Timer 14 (type state)
         pub struct TIM14_CH1 {}
@@ -1592,7 +1592,7 @@ pwm_channel1n_pin!(TIM17, TIM17_CH1, output_to_pa13, PA13, AF1);
 #[cfg(feature = "stm32f373")]
 macro_rules! tim19 {
     () => {
-        use crate::stm32::TIM19;
+        use crate::pac::TIM19;
 
         /// Output Compare Channel 1 of Timer 19 (type state)
         pub struct TIM19_CH1 {}
@@ -1650,7 +1650,7 @@ tim19!();
 #[cfg(feature = "stm32f398")]
 macro_rules! tim20 {
     () => {
-        use crate::stm32::TIM20;
+        use crate::pac::TIM20;
 
         /// Output Compare Channel 1 of Timer 20 (type state)
         pub struct TIM20_CH1 {}

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,6 +1,6 @@
 //! Reset and Clock Control
 
-use crate::stm32::{
+use crate::pac::{
     rcc::{self, cfgr, cfgr2},
     RCC,
 };
@@ -100,7 +100,6 @@ const HSI: u32 = 8_000_000; // Hz
 #[cfg(any(feature = "stm32f301", feature = "stm32f334",))]
 mod usb_clocking {
     use crate::rcc::PllConfig;
-    use crate::stm32::rcc::cfgr;
 
     pub(crate) fn is_valid(
         _sysclk: u32,
@@ -127,8 +126,8 @@ mod usb_clocking {
     feature = "stm32f398",
 ))]
 mod usb_clocking {
+    use crate::pac::rcc::cfgr;
     use crate::rcc::PllConfig;
-    use crate::stm32::rcc::cfgr;
 
     /// Check for all clock options to be
     pub(crate) fn is_valid(

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,7 +6,7 @@ use core::ptr;
 
 use crate::hal::blocking::serial::write::Default;
 use crate::hal::serial;
-use crate::stm32::{USART1, USART2, USART3};
+use crate::pac::{USART1, USART2, USART3};
 use nb;
 
 use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -4,7 +4,7 @@ use core::ptr;
 
 use crate::hal::spi::FullDuplex;
 pub use crate::hal::spi::{Mode, Phase, Polarity};
-use crate::stm32::{SPI1, SPI2, SPI3};
+use crate::pac::{SPI1, SPI2, SPI3};
 use nb;
 
 use crate::gpio::gpioa::{PA5, PA6, PA7};

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -11,7 +11,7 @@ use crate::hal::timer::{CountDown, Periodic};
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-use crate::stm32::TIM1;
+use crate::pac::TIM1;
 #[cfg(any(
     feature = "stm32f303",
     feature = "stm32f318",
@@ -20,7 +20,7 @@ use crate::stm32::TIM1;
     feature = "stm32f378",
     feature = "stm32f398"
 ))]
-use crate::stm32::TIM20;
+use crate::pac::TIM20;
 #[cfg(any(
     feature = "stm32f303",
     feature = "stm32f318",
@@ -30,7 +30,7 @@ use crate::stm32::TIM20;
     feature = "stm32f378",
     feature = "stm32f398"
 ))]
-use crate::stm32::TIM4;
+use crate::pac::TIM4;
 #[cfg(any(
     feature = "stm32f303",
     feature = "stm32f318",
@@ -39,10 +39,10 @@ use crate::stm32::TIM4;
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-use crate::stm32::TIM8;
+use crate::pac::TIM8;
 #[cfg(feature = "stm32f373")]
-use crate::stm32::{TIM12, TIM13, TIM14, TIM18, TIM19, TIM5};
-use crate::stm32::{TIM15, TIM16, TIM17, TIM2, TIM6};
+use crate::pac::{TIM12, TIM13, TIM14, TIM18, TIM19, TIM5};
+use crate::pac::{TIM15, TIM16, TIM17, TIM2, TIM6};
 #[cfg(any(
     feature = "stm32f303",
     feature = "stm32f318",
@@ -53,7 +53,7 @@ use crate::stm32::{TIM15, TIM16, TIM17, TIM2, TIM6};
     feature = "stm32f378",
     feature = "stm32f398"
 ))]
-use crate::stm32::{TIM3, TIM7};
+use crate::pac::{TIM3, TIM7};
 
 use cast::{u16, u32};
 use nb;

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -5,7 +5,7 @@
 //! See <https://github.com/stm32-rs/stm32f3xx-hal/tree/master/examples>
 //! for usage examples.
 
-use crate::stm32::{RCC, USB};
+use crate::pac::{RCC, USB};
 use stm32_usbd::UsbPeripheral;
 
 use crate::gpio::gpioa::{PA11, PA12};

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -2,7 +2,7 @@
 
 use crate::hal::watchdog::{Watchdog, WatchdogEnable};
 
-use crate::stm32::{DBGMCU, IWDG};
+use crate::pac::{DBGMCU, IWDG};
 use crate::time::MilliSeconds;
 
 const LSI_KHZ: u32 = 40;


### PR DESCRIPTION
This checks one of the boxes listed in the [new chapter](https://rust-embedded.github.io/book/design-patterns/index.html) of the embedded book. 

[C-REEXPORT-PAC](https://rust-embedded.github.io/book/design-patterns/hal/interoperability.html#c-reexport-pac)