### PR TITLE
Implemented InputPin trait for output pins

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -398,6 +398,20 @@ macro_rules! gpio {
                 }
 
                 #[cfg(feature = "unproven")]
+                impl<MODE> InputPin for $PXx<Output<MODE>> {
+                    type Error = Infallible;
+
+                    fn is_high(&self) -> Result<bool, Self::Error> {
+                        Ok(!self.is_low()?)
+                    }
+
+                     fn is_low(&self) -> Result<bool, Self::Error> {
+                        // NOTE(unsafe) atomic read with no side effects
+                        Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 })
+                    }
+                }
+
+                #[cfg(feature = "unproven")]
                 impl<MODE> InputPin for $PXx<Input<MODE>> {
                     type Error = Infallible;
 
@@ -670,6 +684,20 @@ macro_rules! gpio {
                             // NOTE(unsafe, write) atomic write to a stateless register
                             unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + $i))) }
                             Ok(())
+                        }
+                    }
+
+                    #[cfg(feature = "unproven")]
+                    impl<MODE> InputPin for $PXi<Output<MODE>> {
+                        type Error = Infallible;
+
+                        fn is_high(&self) -> Result<bool, Self::Error> {
+                            Ok(!self.is_low()?)
+                        }
+
+                         fn is_low(&self) -> Result<bool, Self::Error> {
+                            // NOTE(unsafe) atomic read with no side effects
+                            Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 })
                         }
                     }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -205,7 +205,7 @@ macro_rules! gpio {
             }
         }
 
-        
+
         #[cfg(feature = "unproven")]
         impl<MODE> InputPin for PXx<Output<MODE>> {
             type Error = Infallible;

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -205,6 +205,32 @@ macro_rules! gpio {
             }
         }
 
+        
+        #[cfg(feature = "unproven")]
+        impl<MODE> InputPin for PXx<Output<MODE>> {
+            type Error = Infallible;
+
+            fn is_high(&self) -> Result<bool, Self::Error> {
+                Ok(!self.is_low()?)
+            }
+
+             fn is_low(&self) -> Result<bool, Self::Error> {
+                // NOTE(unsafe) atomic read with no side effects
+                Ok(unsafe {
+                    match &self.gpio {
+                        $(
+                            #[cfg(all(any(
+                                $(feature = $device,)+
+                            ), not(any(
+                                $(feature = $device_except,)*
+                            ))))]
+                            Gpio::$GPIOX => (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0,
+                        )+
+                    }
+                })
+            }
+        }
+
         #[cfg(feature = "unproven")]
         impl <MODE> StatefulOutputPin for PXx<Output<MODE>> {
             fn is_set_high(&self) -> Result<bool, Self::Error> {

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -66,7 +66,7 @@ pub struct APB1 {
 }
 
 impl APB1 {
-    pub fn enr(&mut self) -> &rcc::APB1ENR {
+    pub(crate) fn enr(&mut self) -> &rcc::APB1ENR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb1enr }
     }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -66,7 +66,7 @@ pub struct APB1 {
 }
 
 impl APB1 {
-    pub(crate) fn enr(&mut self) -> &rcc::APB1ENR {
+    pub fn enr(&mut self) -> &rcc::APB1ENR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb1enr }
     }


### PR DESCRIPTION
This enables things like OneWire. Equiv of [this PR](https://github.com/stm32-rs/stm32f4xx-hal/pull/18) from the 4xx lib.