### PR TITLE
Use match instead of nested `if let`

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -438,32 +438,23 @@ impl CFGR {
     fn get_sysclk(&self) -> (u32, cfgr::SW_A, Option<PllConfig>) {
         // If a sysclk is given, check if the PLL has to be used,
         // else select the system clock source, which is either HSI or HSE.
-        if let Some(sysclk) = self.sysclk {
-            if let Some(hseclk) = self.hse {
-                if sysclk == hseclk {
-                    // No need to use the PLL
-                    // PLL is needed for USB, but we can make this assumption, to not use PLL here,
-                    // because the two valid USB clocks, 72 Mhz and 48 Mhz, can't be generated
-                    // directly from neither the internal rc (8 Mhz)  nor the external
-                    // Oscillator (max 32 Mhz), without using the PLL.
-                    (hseclk, cfgr::SW_A::HSE, None)
-                } else {
-                    let clock_with_pll = self.calc_pll(sysclk);
-                    (clock_with_pll.0, cfgr::SW_A::PLL, Some(clock_with_pll.1))
-                }
-            } else if sysclk == HSI {
-                // No need to use the PLL
-                (HSI, cfgr::SW_A::HSE, None)
-            } else {
-                let clock_with_pll = self.calc_pll(sysclk);
-                (clock_with_pll.0, cfgr::SW_A::PLL, Some(clock_with_pll.1))
+        match (self.sysclk, self.hse) {
+            // No need to use the PLL
+            // PLL is needed for USB, but we can make this assumption, to not use PLL here,
+            // because the two valid USB clocks, 72 Mhz and 48 Mhz, can't be generated
+            // directly from neither the internal rc (8 Mhz)  nor the external
+            // Oscillator (max 32 Mhz), without using the PLL.
+            (Some(sysclk), Some(hse)) if sysclk == hse => (hse, cfgr::SW_A::HSE, None),
+            // No need to use the PLL
+            (Some(sysclk), None) if sysclk == HSI => (HSI, cfgr::SW_A::HSI, None),
+            (Some(sysclk), _) => {
+                let (sysclk, pll_config) = self.calc_pll(sysclk);
+                (sysclk, cfgr::SW_A::PLL, Some(pll_config))
             }
-        } else if let Some(hseclk) = self.hse {
             // Use HSE as system clock
-            (hseclk, cfgr::SW_A::HSE, None)
-        } else {
+            (None, Some(hse)) => (hse, cfgr::SW_A::HSE, None),
             // Use HSI as system clock
-            (HSI, cfgr::SW_A::HSI, None)
+            (None, None) => (HSI, cfgr::SW_A::HSI, None),
         }
     }
 


### PR DESCRIPTION
I stumbled upon this code again and thought I could make it a bit more readable. 