### PR TITLE
Fix Github Actions CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,3 @@
-# Note: The checkout@v2 action sometimes checks out the wrong commit:
-#   https://github.com/actions/checkout/issues/237
-# Until that is fixed we use checkout@v1 here instead.
-
 name: CI
 
 on:
@@ -39,7 +35,7 @@ jobs:
           - mcu: stm32f303xc
             features: rt,stm32-usbd
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -49,13 +45,13 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features=${{ matrix.mcu }},${{ matrix.features }} --examples
+          args: --features=${{ matrix.mcu }},${{ matrix.features }} --lib --examples
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -67,14 +63,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: >
-            --features=stm32f303xc,rt,stm32-usbd --examples
+            --features=stm32f303xc,rt,stm32-usbd --lib --examples
             -- -D warnings
 
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
The previous CI executed the `cargo check` command with the `--examples` flag. The intention was to check both the library itself and the examples. However, for most MCU versions we don't provide any examples, they are explicitly feature gated to stm32f303 devices. In these cases cargo decides that there is nothing to do, so it also doesn't check the library itself, effectively disabling checking for most MCU families.

We instead want to use the `--all-features` flag. From the cargo docs:
  "Check all targets. This is equivalent to specifying `--lib --bins --tests --benches --examples`."
However, this doesn't work unfortunately since cargo is complaining about a missing crate "test" for the thumb7em-none-eabihf target. So instead we explicitly use `--lib --examples`.

This PR also updates the checkout action to v2 since the bug that existed in this version is officially fixed now.