### PR TITLE
Enable DMA for USART on STM32F302 devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - SPI support for reclock after initialization ([#98](https://github.com/stm32-rs/stm32f3xx-hal/pull/98))
 - Support for `stm32f302x6` and `stm32f302x8` devices ([#132](https://github.com/stm32-rs/stm32f3xx-hal/pull/132))
 - Support for the onboard real-time clock (RTC) ([#136](https://github.com/stm32-rs/stm32f3xx-hal/pull/136))
+- Enable DMA for USART on `stm32f302` devices ([#139](https://github.com/stm32-rs/stm32f3xx-hal/pull/139))
 
 ## [v0.5.0] - 2020-07-21
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -494,10 +494,14 @@ dma!(
 );
 
 #[cfg(any(
+    feature = "stm32f302xb",
+    feature = "stm32f302xc",
+    feature = "stm32f302xd",
+    feature = "stm32f302xe",
     feature = "stm32f303xb",
     feature = "stm32f303xc",
     feature = "stm32f303xd",
-    feature = "stm32f303xe"
+    feature = "stm32f303xe",
 ))]
 dma!(
     DMA2, dma2, dma2en,

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -540,18 +540,3 @@ on_channel!(dma1,
     serial::Rx<pac::USART3> => C3,
     serial::Tx<pac::USART3> => C2,
 );
-
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-))]
-on_channel!(dma2,
-    serial::Rx<pac::USART4> => C3,
-    serial::Tx<pac::USART4> => C5,
-);

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -531,7 +531,6 @@ macro_rules! on_channel {
     };
 }
 
-#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
 on_channel!(dma1,
     serial::Rx<pac::USART1> => C5,
     serial::Tx<pac::USART1> => C4,

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -531,7 +531,7 @@ macro_rules! on_channel {
     };
 }
 
-#[cfg(feature = "stm32f303")]
+#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
 on_channel!(dma1,
     serial::Rx<pac::USART1> => C5,
     serial::Tx<pac::USART1> => C4,
@@ -539,4 +539,19 @@ on_channel!(dma1,
     serial::Tx<pac::USART2> => C7,
     serial::Rx<pac::USART3> => C3,
     serial::Tx<pac::USART3> => C2,
+);
+
+#[cfg(any(
+    feature = "stm32f302xb",
+    feature = "stm32f302xc",
+    feature = "stm32f302xd",
+    feature = "stm32f302xe",
+    feature = "stm32f303xb",
+    feature = "stm32f303xc",
+    feature = "stm32f303xd",
+    feature = "stm32f303xe",
+))]
+on_channel!(dma2,
+    serial::Rx<pac::USART4> => C3,
+    serial::Tx<pac::USART4> => C5,
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub use crate::pac::interrupt;
 pub mod adc;
 #[cfg(feature = "device-selected")]
 pub mod delay;
-#[cfg(feature = "stm32f303")]
+#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
 pub mod dma;
 #[cfg(feature = "device-selected")]
 pub mod flash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub use crate::pac::interrupt;
 pub mod adc;
 #[cfg(feature = "device-selected")]
 pub mod delay;
-#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
+#[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
 pub mod dma;
 #[cfg(feature = "device-selected")]
 pub mod flash;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 //! Prelude
 
-#[cfg(feature = "stm32f303")]
+#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
 pub use crate::dma::DmaExt as _stm32f3xx_hal_dma_DmaExt;
 pub use crate::flash::FlashExt as _stm32f3xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32f3xx_hal_gpio_GpioExt;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 //! Prelude
 
-#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
+#[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
 pub use crate::dma::DmaExt as _stm32f3xx_hal_dma_DmaExt;
 pub use crate::flash::FlashExt as _stm32f3xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32f3xx_hal_gpio_GpioExt;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -37,9 +37,9 @@ use crate::gpio::gpiod;
 ))]
 use crate::gpio::gpioe;
 
-#[cfg(feature = "stm32f303")]
+#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
 use crate::dma;
-#[cfg(feature = "stm32f303")]
+#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
 use cortex_m::interrupt;
 
 /// Interrupt event
@@ -363,7 +363,7 @@ macro_rules! hal {
 
             impl blocking::serial::write::Default<u8> for Tx<$USARTX> {}
 
-            #[cfg(feature = "stm32f303")]
+            #[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
             impl Rx<$USARTX> {
                 /// Fill the buffer with received data using DMA.
                 pub fn read_exact<B, C>(
@@ -384,7 +384,7 @@ macro_rules! hal {
                 }
             }
 
-            #[cfg(feature = "stm32f303")]
+            #[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
             impl Tx<$USARTX> {
                 /// Transmit all data in the buffer using DMA.
                 pub fn write_all<B, C>(
@@ -405,7 +405,7 @@ macro_rules! hal {
                 }
             }
 
-            #[cfg(feature = "stm32f303")]
+            #[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
             impl dma::Target for Rx<$USARTX> {
                 fn enable_dma(&mut self) {
                     // NOTE(unsafe) critical section prevents races
@@ -424,7 +424,7 @@ macro_rules! hal {
                 }
             }
 
-            #[cfg(feature = "stm32f303")]
+            #[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
             impl dma::Target for Tx<$USARTX> {
                 fn enable_dma(&mut self) {
                     // NOTE(unsafe) critical section prevents races

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -447,12 +447,14 @@ macro_rules! hal {
 }
 
 #[cfg(any(
+    feature = "stm32f302",
     feature = "stm32f301",
     feature = "stm32f318",
     feature = "stm32f303",
     feature = "stm32f373",
     feature = "stm32f378",
     feature = "stm32f328",
+    feature = "stm32f334",
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
@@ -462,8 +464,16 @@ hal! {
     USART3: (usart3, APB1, usart3en, usart3rst, pclk1),
 }
 
-#[cfg(any(feature = "stm32f302", feature = "stm32f334"))]
+#[cfg(any(
+    feature = "stm32f302xb",
+    feature = "stm32f302xc",
+    feature = "stm32f302xd",
+    feature = "stm32f302xe",
+    feature = "stm32f303xb",
+    feature = "stm32f303xc",
+    feature = "stm32f303xd",
+    feature = "stm32f303xe",
+))]
 hal! {
-    USART1: (usart1, APB2, usart1en, usart1rst, pclk2),
-    USART2: (usart2, APB1, usart2en, usart2rst, pclk1),
+    USART4: (usart4, APB1, usart4en, usart4rst, pclk2),
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -463,20 +463,3 @@ hal! {
     USART2: (usart2, APB1, usart2en, usart2rst, pclk1),
     USART3: (usart3, APB1, usart3en, usart3rst, pclk1),
 }
-
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f358",
-    feature = "stm32f398"
-))]
-hal! {
-    USART4: (usart4, APB1, usart4en, usart4rst, pclk1),
-    USART5: (usart5, APB1, usart5en, usart5rst, pclk1),
-}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -473,7 +473,10 @@ hal! {
     feature = "stm32f303xc",
     feature = "stm32f303xd",
     feature = "stm32f303xe",
+    feature = "stm32f358",
+    feature = "stm32f398"
 ))]
 hal! {
     USART4: (usart4, APB1, usart4en, usart4rst, pclk2),
+    USART5: (usart5, APB1, usart5en, usart5rst, pclk2),
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -446,18 +446,6 @@ macro_rules! hal {
     }
 }
 
-#[cfg(any(
-    feature = "stm32f302",
-    feature = "stm32f301",
-    feature = "stm32f318",
-    feature = "stm32f303",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f328",
-    feature = "stm32f334",
-    feature = "stm32f358",
-    feature = "stm32f398"
-))]
 hal! {
     USART1: (usart1, APB2, usart1en, usart1rst, pclk2),
     USART2: (usart2, APB1, usart2en, usart2rst, pclk1),

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -37,9 +37,9 @@ use crate::gpio::gpiod;
 ))]
 use crate::gpio::gpioe;
 
-#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
+#[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
 use crate::dma;
-#[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
+#[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
 use cortex_m::interrupt;
 
 /// Interrupt event
@@ -363,7 +363,7 @@ macro_rules! hal {
 
             impl blocking::serial::write::Default<u8> for Tx<$USARTX> {}
 
-            #[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
+            #[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
             impl Rx<$USARTX> {
                 /// Fill the buffer with received data using DMA.
                 pub fn read_exact<B, C>(
@@ -384,7 +384,7 @@ macro_rules! hal {
                 }
             }
 
-            #[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
+            #[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
             impl Tx<$USARTX> {
                 /// Transmit all data in the buffer using DMA.
                 pub fn write_all<B, C>(
@@ -405,7 +405,7 @@ macro_rules! hal {
                 }
             }
 
-            #[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
+            #[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
             impl dma::Target for Rx<$USARTX> {
                 fn enable_dma(&mut self) {
                     // NOTE(unsafe) critical section prevents races
@@ -424,7 +424,7 @@ macro_rules! hal {
                 }
             }
 
-            #[cfg(any(feature = "stm32f303", feature = "stm32f302"))]
+            #[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
             impl dma::Target for Tx<$USARTX> {
                 fn enable_dma(&mut self) {
                     // NOTE(unsafe) critical section prevents races

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -477,6 +477,6 @@ hal! {
     feature = "stm32f398"
 ))]
 hal! {
-    USART4: (usart4, APB1, usart4en, usart4rst, pclk2),
-    USART5: (usart5, APB1, usart5en, usart5rst, pclk2),
+    USART4: (usart4, APB1, usart4en, usart4rst, pclk1),
+    USART5: (usart5, APB1, usart5en, usart5rst, pclk1),
 }


### PR DESCRIPTION
Replaces #135.
Closes #134.