### PR TITLE
Add support for HSE bypass and CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - SPI4 peripheral for supported
   devices. ([#99](https://github.com/stm32-rs/stm32f3xx-hal/pull/99))
 - Support for I2C transfer of more than 255 bytes, and 0 byte write ([#154](https://github.com/stm32-rs/stm32f3xx-hal/pull/154))
+- Support for HSE bypass and CSS ([#156](https://github.com/stm32-rs/stm32f3xx-hal/pull/156))
 
 ### Changed
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -87,7 +87,7 @@ impl AHB {
 /// ```
 /// let dp = pac::Peripherals::take().unwrap();
 /// let rcc = dp.RCC.constrain();
-/// use_ahb(&mut rcc.apb1)
+/// use_apb1(&mut rcc.apb1)
 /// ```
 pub struct APB1 {
     _0: (),
@@ -112,7 +112,7 @@ impl APB1 {
 /// ```
 /// let dp = pac::Peripherals::take().unwrap();
 /// let rcc = dp.RCC.constrain();
-/// use_ahb(&mut rcc.apb2)
+/// use_apb2(&mut rcc.apb2)
 /// ```
 pub struct APB2 {
     _0: (),
@@ -212,7 +212,7 @@ impl BDCR {
 /// ```
 /// let dp = pac::Peripherals::take().unwrap();
 /// let rcc = dp.RCC.constrain();
-/// use_ahb(&mut rcc.cfgr)
+/// use_cfgr(&mut rcc.cfgr)
 /// ```
 pub struct CFGR {
     hse: Option<u32>,
@@ -376,9 +376,10 @@ impl CFGR {
             }
 
             // PLL_MUL maximal value is 16
-            assert!(divisor <= 16);
-            // PRE_DIV maximal value is 16
             assert!(multiplier <= 16);
+
+            // PRE_DIV maximal value is 16
+            assert!(divisor <= 16);
 
             (multiplier, Some(divisor))
         }


### PR DESCRIPTION
Fix #142.

However, APIs for the same thing are vary in all stm32-rs HALs... Are there any suggestions?

* this PR
```rust
let clocks = rcc.cfgr/* .use_hse_crystal(8.mhz()) */.use_hse_bypass(8.mhz()).enable_css().freeze();
```

* f0xx
```rust
let rcc = dp.RCC.configure().hse(HSEClock::new(8.mhz(), HSEBypassMode::Bypassed)).freeze(&mut dp.FLASH);
```

* f7xx
```rust
let clocks = rcc.cfgr.hse(HSEClock::new(25.mhz(), HSEClockMode::Bypass)).freeze();
```

* g0xx, g4xx
```rust
let rcc = rcc.freeze(Config::pll().pll_cfg(PllConfig { max: PLLSrc::HSE_BYPASS(8.mhz()), ..Default::default() }));
```

* h7xx
```rust
let ccdr = rcc.use_hse(25.mhz()).bypass_hse().freeze(pwrcfg, &dp.SYSCFG);
```

* l4xx
```rust
let clocks = rcc.cfgr.hse(8.mhz(), CrystalBypass::Disable, ClockSecuritySystem::Disable).freeze(&mut flash.acr, &mut pwr);
```