### PR TITLE
Fix I2C clock and support I2C3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   devices. ([#99](https://github.com/stm32-rs/stm32f3xx-hal/pull/99))
 - Support for I2C transfer of more than 255 bytes, and 0 byte write ([#154](https://github.com/stm32-rs/stm32f3xx-hal/pull/154))
 - Support for HSE bypass and CSS ([#156](https://github.com/stm32-rs/stm32f3xx-hal/pull/156))
+- Impls for missing I2C pin definitions ([#164](https://github.com/stm32-rs/stm32f3xx-hal/pull/164))
+- Support I2C3 ([#164](https://github.com/stm32-rs/stm32f3xx-hal/pull/164))
 
 ### Changed
 
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed [#151][] not being able to generate 72 MHz HCLK for stm32f303xc devices
   ([#152](https://github.com/stm32-rs/stm32f3xx-hal/pull/152))
+- Wrong I2C clock source ([#164](https://github.com/stm32-rs/stm32f3xx-hal/pull/164))
 
 [#151]: https://github.com/stm32-rs/stm32f3xx-hal/issues/151
 
@@ -47,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   not mean, that we guarantee any MSRV policy. It is rather for documentation
   purposes and if a new useful feature arises, we will increase the MSRV.
   ([#170](https://github.com/stm32-rs/stm32f3xx-hal/pull/170))
+- Removed I2C2 support for `stm32f303x6`, `stm32f303x8` and `stm32f328` targets. ([#164](https://github.com/stm32-rs/stm32f3xx-hal/pull/164))
 
 ## [v0.5.0] - 2020-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   purposes and if a new useful feature arises, we will increase the MSRV.
   ([#170](https://github.com/stm32-rs/stm32f3xx-hal/pull/170))
 - Removed I2C2 support for `stm32f303x6`, `stm32f303x8` and `stm32f328` targets. ([#164](https://github.com/stm32-rs/stm32f3xx-hal/pull/164))
+- `I2c::i2c1` and `I2c::i2c2` functions are renamed to `I2c::new`. ([#164](https://github.com/stm32-rs/stm32f3xx-hal/pull/164))
 
 ## [v0.5.0] - 2020-07-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,3 +134,7 @@ required-features = ["stm32f303"]
 [[example]]
 name = "adc"
 required-features = ["stm32f303"]
+
+[[example]]
+name = "i2c_scanner"
+required-features = ["stm32f303xc"]

--- a/examples/i2c_scanner.rs
+++ b/examples/i2c_scanner.rs
@@ -1,0 +1,61 @@
+//! Example of using I2C.
+//! Scans available I2C devices on bus and print the result.
+//! Appropriate pull-up registers should be installed on I2C bus.
+//! Target board: STM32F3DISCOVERY
+
+#![no_std]
+#![no_main]
+
+use core::ops::Range;
+
+use panic_semihosting as _;
+
+use cortex_m::asm;
+use cortex_m_rt::entry;
+use cortex_m_semihosting::{hprint, hprintln};
+
+use stm32f3xx_hal::{self as hal, pac, prelude::*};
+
+const VALID_ADDR_RANGE: Range<u8> = 0x08..0x78;
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut gpiob = dp.GPIOB.split(&mut rcc.ahb);
+
+    // Configure I2C1
+    let pins = (
+        gpiob.pb6.into_af4(&mut gpiob.moder, &mut gpiob.afrl), // SCL
+        gpiob.pb7.into_af4(&mut gpiob.moder, &mut gpiob.afrl), // SDA
+    );
+    let mut i2c = hal::i2c::I2c::new(dp.I2C1, pins, 100.khz(), clocks, &mut rcc.apb1);
+
+    hprintln!("Start i2c scanning...").expect("Error using hprintln.");
+    hprintln!().unwrap();
+
+    for addr in 0x00_u8..0x80 {
+        // Write the empty array and check the slave response.
+        if VALID_ADDR_RANGE.contains(&addr) && i2c.write(addr, &[]).is_ok() {
+            hprint!("{:02x}", addr).unwrap();
+        } else {
+            hprint!("..").unwrap();
+        }
+        if addr % 0x10 == 0x0F {
+            hprintln!().unwrap();
+        } else {
+            hprint!(" ").unwrap();
+        }
+    }
+
+    hprintln!().unwrap();
+    hprintln!("Done!").unwrap();
+
+    loop {
+        asm::wfi();
+    }
+}

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,13 +1,14 @@
 //! Inter-Integrated Circuit (I2C) bus
 
 use core::convert::TryFrom;
+use core::ops::Deref;
 
 use crate::{
     gpio::{gpioa, gpiob, AF4},
     hal::blocking::i2c::{Read, Write, WriteRead},
-    pac::{rcc::cfgr3::I2C1SW_A, I2C1, RCC},
+    pac::{i2c1::RegisterBlock, rcc::cfgr3::I2C1SW_A, I2C1, RCC},
     rcc::{Clocks, APB1},
-    time::Hertz,
+    time::{Hertz, U32Ext},
 };
 
 #[cfg(not(feature = "gpio-f333"))]
@@ -104,338 +105,351 @@ macro_rules! busy_wait {
     };
 }
 
+impl<I2C, SCL, SDA> I2c<I2C, (SCL, SDA)> {
+    /// Configures the I2C peripheral to work in master mode
+    pub fn new<F>(i2c: I2C, pins: (SCL, SDA), freq: F, clocks: Clocks, apb1: &mut APB1) -> Self
+    where
+        I2C: Instance,
+        SCL: SclPin<I2C>,
+        SDA: SdaPin<I2C>,
+        F: Into<Hertz>,
+    {
+        let freq = freq.into().0;
+
+        assert!(freq <= 1_000_000);
+
+        I2C::enable_clock(apb1);
+
+        // TODO review compliance with the timing requirements of I2C
+        // t_I2CCLK = 1 / PCLK1
+        // t_PRESC  = (PRESC + 1) * t_I2CCLK
+        // t_SCLL   = (SCLL + 1) * t_PRESC
+        // t_SCLH   = (SCLH + 1) * t_PRESC
+        //
+        // t_SYNC1 + t_SYNC2 > 4 * t_I2CCLK
+        // t_SCL ~= t_SYNC1 + t_SYNC2 + t_SCLL + t_SCLH
+        let i2cclk = I2C::clock(&clocks).0;
+        let ratio = i2cclk / freq - 4;
+        let (presc, scll, sclh, sdadel, scldel) = if freq >= 100_000 {
+            // fast-mode or fast-mode plus
+            // here we pick SCLL + 1 = 2 * (SCLH + 1)
+            let presc = ratio / 387;
+
+            let sclh = ((ratio / (presc + 1)) - 3) / 3;
+            let scll = 2 * (sclh + 1) - 1;
+
+            let (sdadel, scldel) = if freq > 400_000 {
+                // fast-mode plus
+                let sdadel = 0;
+                let scldel = i2cclk / 4_000_000 / (presc + 1) - 1;
+
+                (sdadel, scldel)
+            } else {
+                // fast-mode
+                let sdadel = i2cclk / 8_000_000 / (presc + 1);
+                let scldel = i2cclk / 2_000_000 / (presc + 1) - 1;
+
+                (sdadel, scldel)
+            };
+
+            (presc, scll, sclh, sdadel, scldel)
+        } else {
+            // standard-mode
+            // here we pick SCLL = SCLH
+            let presc = ratio / 514;
+
+            let sclh = ((ratio / (presc + 1)) - 2) / 2;
+            let scll = sclh;
+
+            let sdadel = i2cclk / 2_000_000 / (presc + 1);
+            let scldel = i2cclk / 800_000 / (presc + 1) - 1;
+
+            (presc, scll, sclh, sdadel, scldel)
+        };
+
+        assert!(presc < 16);
+        assert!(scldel < 16);
+        assert!(sdadel < 16);
+        let sclh = u8::try_from(sclh).unwrap();
+        let scll = u8::try_from(scll).unwrap();
+
+        // Configure for "fast mode" (400 KHz)
+        // NOTE(write): writes all non-reserved bits.
+        i2c.timingr.write(|w| {
+            w.presc()
+                .bits(presc as u8)
+                .sdadel()
+                .bits(sdadel as u8)
+                .scldel()
+                .bits(scldel as u8)
+                .scll()
+                .bits(scll)
+                .sclh()
+                .bits(sclh)
+        });
+
+        // Enable the peripheral
+        i2c.cr1.modify(|_, w| w.pe().set_bit());
+
+        Self { i2c, pins }
+    }
+
+    /// Releases the I2C peripheral and associated pins
+    pub fn free(self) -> (I2C, (SCL, SDA)) {
+        (self.i2c, self.pins)
+    }
+}
+
+impl<I2C, PINS> Read for I2c<I2C, PINS>
+where
+    I2C: Instance,
+{
+    type Error = Error;
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        assert!(!buffer.is_empty());
+
+        // Detect Bus busy
+        if self.i2c.isr.read().busy().is_busy() {
+            return Err(Error::Busy);
+        }
+
+        let end = buffer.len() / 0xFF;
+
+        // Process 255 bytes at a time
+        for (i, buffer) in buffer.chunks_mut(0xFF).enumerate() {
+            // Prepare to receive `bytes`
+            self.i2c.cr2.modify(|_, w| {
+                if i == 0 {
+                    w.add10().bit7();
+                    w.sadd().bits((addr << 1) as u16);
+                    w.rd_wrn().read();
+                    w.start().start();
+                }
+                w.nbytes().bits(buffer.len() as u8);
+                if i != end {
+                    w.reload().not_completed()
+                } else {
+                    w.reload().completed().autoend().automatic()
+                }
+            });
+
+            for byte in buffer {
+                // Wait until we have received something
+                busy_wait!(self.i2c, rxne, is_not_empty);
+
+                *byte = self.i2c.rxdr.read().rxdata().bits();
+            }
+
+            if i != end {
+                // Wait until the last transmission is finished
+                busy_wait!(self.i2c, tcr, is_complete);
+            }
+        }
+
+        // automatic STOP
+        // Wait until the last transmission is finished
+        busy_wait!(self.i2c, stopf, is_stop);
+
+        self.i2c.icr.write(|w| w.stopcf().clear());
+
+        Ok(())
+    }
+}
+
+impl<I2C, PINS> Write for I2c<I2C, PINS>
+where
+    I2C: Instance,
+{
+    type Error = Error;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+        // Detect Bus busy
+        if self.i2c.isr.read().busy().is_busy() {
+            return Err(Error::Busy);
+        }
+
+        if bytes.is_empty() {
+            // 0 byte write
+            self.i2c.cr2.modify(|_, w| {
+                w.add10().bit7();
+                w.sadd().bits((addr << 1) as u16);
+                w.rd_wrn().write();
+                w.nbytes().bits(0);
+                w.reload().completed();
+                w.autoend().automatic();
+                w.start().start()
+            });
+        } else {
+            let end = bytes.len() / 0xFF;
+
+            // Process 255 bytes at a time
+            for (i, bytes) in bytes.chunks(0xFF).enumerate() {
+                // Prepare to send `bytes`
+                self.i2c.cr2.modify(|_, w| {
+                    if i == 0 {
+                        w.add10().bit7();
+                        w.sadd().bits((addr << 1) as u16);
+                        w.rd_wrn().write();
+                        w.start().start();
+                    }
+                    w.nbytes().bits(bytes.len() as u8);
+                    if i != end {
+                        w.reload().not_completed()
+                    } else {
+                        w.reload().completed().autoend().automatic()
+                    }
+                });
+
+                for byte in bytes {
+                    // Wait until we are allowed to send data
+                    // (START has been ACKed or last byte went through)
+                    busy_wait!(self.i2c, txis, is_empty);
+
+                    // Put byte on the wire
+                    // NOTE(write): Writes all non-reserved bits.
+                    self.i2c.txdr.write(|w| w.txdata().bits(*byte));
+                }
+
+                if i != end {
+                    // Wait until the last transmission is finished
+                    busy_wait!(self.i2c, tcr, is_complete);
+                }
+            }
+        }
+
+        // automatic STOP
+        // Wait until the last transmission is finished
+        busy_wait!(self.i2c, stopf, is_stop);
+
+        self.i2c.icr.write(|w| w.stopcf().clear());
+
+        Ok(())
+    }
+}
+
+impl<I2C, PINS> WriteRead for I2c<I2C, PINS>
+where
+    I2C: Instance,
+{
+    type Error = Error;
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
+        assert!(!bytes.is_empty() && !buffer.is_empty());
+
+        // Detect Bus busy
+        if self.i2c.isr.read().busy().is_busy() {
+            return Err(Error::Busy);
+        }
+
+        let end = bytes.len() / 0xFF;
+
+        // Process 255 bytes at a time
+        for (i, bytes) in bytes.chunks(0xFF).enumerate() {
+            // Prepare to send `bytes`
+            self.i2c.cr2.modify(|_, w| {
+                if i == 0 {
+                    w.add10().bit7();
+                    w.sadd().bits((addr << 1) as u16);
+                    w.rd_wrn().write();
+                    w.start().start();
+                }
+                w.nbytes().bits(bytes.len() as u8);
+                if i != end {
+                    w.reload().not_completed()
+                } else {
+                    w.reload().completed().autoend().software()
+                }
+            });
+
+            for byte in bytes {
+                // Wait until we are allowed to send data
+                // (START has been ACKed or last byte went through)
+                busy_wait!(self.i2c, txis, is_empty);
+
+                // Put byte on the wire
+                // NOTE(write): Writes all non-reserved bits.
+                self.i2c.txdr.write(|w| w.txdata().bits(*byte));
+            }
+
+            if i != end {
+                // Wait until the last transmission is finished
+                busy_wait!(self.i2c, tcr, is_complete);
+            }
+        }
+
+        // Wait until the last transmission is finished
+        busy_wait!(self.i2c, tc, is_complete);
+
+        // restart
+
+        let end = buffer.len() / 0xFF;
+
+        // Process 255 bytes at a time
+        for (i, buffer) in buffer.chunks_mut(0xFF).enumerate() {
+            // Prepare to receive `bytes`
+            self.i2c.cr2.modify(|_, w| {
+                if i == 0 {
+                    w.add10().bit7();
+                    w.sadd().bits((addr << 1) as u16);
+                    w.rd_wrn().read();
+                    w.start().start();
+                }
+                w.nbytes().bits(buffer.len() as u8);
+                if i != end {
+                    w.reload().not_completed()
+                } else {
+                    w.reload().completed().autoend().automatic()
+                }
+            });
+
+            for byte in buffer {
+                // Wait until we have received something
+                busy_wait!(self.i2c, rxne, is_not_empty);
+
+                *byte = self.i2c.rxdr.read().rxdata().bits();
+            }
+
+            if i != end {
+                // Wait until the last transmission is finished
+                busy_wait!(self.i2c, tcr, is_complete);
+            }
+        }
+
+        // automatic STOP
+        // Wait until the last transmission is finished
+        busy_wait!(self.i2c, stopf, is_stop);
+
+        self.i2c.icr.write(|w| w.stopcf().clear());
+
+        Ok(())
+    }
+}
+
+/// I2C instance -- DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait Instance: Deref<Target = RegisterBlock> {
+    #[doc(hidden)]
+    fn enable_clock(apb1: &mut APB1);
+    #[doc(hidden)]
+    fn clock(clocks: &Clocks) -> Hertz;
+}
+
 macro_rules! i2c {
-    ($($I2CX:ident: ($i2cX:ident, $i2cXen:ident, $i2cXrst:ident, $i2cXsw:ident),)+) => {
+    ($($I2CX:ident: ($i2cXen:ident, $i2cXrst:ident, $i2cXsw:ident),)+) => {
         $(
-            impl<SCL, SDA> I2c<$I2CX, (SCL, SDA)> {
-                /// Configures the I2C peripheral to work in master mode
-                pub fn $i2cX<F>(
-                    i2c: $I2CX,
-                    pins: (SCL, SDA),
-                    freq: F,
-                    clocks: Clocks,
-                    apb1: &mut APB1,
-                ) -> Self where
-                    F: Into<Hertz>,
-                    SCL: SclPin<$I2CX>,
-                    SDA: SdaPin<$I2CX>,
-                {
+            unsafe impl Instance for $I2CX {
+                fn enable_clock(apb1: &mut APB1) {
                     apb1.enr().modify(|_, w| w.$i2cXen().enabled());
                     apb1.rstr().modify(|_, w| w.$i2cXrst().reset());
                     apb1.rstr().modify(|_, w| w.$i2cXrst().clear_bit());
+                }
 
-                    let freq = freq.into().0;
-
-                    assert!(freq <= 1_000_000);
-
+                fn clock(clocks: &Clocks) -> Hertz {
                     // NOTE(unsafe) atomic read with no side effects
-                    let i2cclk = match unsafe { (*RCC::ptr()).cfgr3.read().$i2cXsw().variant() } {
-                        I2C1SW_A::HSI => 8_000_000,
-                        I2C1SW_A::SYSCLK => clocks.sysclk().0,
-                    };
-
-                    // TODO review compliance with the timing requirements of I2C
-                    // t_I2CCLK = 1 / PCLK1
-                    // t_PRESC  = (PRESC + 1) * t_I2CCLK
-                    // t_SCLL   = (SCLL + 1) * t_PRESC
-                    // t_SCLH   = (SCLH + 1) * t_PRESC
-                    //
-                    // t_SYNC1 + t_SYNC2 > 4 * t_I2CCLK
-                    // t_SCL ~= t_SYNC1 + t_SYNC2 + t_SCLL + t_SCLH
-                    let ratio = i2cclk / freq - 4;
-                    let (presc, scll, sclh, sdadel, scldel) = if freq >= 100_000 {
-                        // fast-mode or fast-mode plus
-                        // here we pick SCLL + 1 = 2 * (SCLH + 1)
-                        let presc = ratio / 387;
-
-                        let sclh = ((ratio / (presc + 1)) - 3) / 3;
-                        let scll = 2 * (sclh + 1) - 1;
-
-                        let (sdadel, scldel) = if freq > 400_000 {
-                            // fast-mode plus
-                            let sdadel = 0;
-                            let scldel = i2cclk / 4_000_000 / (presc + 1) - 1;
-
-                            (sdadel, scldel)
-                        } else {
-                            // fast-mode
-                            let sdadel = i2cclk / 8_000_000 / (presc + 1);
-                            let scldel = i2cclk / 2_000_000 / (presc + 1) - 1;
-
-                            (sdadel, scldel)
-                        };
-
-                        (presc, scll, sclh, sdadel, scldel)
-                    } else {
-                        // standard-mode
-                        // here we pick SCLL = SCLH
-                        let presc = ratio / 514;
-
-                        let sclh = ((ratio / (presc + 1)) - 2) / 2;
-                        let scll = sclh;
-
-                        let sdadel = i2cclk / 2_000_000 / (presc + 1);
-                        let scldel = i2cclk / 800_000 / (presc + 1) - 1;
-
-                        (presc, scll, sclh, sdadel, scldel)
-                    };
-
-                    assert!(presc < 16);
-                    assert!(scldel < 16);
-                    assert!(sdadel < 16);
-                    let sclh = u8::try_from(sclh).unwrap();
-                    let scll = u8::try_from(scll).unwrap();
-
-                    // Configure for "fast mode" (400 KHz)
-                    // NOTE(write): writes all non-reserved bits.
-                    i2c.timingr.write(|w| {
-                        w.presc()
-                            .bits(presc as u8)
-                            .sdadel()
-                            .bits(sdadel as u8)
-                            .scldel()
-                            .bits(scldel as u8)
-                            .scll()
-                            .bits(scll)
-                            .sclh()
-                            .bits(sclh)
-                    });
-
-                    // Enable the peripheral
-                    i2c.cr1.modify(|_, w| w.pe().set_bit());
-
-                    I2c { i2c, pins }
-                }
-
-                /// Releases the I2C peripheral and associated pins
-                pub fn free(self) -> ($I2CX, (SCL, SDA)) {
-                    (self.i2c, self.pins)
-                }
-            }
-
-            impl<PINS> Read for I2c<$I2CX, PINS> {
-                type Error = Error;
-                fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-                    assert!(buffer.len() > 0);
-
-                    // Detect Bus busy
-                    if self.i2c.isr.read().busy().is_busy() {
-                        return Err(Error::Busy);
+                    match unsafe { (*RCC::ptr()).cfgr3.read().$i2cXsw().variant() } {
+                        I2C1SW_A::HSI => 8.mhz().into(),
+                        I2C1SW_A::SYSCLK => clocks.sysclk(),
                     }
-
-                    let end = buffer.len() / 0xFF;
-
-                    // Process 255 bytes at a time
-                    for (i, buffer) in buffer.chunks_mut(0xFF).enumerate() {
-                        // Prepare to receive `bytes`
-                        self.i2c.cr2.modify(|_, w| {
-                            if i == 0 {
-                                w
-                                    .add10().bit7()
-                                    .sadd().bits((addr << 1) as u16)
-                                    .rd_wrn().read()
-                                    .start().start();
-                            }
-                            w.nbytes().bits(buffer.len() as u8);
-                            if i != end {
-                                w.reload().not_completed()
-                            } else {
-                                w.reload().completed().autoend().automatic()
-                            }
-                        });
-
-                        for byte in buffer {
-                            // Wait until we have received something
-                            busy_wait!(self.i2c, rxne, is_not_empty);
-
-                            *byte = self.i2c.rxdr.read().rxdata().bits();
-                        }
-
-                        if i != end {
-                            // Wait until the last transmission is finished
-                            busy_wait!(self.i2c, tcr, is_complete);
-                        }
-                    }
-
-                    // automatic STOP
-                    // Wait until the last transmission is finished
-                    busy_wait!(self.i2c, stopf, is_stop);
-
-                    self.i2c.icr.write(|w| w.stopcf().clear());
-
-                    Ok(())
-                }
-            }
-
-            impl<PINS> Write for I2c<$I2CX, PINS> {
-                type Error = Error;
-
-                fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
-                    // Detect Bus busy
-                    if self.i2c.isr.read().busy().is_busy() {
-                        return Err(Error::Busy);
-                    }
-
-                    if bytes.len() == 0 {
-                        // 0 byte write
-                        self.i2c.cr2.modify(|_, w| {
-                            w
-                                .add10().bit7()
-                                .sadd().bits((addr << 1) as u16)
-                                .rd_wrn().write()
-                                .nbytes().bits(0)
-                                .reload().completed()
-                                .autoend().automatic()
-                                .start().start()
-                        });
-                    } else {
-                        let end = bytes.len() / 0xFF;
-
-                        // Process 255 bytes at a time
-                        for (i, bytes) in bytes.chunks(0xFF).enumerate() {
-                            // Prepare to send `bytes`
-                            self.i2c.cr2.modify(|_, w| {
-                                if i == 0 {
-                                    w
-                                        .add10().bit7()
-                                        .sadd().bits((addr << 1) as u16)
-                                        .rd_wrn().write()
-                                        .start().start();
-                                }
-                                w.nbytes().bits(bytes.len() as u8);
-                                if i != end {
-                                    w.reload().not_completed()
-                                } else {
-                                    w.reload().completed().autoend().automatic()
-                                }
-                            });
-
-                            for byte in bytes {
-                                // Wait until we are allowed to send data
-                                // (START has been ACKed or last byte went through)
-                                busy_wait!(self.i2c, txis, is_empty);
-
-                                // Put byte on the wire
-                                // NOTE(write): Writes all non-reserved bits.
-                                self.i2c.txdr.write(|w| w.txdata().bits(*byte));
-                            }
-
-                            if i != end {
-                                // Wait until the last transmission is finished
-                                busy_wait!(self.i2c, tcr, is_complete);
-                            }
-                        }
-                    }
-
-                    // automatic STOP
-                    // Wait until the last transmission is finished
-                    busy_wait!(self.i2c, stopf, is_stop);
-
-                    self.i2c.icr.write(|w| w.stopcf().clear());
-
-                    Ok(())
-                }
-            }
-
-            impl<PINS> WriteRead for I2c<$I2CX, PINS> {
-                type Error = Error;
-
-                fn write_read(
-                    &mut self,
-                    addr: u8,
-                    bytes: &[u8],
-                    buffer: &mut [u8],
-                ) -> Result<(), Error> {
-                    assert!(bytes.len() > 0 && buffer.len() > 0);
-
-                    // Detect Bus busy
-                    if self.i2c.isr.read().busy().is_busy() {
-                        return Err(Error::Busy);
-                    }
-
-                    let end = bytes.len() / 0xFF;
-
-                    // Process 255 bytes at a time
-                    for (i, bytes) in bytes.chunks(0xFF).enumerate() {
-                        // Prepare to send `bytes`
-                        self.i2c.cr2.modify(|_, w| {
-                            if i == 0 {
-                                w
-                                    .add10().bit7()
-                                    .sadd().bits((addr << 1) as u16)
-                                    .rd_wrn().write()
-                                    .start().start();
-                            }
-                            w.nbytes().bits(bytes.len() as u8);
-                            if i != end {
-                                w.reload().not_completed()
-                            } else {
-                                w.reload().completed().autoend().software()
-                            }
-                        });
-
-                        for byte in bytes {
-                            // Wait until we are allowed to send data
-                            // (START has been ACKed or last byte went through)
-                            busy_wait!(self.i2c, txis, is_empty);
-
-                            // Put byte on the wire
-                            // NOTE(write): Writes all non-reserved bits.
-                            self.i2c.txdr.write(|w| w.txdata().bits(*byte));
-                        }
-
-                        if i != end {
-                            // Wait until the last transmission is finished
-                            busy_wait!(self.i2c, tcr, is_complete);
-                        }
-                    }
-
-                    // Wait until the last transmission is finished
-                    busy_wait!(self.i2c, tc, is_complete);
-
-                    // restart
-
-                    let end = buffer.len() / 0xFF;
-
-                    // Process 255 bytes at a time
-                    for (i, buffer) in buffer.chunks_mut(0xFF).enumerate() {
-                        // Prepare to receive `bytes`
-                        self.i2c.cr2.modify(|_, w| {
-                            if i == 0 {
-                                w
-                                    .add10().bit7()
-                                    .sadd().bits((addr << 1) as u16)
-                                    .rd_wrn().read()
-                                    .start().start();
-                            }
-                            w.nbytes().bits(buffer.len() as u8);
-                            if i != end {
-                                w.reload().not_completed()
-                            } else {
-                                w.reload().completed().autoend().automatic()
-                            }
-                        });
-
-                        for byte in buffer {
-                            // Wait until we have received something
-                            busy_wait!(self.i2c, rxne, is_not_empty);
-
-                            *byte = self.i2c.rxdr.read().rxdata().bits();
-                        }
-
-                        if i != end {
-                            // Wait until the last transmission is finished
-                            busy_wait!(self.i2c, tcr, is_complete);
-                        }
-                    }
-
-                    // automatic STOP
-                    // Wait until the last transmission is finished
-                    busy_wait!(self.i2c, stopf, is_stop);
-
-                    self.i2c.icr.write(|w| w.stopcf().clear());
-
-                    Ok(())
                 }
             }
         )+
@@ -444,7 +458,7 @@ macro_rules! i2c {
     ([ $($X:literal),+ ]) => {
         paste::paste! {
             i2c!(
-                $([<I2C $X>]: ([<i2c $X>], [<i2c $X en>], [<i2c $X rst>], [<i2c $X sw>]),)+
+                $([<I2C $X>]: ([<i2c $X en>], [<i2c $X rst>], [<i2c $X sw>]),)+
             );
         }
     };

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -10,24 +10,10 @@ use crate::{
     time::Hertz,
 };
 
-#[cfg(not(any(
-    feature = "stm32f303x6",
-    feature = "stm32f303x8",
-    feature = "stm32f334",
-    feature = "stm32f328",
-)))]
+#[cfg(not(feature = "gpio-f333"))]
 use crate::{gpio::gpiof, pac::I2C2};
-#[cfg(any(
-    feature = "stm32f301",
-    feature = "stm32f302x6",
-    feature = "stm32f302x8",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f398",
-))]
+
+#[cfg(any(feature = "gpio-f302", feature = "gpio-f303e"))]
 use crate::{
     gpio::{gpioc, AF3, AF8},
     pac::I2C3,
@@ -68,12 +54,7 @@ unsafe impl SdaPin<I2C1> for gpiob::PB7<AF4> {}
 unsafe impl SdaPin<I2C1> for gpiob::PB9<AF4> {}
 
 cfg_if! {
-    if #[cfg(not(any(
-        feature = "stm32f303x6",
-        feature = "stm32f303x8",
-        feature = "stm32f334",
-        feature = "stm32f328",
-    )))] {
+    if #[cfg(not(feature = "gpio-f333"))] {
         unsafe impl SclPin<I2C2> for gpioa::PA9<AF4> {}
         unsafe impl SclPin<I2C2> for gpiof::PF1<AF4> {}
         #[cfg(any(feature = "gpio-f303", feature = "gpio-f303e", feature = "gpio-f373"))]
@@ -86,17 +67,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(
-        feature = "stm32f301",
-        feature = "stm32f302x6",
-        feature = "stm32f302x8",
-        feature = "stm32f302xd",
-        feature = "stm32f302xe",
-        feature = "stm32f303xd",
-        feature = "stm32f303xe",
-        feature = "stm32f318",
-        feature = "stm32f398",
-    ))] {
+    if #[cfg(any(feature = "gpio-f302", feature = "gpio-f303e"))] {
         unsafe impl SclPin<I2C3> for gpioa::PA8<AF3> {}
         unsafe impl SdaPin<I2C3> for gpiob::PB5<AF8> {}
         unsafe impl SdaPin<I2C3> for gpioc::PC9<AF3> {}
@@ -479,34 +450,11 @@ macro_rules! i2c {
     };
 }
 
-#[cfg(any(
-    feature = "stm32f303x6",
-    feature = "stm32f303x8",
-    feature = "stm32f334",
-    feature = "stm32f328",
-))]
+#[cfg(feature = "gpio-f333")]
 i2c!([1]);
 
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f358",
-    feature = "stm32f373",
-    feature = "stm32f378",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f373"))]
 i2c!([1, 2]);
 
-#[cfg(any(
-    feature = "stm32f301",
-    feature = "stm32f302x6",
-    feature = "stm32f302x8",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f398",
-))]
+#[cfg(any(feature = "gpio-f302", feature = "gpio-f303e"))]
 i2c!([1, 2, 3]);

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -82,7 +82,7 @@ macro_rules! busy_wait {
     };
 }
 
-macro_rules! hal {
+macro_rules! i2c {
     ($($I2CX:ident: ($i2cX:ident, $i2cXen:ident, $i2cXrst:ident, $i2cXsw:ident),)+) => {
         $(
             impl<SCL, SDA> I2c<$I2CX, (SCL, SDA)> {
@@ -417,7 +417,15 @@ macro_rules! hal {
                 }
             }
         )+
-    }
+    };
+
+    ([ $($X:literal),+ ]) => {
+        paste::paste! {
+            i2c!(
+                $([<I2C $X>]: ([<i2c $X>], [<i2c $X en>], [<i2c $X rst>], [<i2c $X sw>]),)+
+            );
+        }
+    };
 }
 
 #[cfg(any(
@@ -431,12 +439,7 @@ macro_rules! hal {
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-hal! {
-    I2C1: (i2c1, i2c1en, i2c1rst, i2c1sw),
-    I2C2: (i2c2, i2c2en, i2c2rst, i2c2sw),
-}
+i2c!([1, 2]);
 
 #[cfg(feature = "stm32f334")]
-hal! {
-    I2C1: (i2c1, i2c1en, i2c1rst, i2c1sw),
-}
+i2c!([1]);


### PR DESCRIPTION
* Fix I2C clock
  STM32F3 I2C peripherals are clocked by HSI or sysclk, not pclk1

* Support I2C3
  I2C3 is available on f301, f318, f302x6/8/d/e, f303xd/e and f398
  Also remove I2C2 support on f303x6/8 and f328

* Move I2C implementation out of macro
  The big `i2c!` macro makes code less readable and confuses rustfmt, clippy, etc.
  Inspired by f7xx-hal