### PR TITLE
Seal "private" traits 🦭

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.50.0
+          toolchain: 1.51.0
           target: thumbv7em-none-eabihf
           override: true
           profile: minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 
-- The MSVR was bumped to 1.50 ([#220])
+- The MSVR was bumped to 1.51 ([#169])
 - Replace custom time based units with types defined in the [embedded-time][]
   crate ([#192])
 - The `rcc` public API now expects time based units in `Megahertz`.
@@ -333,6 +333,7 @@ let clocks = rcc
 [#184]: https://github.com/stm32-rs/stm32f3xx-hal/pull/184
 [#172]: https://github.com/stm32-rs/stm32f3xx-hal/pull/172
 [#170]: https://github.com/stm32-rs/stm32f3xx-hal/pull/170
+[#169]: https://github.com/stm32-rs/stm32f3xx-hal/pull/169
 [#164]: https://github.com/stm32-rs/stm32f3xx-hal/pull/164
 [#156]: https://github.com/stm32-rs/stm32f3xx-hal/pull/156
 [#154]: https://github.com/stm32-rs/stm32f3xx-hal/pull/154

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ paste = "1"
 rtcc = "0.2"
 stm32f3 = "0.13"
 typenum = "1"
+sealed = "0.2.1"
 
 [dependencies.embedded-hal-can]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ See the [examples folder](examples) for more example programs.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.50.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.51.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 <!-- This should not prevent anyone to use newer features. -->
-<!-- As soon as the MSVR does not compile anymore, just bump it. -->
+<!-- As soon as the MSRV does not compile anymore, just bump it. -->
 
-<!-- Don't forget to also adjust the MSVR version in `.github/workflows/ci.yml` -->
+<!-- Don't forget to also adjust the MSRV version in `.github/workflows/ci.yml` -->
 
 ## License
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -16,6 +16,7 @@ use core::{
 };
 
 pub use embedded_dma::{ReadBuffer, WriteBuffer};
+use sealed::sealed;
 
 use crate::{
     pac::{self, dma1::ch::cr},
@@ -549,14 +550,18 @@ dma!( 2: { 1,2,3,4,5 } );
 ///
 /// `C` must be the correct DMA channel for the peripheral implementing
 /// this trait.
-pub unsafe trait OnChannel<C: Channel>: Target {}
+#[sealed]
+pub trait OnChannel<C: Channel>: Target {}
 
 macro_rules! on_channel {
     (
         $dma:ident,
         $( $target:ty => $C:ident, )+
     ) => {
-        $( unsafe impl OnChannel<$dma::$C> for $target {} )+
+        $(
+            #[sealed]
+            impl OnChannel<$dma::$C> for $target {}
+        )+
     };
 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -9,17 +9,18 @@
 // To learn about most of the ideas implemented here, check out the DMA section
 // of the Embedonomicon: https://docs.rust-embedded.org/embedonomicon/dma.html
 
+use core::{
+    convert::TryFrom,
+    mem,
+    sync::atomic::{self, Ordering},
+};
+
 pub use embedded_dma::{ReadBuffer, WriteBuffer};
 
 use crate::{
     pac::{self, dma1::ch::cr},
     rcc::AHB,
     serial,
-};
-use core::{
-    convert::TryFrom,
-    mem,
-    sync::atomic::{self, Ordering},
 };
 
 /// Extension trait to split a DMA peripheral into independent channels

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -6,6 +6,8 @@
 
 use core::{convert::TryFrom, ops::Deref};
 
+use cfg_if::cfg_if;
+
 use crate::{
     gpio::{gpioa, gpiob, OpenDrain, AF4},
     hal::blocking::i2c::{Read, Write, WriteRead},
@@ -22,8 +24,6 @@ use crate::{
     gpio::{gpioc, AF3, AF8},
     pac::I2C3,
 };
-
-use cfg_if::cfg_if;
 
 /// I2C error
 #[derive(Debug)]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -7,6 +7,7 @@
 use core::{convert::TryFrom, ops::Deref};
 
 use cfg_if::cfg_if;
+use sealed::sealed;
 
 use crate::{
     gpio::{gpioa, gpiob, OpenDrain, AF4},
@@ -43,38 +44,54 @@ pub enum Error {
     // Alert, // SMBUS mode only
 }
 
-// FIXME these should be "closed" traits
-/// SCL pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait SclPin<I2C> {}
+/// SCL pin
+#[sealed]
+pub trait SclPin<I2C> {}
 
-/// SDA pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait SdaPin<I2C> {}
+/// SDA pin
+#[sealed]
+pub trait SdaPin<I2C> {}
 
-unsafe impl SclPin<I2C1> for gpioa::PA15<AF4<OpenDrain>> {}
-unsafe impl SclPin<I2C1> for gpiob::PB6<AF4<OpenDrain>> {}
-unsafe impl SclPin<I2C1> for gpiob::PB8<AF4<OpenDrain>> {}
-unsafe impl SdaPin<I2C1> for gpioa::PA14<AF4<OpenDrain>> {}
-unsafe impl SdaPin<I2C1> for gpiob::PB7<AF4<OpenDrain>> {}
-unsafe impl SdaPin<I2C1> for gpiob::PB9<AF4<OpenDrain>> {}
+#[sealed]
+impl SclPin<I2C1> for gpioa::PA15<AF4<OpenDrain>> {}
+#[sealed]
+impl SclPin<I2C1> for gpiob::PB6<AF4<OpenDrain>> {}
+#[sealed]
+impl SclPin<I2C1> for gpiob::PB8<AF4<OpenDrain>> {}
+#[sealed]
+impl SdaPin<I2C1> for gpioa::PA14<AF4<OpenDrain>> {}
+#[sealed]
+impl SdaPin<I2C1> for gpiob::PB7<AF4<OpenDrain>> {}
+#[sealed]
+impl SdaPin<I2C1> for gpiob::PB9<AF4<OpenDrain>> {}
 
 cfg_if! {
     if #[cfg(not(feature = "gpio-f333"))] {
-        unsafe impl SclPin<I2C2> for gpioa::PA9<AF4<OpenDrain>> {}
-        unsafe impl SclPin<I2C2> for gpiof::PF1<AF4<OpenDrain>> {}
+        #[sealed]
+        impl SclPin<I2C2> for gpioa::PA9<AF4<OpenDrain>> {}
+        #[sealed]
+        impl SclPin<I2C2> for gpiof::PF1<AF4<OpenDrain>> {}
         #[cfg(any(feature = "gpio-f303", feature = "gpio-f303e", feature = "gpio-f373"))]
-        unsafe impl SclPin<I2C2> for gpiof::PF6<AF4<OpenDrain>> {}
-        unsafe impl SdaPin<I2C2> for gpioa::PA10<AF4<OpenDrain>> {}
-        unsafe impl SdaPin<I2C2> for gpiof::PF0<AF4<OpenDrain>> {}
+        #[sealed]
+        impl SclPin<I2C2> for gpiof::PF6<AF4<OpenDrain>> {}
+        #[sealed]
+        impl SdaPin<I2C2> for gpioa::PA10<AF4<OpenDrain>> {}
+        #[sealed]
+        impl SdaPin<I2C2> for gpiof::PF0<AF4<OpenDrain>> {}
         #[cfg(feature = "gpio-f373")]
-        unsafe impl SdaPin<I2C2> for gpiof::PF7<AF4<OpenDrain>> {}
+        #[sealed]
+        impl SdaPin<I2C2> for gpiof::PF7<AF4<OpenDrain>> {}
     }
 }
 
 cfg_if! {
     if #[cfg(any(feature = "gpio-f302", feature = "gpio-f303e"))] {
-        unsafe impl SclPin<I2C3> for gpioa::PA8<AF3<OpenDrain>> {}
-        unsafe impl SdaPin<I2C3> for gpiob::PB5<AF8<OpenDrain>> {}
-        unsafe impl SdaPin<I2C3> for gpioc::PC9<AF3<OpenDrain>> {}
+        #[sealed]
+        impl SclPin<I2C3> for gpioa::PA8<AF3<OpenDrain>> {}
+        #[sealed]
+        impl SdaPin<I2C3> for gpiob::PB5<AF8<OpenDrain>> {}
+        #[sealed]
+        impl SdaPin<I2C3> for gpioc::PC9<AF3<OpenDrain>> {}
     }
 }
 
@@ -426,8 +443,9 @@ where
     }
 }
 
-/// I2C instance -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait Instance: Deref<Target = RegisterBlock> {
+/// I2C instance
+#[sealed]
+pub trait Instance: Deref<Target = RegisterBlock> {
     #[doc(hidden)]
     fn enable_clock(apb1: &mut APB1);
     #[doc(hidden)]
@@ -437,7 +455,8 @@ pub unsafe trait Instance: Deref<Target = RegisterBlock> {
 macro_rules! i2c {
     ($($I2CX:ident: ($i2cXen:ident, $i2cXrst:ident, $i2cXsw:ident),)+) => {
         $(
-            unsafe impl Instance for $I2CX {
+            #[sealed]
+            impl Instance for $I2CX {
                 fn enable_clock(apb1: &mut APB1) {
                     apb1.enr().modify(|_, w| w.$i2cXen().enabled());
                     apb1.rstr().modify(|_, w| w.$i2cXrst().reset());

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -3,6 +3,7 @@
 use core::{convert::Infallible, marker::PhantomData, ptr};
 
 use cfg_if::cfg_if;
+use sealed::sealed;
 
 use crate::{
     gpio::{gpioa, gpiob, gpioc, AF7},
@@ -41,51 +42,75 @@ pub enum Error {
     Parity,
 }
 
-// FIXME these should be "closed" traits
-/// TX pin - DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait TxPin<USART> {}
+/// TX pin
+#[sealed]
+pub trait TxPin<USART> {}
 
-/// RX pin - DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait RxPin<USART> {}
+/// RX pin
+#[sealed]
+pub trait RxPin<USART> {}
 
-unsafe impl<Otype> TxPin<USART1> for gpioa::PA9<AF7<Otype>> {}
-unsafe impl<Otype> TxPin<USART1> for gpiob::PB6<AF7<Otype>> {}
-unsafe impl<Otype> TxPin<USART1> for gpioc::PC4<AF7<Otype>> {}
-unsafe impl<Otype> RxPin<USART1> for gpioa::PA10<AF7<Otype>> {}
-unsafe impl<Otype> RxPin<USART1> for gpiob::PB7<AF7<Otype>> {}
-unsafe impl<Otype> RxPin<USART1> for gpioc::PC5<AF7<Otype>> {}
+#[sealed]
+impl<Otype> TxPin<USART1> for gpioa::PA9<AF7<Otype>> {}
+#[sealed]
+impl<Otype> TxPin<USART1> for gpiob::PB6<AF7<Otype>> {}
+#[sealed]
+impl<Otype> TxPin<USART1> for gpioc::PC4<AF7<Otype>> {}
+#[sealed]
+impl<Otype> RxPin<USART1> for gpioa::PA10<AF7<Otype>> {}
+#[sealed]
+impl<Otype> RxPin<USART1> for gpiob::PB7<AF7<Otype>> {}
+#[sealed]
+impl<Otype> RxPin<USART1> for gpioc::PC5<AF7<Otype>> {}
 
-unsafe impl<Otype> TxPin<USART2> for gpioa::PA2<AF7<Otype>> {}
-unsafe impl<Otype> TxPin<USART2> for gpiob::PB3<AF7<Otype>> {}
-unsafe impl<Otype> RxPin<USART2> for gpioa::PA3<AF7<Otype>> {}
-unsafe impl<Otype> RxPin<USART2> for gpiob::PB4<AF7<Otype>> {}
+#[sealed]
+impl<Otype> TxPin<USART2> for gpioa::PA2<AF7<Otype>> {}
+#[sealed]
+impl<Otype> TxPin<USART2> for gpiob::PB3<AF7<Otype>> {}
+#[sealed]
+impl<Otype> RxPin<USART2> for gpioa::PA3<AF7<Otype>> {}
+#[sealed]
+impl<Otype> RxPin<USART2> for gpiob::PB4<AF7<Otype>> {}
 
-unsafe impl<Otype> TxPin<USART3> for gpiob::PB10<AF7<Otype>> {}
-unsafe impl<Otype> TxPin<USART3> for gpioc::PC10<AF7<Otype>> {}
-unsafe impl<Otype> RxPin<USART3> for gpioc::PC11<AF7<Otype>> {}
+#[sealed]
+impl<Otype> TxPin<USART3> for gpiob::PB10<AF7<Otype>> {}
+#[sealed]
+impl<Otype> TxPin<USART3> for gpioc::PC10<AF7<Otype>> {}
+#[sealed]
+impl<Otype> RxPin<USART3> for gpioc::PC11<AF7<Otype>> {}
 
 cfg_if! {
     if #[cfg(any(feature = "gpio-f303", feature = "gpio-f303e", feature = "gpio-f373"))] {
         use crate::gpio::{gpiod, gpioe};
 
-        unsafe impl<Otype> TxPin<USART1> for gpioe::PE0<AF7<Otype>> {}
-        unsafe impl<Otype> RxPin<USART1> for gpioe::PE1<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> TxPin<USART1> for gpioe::PE0<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> RxPin<USART1> for gpioe::PE1<AF7<Otype>> {}
 
-        unsafe impl<Otype> TxPin<USART2> for gpiod::PD5<AF7<Otype>> {}
-        unsafe impl<Otype> RxPin<USART2> for gpiod::PD6<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> TxPin<USART2> for gpiod::PD5<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> RxPin<USART2> for gpiod::PD6<AF7<Otype>> {}
 
-        unsafe impl<Otype> TxPin<USART3> for gpiod::PD8<AF7<Otype>> {}
-        unsafe impl<Otype> RxPin<USART3> for gpiod::PD9<AF7<Otype>> {}
-        unsafe impl<Otype> RxPin<USART3> for gpioe::PE15<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> TxPin<USART3> for gpiod::PD8<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> RxPin<USART3> for gpiod::PD9<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> RxPin<USART3> for gpioe::PE15<AF7<Otype>> {}
     }
 }
 
 cfg_if! {
     if #[cfg(not(feature = "gpio-f373"))] {
-        unsafe impl<Otype> TxPin<USART2> for gpioa::PA14<AF7<Otype>> {}
-        unsafe impl<Otype> RxPin<USART2> for gpioa::PA15<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> TxPin<USART2> for gpioa::PA14<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> RxPin<USART2> for gpioa::PA15<AF7<Otype>> {}
 
-        unsafe impl<Otype> RxPin<USART3> for gpiob::PB11<AF7<Otype>> {}
+        #[sealed]
+        impl<Otype> RxPin<USART3> for gpiob::PB11<AF7<Otype>> {}
     }
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -2,6 +2,8 @@
 
 use core::{convert::Infallible, marker::PhantomData, ptr};
 
+use cfg_if::cfg_if;
+
 use crate::{
     gpio::{gpioa, gpiob, gpioc, AF7},
     hal::{blocking, serial},
@@ -9,8 +11,6 @@ use crate::{
     rcc::{Clocks, APB1, APB2},
     time::rate::*,
 };
-
-use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(any(feature = "stm32f302", feature = "stm32f303"))] {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -4,6 +4,7 @@
 //!
 //! [examples/spi.rs]: https://github.com/stm32-rs/stm32f3xx-hal/blob/v0.6.0/examples/spi.rs
 
+use core::marker::PhantomData;
 use core::ptr;
 
 use crate::hal::spi::FullDuplex;
@@ -132,7 +133,6 @@ use crate::rcc::APB1;
 ))]
 use crate::rcc::APB2;
 use crate::time::rate::*;
-use core::marker::PhantomData;
 
 /// SPI error
 #[derive(Debug)]

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -7,6 +7,8 @@
 use core::marker::PhantomData;
 use core::ptr;
 
+use sealed::sealed;
+
 use crate::hal::spi::FullDuplex;
 pub use crate::hal::spi::{Mode, Phase, Polarity};
 use crate::pac::{
@@ -146,19 +148,23 @@ pub enum Error {
     Crc,
 }
 
-// FIXME these should be "closed" traits
-/// SCK pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait SckPin<SPI> {}
+/// SCK pin
+#[sealed]
+pub trait SckPin<SPI> {}
 
-/// MISO pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait MisoPin<SPI> {}
+/// MISO pin
+#[sealed]
+pub trait MisoPin<SPI> {}
 
-/// MOSI pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait MosiPin<SPI> {}
+/// MOSI pin
+#[sealed]
+pub trait MosiPin<SPI> {}
 
-unsafe impl SckPin<SPI1> for PA5<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI1> for PA5<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI1> for PA12<AF6<PushPull>> {}
+#[sealed]
+impl SckPin<SPI1> for PA12<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -172,16 +178,21 @@ unsafe impl SckPin<SPI1> for PA12<AF6<PushPull>> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI1> for PB3<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI1> for PB3<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI1> for PC7<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI1> for PC7<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PA8<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PA8<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PB8<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PB8<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PB10<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PB10<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f301",
     feature = "stm32f302",
@@ -191,11 +202,14 @@ unsafe impl SckPin<SPI2> for PB10<AF5<PushPull>> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl SckPin<SPI2> for PB13<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PB13<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PD7<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PD7<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PD8<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PD8<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -206,7 +220,8 @@ unsafe impl SckPin<SPI2> for PD8<AF5<PushPull>> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF1<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PF1<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -219,7 +234,8 @@ unsafe impl SckPin<SPI2> for PF1<AF5<PushPull>> {}
     feature = "stm32f358",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF9<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PF9<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -232,10 +248,12 @@ unsafe impl SckPin<SPI2> for PF9<AF5<PushPull>> {}
     feature = "stm32f358",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF10<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI2> for PF10<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI3> for PA1<AF6<PushPull>> {}
+#[sealed]
+impl SckPin<SPI3> for PA1<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xd",
@@ -245,8 +263,10 @@ unsafe impl SckPin<SPI3> for PA1<AF6<PushPull>> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI3> for PB3<AF6<PushPull>> {}
-unsafe impl SckPin<SPI3> for PC10<AF6<PushPull>> {}
+#[sealed]
+impl SckPin<SPI3> for PB3<AF6<PushPull>> {}
+#[sealed]
+impl SckPin<SPI3> for PC10<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -255,7 +275,8 @@ unsafe impl SckPin<SPI3> for PC10<AF6<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI4> for PE2<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI4> for PE2<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -263,11 +284,14 @@ unsafe impl SckPin<SPI4> for PE2<AF5<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI4> for PE12<AF5<PushPull>> {}
+#[sealed]
+impl SckPin<SPI4> for PE12<AF5<PushPull>> {}
 
-unsafe impl MisoPin<SPI1> for PA6<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI1> for PA6<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI1> for PA13<AF6<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI1> for PA13<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -281,12 +305,15 @@ unsafe impl MisoPin<SPI1> for PA13<AF6<PushPull>> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI1> for PB4<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI1> for PB4<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI1> for PC8<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI1> for PC8<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PA9<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI2> for PA9<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -297,15 +324,20 @@ unsafe impl MisoPin<SPI2> for PA9<AF5<PushPull>> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI2> for PA10<AF5<PushPull>> {}
-unsafe impl MisoPin<SPI2> for PB14<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI2> for PA10<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI2> for PB14<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PC2<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI2> for PC2<AF5<PushPull>> {}
+#[sealed]
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PD3<AF5<PushPull>> {}
+impl MisoPin<SPI2> for PD3<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI3> for PA2<AF6<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI3> for PA2<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xd",
@@ -315,8 +347,10 @@ unsafe impl MisoPin<SPI3> for PA2<AF6<PushPull>> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI3> for PB4<AF6<PushPull>> {}
-unsafe impl MisoPin<SPI3> for PC11<AF6<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI3> for PB4<AF6<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI3> for PC11<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -325,7 +359,8 @@ unsafe impl MisoPin<SPI3> for PC11<AF6<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI4> for PE5<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI4> for PE5<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -333,19 +368,26 @@ unsafe impl MisoPin<SPI4> for PE5<AF5<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI4> for PE13<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI4> for PE13<AF5<PushPull>> {}
 
-unsafe impl MosiPin<SPI1> for PA7<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI1> for PA7<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PB0<AF5<PushPull>> {}
-unsafe impl MosiPin<SPI1> for PB5<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI1> for PB0<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI1> for PB5<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PC9<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI1> for PC9<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PF6<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI1> for PF6<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI2> for PA10<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI2> for PA10<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -356,17 +398,24 @@ unsafe impl MosiPin<SPI2> for PA10<AF5<PushPull>> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI2> for PA11<AF5<PushPull>> {}
-unsafe impl MosiPin<SPI2> for PB15<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI2> for PA11<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI2> for PB15<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PC3<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI2> for PC3<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PD4<AF5<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI2> for PD4<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI3> for PA3<AF6<PushPull>> {}
-unsafe impl MosiPin<SPI3> for PB5<AF6<PushPull>> {}
-unsafe impl MosiPin<SPI3> for PC12<AF6<PushPull>> {}
+#[sealed]
+impl MisoPin<SPI3> for PA3<AF6<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI3> for PB5<AF6<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI3> for PC12<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -375,7 +424,8 @@ unsafe impl MosiPin<SPI3> for PC12<AF6<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI4> for PE6<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI4> for PE6<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -383,7 +433,8 @@ unsafe impl MosiPin<SPI4> for PE6<AF5<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI4> for PE14<AF5<PushPull>> {}
+#[sealed]
+impl MosiPin<SPI4> for PE14<AF5<PushPull>> {}
 
 /// Configuration trait for the Word Size
 /// used by the SPI peripheral


### PR DESCRIPTION
Applying the "[Sealed Traits](https://rust-lang.github.io/api-guidelines/future-proofing.html)" pattern 
to make the mentioned trait really private. 

This reduces the amount of unsafe calls, which in this case are not related to any memory safety, 
and resolves the mentioned `FIXME`s in the code. 

I'm not happy about the code-dublication though. Especially in src/spi.rs there are lots of it. 
And I imagine, it won't be fun to adjust the code, when configuration errors are detected. 

Maybe this should be solved with a macro. But as modules can't be split apart, I've not come up with a good solution, yet. 