### PR TITLE
Small fixes for CAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Added support for more CAN bit rates and modes. ([#186](https://github.com/stm32-rs/stm32f3xx-hal/pull/186)
+
 ## [v0.6.1] - 2020-12-10
 
 ### Changed

--- a/src/can.rs
+++ b/src/can.rs
@@ -578,7 +578,7 @@ impl CanFrame {
     ///
     /// This function will panic if length of `data` is greater than `8`
     pub fn new_data(id: CanId, data: &[u8]) -> CanFrame {
-        crate::assert!((0..8).contains(&data.len()));
+        crate::assert!((0..=8).contains(&data.len()));
 
         let mut frame = Self {
             id,

--- a/src/can.rs
+++ b/src/can.rs
@@ -30,38 +30,44 @@ const MAX_EXTENDED_ID: u32 = 0x1FFF_FFFF;
 ///
 /// Use `CanOpts::default()` to get 250kbps at 32mhz system clock
 pub struct CanOpts {
-    pub brp: u16,
-    pub sjw: u8,
-    pub ts1: u8,
-    pub ts2: u8,
-    pub lbkm: LBKM_A,
+    brp: u16,
+    sjw: u8,
+    ts1: u8,
+    ts2: u8,
+    lbkm: LBKM_A,
 }
 
 impl CanOpts {
+    /// Create new `CanOpts` using the default settings from `CanOpts::default()` to get 250kbps at 32mhz system clock.
     pub fn new() -> CanOpts {
         CanOpts::default()
     }
 
+    /// Set the Baud Rate Prescaler. See  http://www.bittiming.can-wiki.info/#bxCAN for generating the timing parameters for different baud rates and clocks.
     pub fn brp(mut self, brp: u16) -> Self {
         self.brp = brp;
         self
     }
 
+    /// Set the Resynchronisation Jump Width. See  http://www.bittiming.can-wiki.info/#bxCAN for generating the timing parameters for different baud rates and clocks.
     pub fn sjw(mut self, sjw: u8) -> Self {
         self.sjw = sjw;
         self
     }
 
+    /// Set Time Segment One. See  http://www.bittiming.can-wiki.info/#bxCAN for generating the timing parameters for different baud rates and clocks.
     pub fn ts1(mut self, ts1: u8) -> Self {
         self.ts1 = ts1;
         self
     }
 
+    /// Set Time Segment Two. See  http://www.bittiming.can-wiki.info/#bxCAN for generating the timing parameters for different baud rates and clocks.
     pub fn ts2(mut self, ts2: u8) -> Self {
         self.ts2 = ts2;
         self
     }
 
+    /// Enable or disable loopback mode on the CAN device. This is useful for debugging.
     pub fn lbkm(mut self, lbkm: LBKM_A) -> Self {
         self.lbkm = lbkm;
         self
@@ -308,6 +314,7 @@ impl CanFilterData {
 }
 
 impl Can {
+    /// Initialize the CAN peripheral using the options specified by `opts`.
     pub fn new_with_opts(
         can: stm32::CAN,
         rx: gpioa::PA11<AF9>,
@@ -619,7 +626,7 @@ impl CanFrame {
     ///
     /// # Panics
     ///
-    /// This function will panic if `dlc` is not inside the vliad range `0..=8`.
+    /// This function will panic if `dlc` is not inside the valid range `0..=8`.
     pub fn new_remote(id: CanId, dlc: usize) -> CanFrame {
         assert!((0..=8).contains(&dlc));
 
@@ -630,7 +637,13 @@ impl CanFrame {
         }
     }
 
+    /// Length of the frame data
     pub fn len(&self) -> usize {
         self.dlc
+    }
+
+    /// Is this frame empty. This usually indicates a remote frame.
+    pub fn is_empty(&self) -> bool {
+        self.dlc == 0
     }
 }

--- a/src/can.rs
+++ b/src/can.rs
@@ -20,7 +20,7 @@ use crate::stm32;
 use nb::{self, Error};
 
 use core::sync::atomic::{AtomicU8, Ordering};
-use stm32::can::btr::LBKM_A;
+pub use stm32::can::btr::LBKM_A;
 
 const EXID_MASK: u32 = 0b1_1111_1111_1100_0000_0000_0000_0000;
 const MAX_EXTENDED_ID: u32 = 0x1FFF_FFFF;
@@ -360,7 +360,7 @@ impl Can {
             _tx: tx,
         }
     }
-    /// Initialize the CAN Peripheral
+    /// Initialize the CAN Peripheral using default options from `CanOpts::default()`
     pub fn new(
         can: stm32::CAN,
         rx: gpioa::PA11<AF9>,

--- a/src/can.rs
+++ b/src/can.rs
@@ -20,6 +20,7 @@ use crate::stm32;
 use nb::{self, Error};
 
 use core::sync::atomic::{AtomicU8, Ordering};
+use stm32::can::btr::LBKM_A;
 
 const EXID_MASK: u32 = 0b1_1111_1111_1100_0000_0000_0000_0000;
 const MAX_EXTENDED_ID: u32 = 0x1FFF_FFFF;
@@ -33,7 +34,7 @@ pub struct CanOpts {
     pub sjw: u8,
     pub ts1: u8,
     pub ts2: u8,
-    pub lbkm: bool,
+    pub lbkm: LBKM_A,
 }
 
 impl CanOpts {
@@ -61,7 +62,7 @@ impl CanOpts {
         self
     }
 
-    pub fn lbkm(mut self, lbkm: bool) -> Self {
+    pub fn lbkm(mut self, lbkm: LBKM_A) -> Self {
         self.lbkm = lbkm;
         self
     }
@@ -74,7 +75,7 @@ impl Default for CanOpts {
             sjw: 0,
             ts1: 10,
             ts2: 3,
-            lbkm: false,
+            lbkm: LBKM_A::DISABLED,
         }
     }
 }
@@ -338,7 +339,7 @@ impl Can {
                 .ts2()
                 .bits(ts2)
                 .lbkm()
-                .bit(lbkm)
+                .variant(lbkm)
         });
 
         // Leave initialization mode by clearing INRQ and switch to normal mode

--- a/src/can.rs
+++ b/src/can.rs
@@ -37,20 +37,45 @@ pub struct CanOpts {
 }
 
 impl CanOpts {
-    pub fn new(brp: u16, sjw: u8, ts1: u8, ts2: u8, lbkm: bool) -> CanOpts {
-        CanOpts {
-            brp,
-            sjw,
-            ts1,
-            ts2,
-            lbkm,
-        }
+    pub fn new() -> CanOpts {
+        CanOpts::default()
+    }
+
+    pub fn brp(mut self, brp: u16) -> Self {
+        self.brp = brp;
+        self
+    }
+
+    pub fn sjw(mut self, sjw: u8) -> Self {
+        self.sjw = sjw;
+        self
+    }
+
+    pub fn ts1(mut self, ts1: u8) -> Self {
+        self.ts1 = ts1;
+        self
+    }
+
+    pub fn ts2(mut self, ts2: u8) -> Self {
+        self.ts2 = ts2;
+        self
+    }
+
+    pub fn lbkm(mut self, lbkm: bool) -> Self {
+        self.lbkm = lbkm;
+        self
     }
 }
 
 impl Default for CanOpts {
     fn default() -> Self {
-        CanOpts::new(4, 0, 10, 3, false)
+        CanOpts {
+            brp: 4,
+            sjw: 0,
+            ts1: 10,
+            ts2: 3,
+            lbkm: false,
+        }
     }
 }
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -27,7 +27,7 @@ const MAX_EXTENDED_ID: u32 = 0x1FFF_FFFF;
 /// Options the CAN bus. This is primarily used to set bus timings, but also controls options like enabling loopback or silent mode for debugging.
 /// See  http://www.bittiming.can-wiki.info/#bxCAN for generating the timing parameters for different baud rates and clocks.
 ///
-/// Use `CanBitRateOpts::default()` to get 250kbps at 32mhz system clock
+/// Use `CanOpts::default()` to get 250kbps at 32mhz system clock
 pub struct CanOpts {
     pub brp: u16,
     pub sjw: u8,


### PR DESCRIPTION
I know there is an open issue for refactoring the CAN impl (#178) but figured I would patch the existing impl slightly in the meantime.

This fixes an issue where weren't actually transmitting the correct length of data, as well as adding options to allow users to configure the baud rate and enable loopback mode.