### PR TITLE
GPIO refactor (Simplify macro, reduce type states, and support interrupt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.7.0] - 2021-03-10
-
 ### Added
 
-- Replace custom time based units with types defined in the [embedded-time][] crate ([#192])
+- Replace custom time based units with types defined in the [embedded-time][]
+  crate ([#192])
 - Make `Clocks` `ppre1()` and `ppre2()` methods public, to get the current
   Prescaler value. ([#210])
+- Implement `into_xxx` methods for partially erased pins ([#189])
+- Enable better GPIO internal resistor configuration ([#189])
+- Support for GPIO output slew rate configuration ([#189])
+- Support for GPIO interrupts ([#189])
 
-### Breaking changes
+[embedded-time]: https://github.com/FluenTech/embedded-time/
+
+### Changed
+
+- Added support for more CAN bit rates and modes. ([#186])
+- The structure of `gpio.rs` is greatly changed. Generic `Pin` struct is used
+  for every GPIO pin now ([#189])
+
+### Fixed
+
+- Delay based on systick no longer panics ([#203]) for to high values
+  and support longer delays ([#208])
+
+### Breaking Changes
 
 - The `rcc` public API now expects time based units in `Megahertz`.
   If the supplied frequency cannot be converted to `Hertz` the code
@@ -34,21 +50,16 @@ let clocks = rcc
 ```
 
 - Bump dependencies: ([#211])
-  - `stm32f3` dependency to 0.13.0
-  - `nb` to 1.0
+  - `stm32f3` dependency to 0.13
+  - `nb` to 1
   - `cortex-m` to 0.7
   - `stm32-usbd` to 0.6
   - `defmt` to 0.2
 
-[embedded-time]: https://github.com/FluenTech/embedded-time/
-### Changed
-
-- Added support for more CAN bit rates and modes. ([#186])
-
-### Fixed
-
-- Delay based on systick no longer panics ([#203]) for to high values
-  and support longer delays ([#208])
+- `into_afx` methods are splitted into `into_afx_push_pull` and
+  `into_afx_open_drain` ([#189])
+- GPIO internal resistor configuration is no longer encoded into pin typestate
+  in input mode ([#189])
 
 ## [v0.6.1] - 2020-12-10
 
@@ -69,8 +80,7 @@ let clocks = rcc
 - Impls for all SPI pins for all `stm32f302` sub-targets, `stm32f303`
   subtargets, `stm32f3x8` targets, `stm32f334`, and `stm32f373`
   ([#99])
-- SPI4 peripheral for supported
-  devices. ([#99])
+- SPI4 peripheral for supported devices. ([#99])
 - Support for I2C transfer of more than 255 bytes, and 0 byte write ([#154])
 - Support for HSE bypass and CSS ([#156])
 - Impls for missing I2C pin definitions ([#164])
@@ -310,14 +320,11 @@ let clocks = rcc
 [#208]: https://github.com/stm32-rs/stm32f3xx-hal/pull/208
 [#203]: https://github.com/stm32-rs/stm32f3xx-hal/issues/203
 [#192]: https://github.com/stm32-rs/stm32f3xx-hal/pull/192
+[#189]: https://github.com/stm32-rs/stm32f3xx-hal/pull/189
 [#186]: https://github.com/stm32-rs/stm32f3xx-hal/pull/186
 [#184]: https://github.com/stm32-rs/stm32f3xx-hal/pull/184
 [#172]: https://github.com/stm32-rs/stm32f3xx-hal/pull/172
 [#170]: https://github.com/stm32-rs/stm32f3xx-hal/pull/170
-[#164]: https://github.com/stm32-rs/stm32f3xx-hal/pull/164
-[#164]: https://github.com/stm32-rs/stm32f3xx-hal/pull/164
-[#164]: https://github.com/stm32-rs/stm32f3xx-hal/pull/164
-[#164]: https://github.com/stm32-rs/stm32f3xx-hal/pull/164
 [#164]: https://github.com/stm32-rs/stm32f3xx-hal/pull/164
 [#156]: https://github.com/stm32-rs/stm32f3xx-hal/pull/156
 [#154]: https://github.com/stm32-rs/stm32f3xx-hal/pull/154
@@ -333,30 +340,24 @@ let clocks = rcc
 [#101]: https://github.com/stm32-rs/stm32f3xx-hal/pull/101
 [#100]: https://github.com/stm32-rs/stm32f3xx-hal/pull/100
 [#99]: https://github.com/stm32-rs/stm32f3xx-hal/pull/99
-[#99]: https://github.com/stm32-rs/stm32f3xx-hal/pull/99
-[#99]: https://github.com/stm32-rs/stm32f3xx-hal/pull/99
 [#98]: https://github.com/stm32-rs/stm32f3xx-hal/pull/98
 [#97]: https://github.com/stm32-rs/stm32f3xx-hal/pull/97
 [#91]: https://github.com/stm32-rs/stm32f3xx-hal/pull/91
-[#86]: https://github.com/stm32-rs/stm32f3xx-hal/pull/86
 [#86]: https://github.com/stm32-rs/stm32f3xx-hal/pull/86
 [#82]: https://github.com/stm32-rs/stm32f3xx-hal/pull/82
 [#75]: https://github.com/stm32-rs/stm32f3xx-hal/pull/75
 [#72]: https://github.com/stm32-rs/stm32f3xx-hal/pull/72
 [#70]: https://github.com/stm32-rs/stm32f3xx-hal/pull/70
 [#67]: https://github.com/stm32-rs/stm32f3xx-hal/pull/67
-[#67]: https://github.com/stm32-rs/stm32f3xx-hal/pull/67
 [#60]: https://github.com/stm32-rs/stm32f3xx-hal/pull/60
 [#58]: https://github.com/stm32-rs/stm32f3xx-hal/pull/58
 [#56]: https://github.com/stm32-rs/stm32f3xx-hal/pull/56
 [#52]: https://github.com/stm32-rs/stm32f3xx-hal/pull/52
 [#50]: https://github.com/stm32-rs/stm32f3xx-hal/pull/50
-[#50]: https://github.com/stm32-rs/stm32f3xx-hal/pull/50
 [#47]: https://github.com/stm32-rs/stm32f3xx-hal/pull/47
 [#42]: https://github.com/stm32-rs/stm32f3xx-hal/pull/42
 [#39]: https://github.com/stm32-rs/stm32f3xx-hal/pull/39
 [#35]: https://github.com/stm32-rs/stm32f3xx-hal/pull/18
-[#35]: https://github.com/stm32-rs/stm32f3xx-hal/pull/35
 [#34]: https://github.com/stm32-rs/stm32f3xx-hal/pull/34
 [#33]: https://github.com/stm32-rs/stm32f3xx-hal/pull/33
 [#31]: https://github.com/stm32-rs/stm32f3xx-hal/pull/33
@@ -368,7 +369,6 @@ let clocks = rcc
 [#17]: https://github.com/stm32-rs/stm32f3xx-hal/pull/17
 [#16]: https://github.com/stm32-rs/stm32f3xx-hal/pull/16
 [#14]: https://github.com/stm32-rs/stm32f3xx-hal/pull/14
-[#12]: https://github.com/stm32-rs/stm32f3xx-hal/pull/12
 [#12]: https://github.com/stm32-rs/stm32f3xx-hal/pull/12
 [#11]: https://github.com/stm32-rs/stm32f3xx-hal/pull/11
 [#6]: https://github.com/stm32-rs/stm32f3xx-hal/pull/6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Replace custom time based units with types defined in the [embedded-time][]
-  crate ([#192])
 - Make `Clocks` `ppre1()` and `ppre2()` methods public, to get the current
   Prescaler value. ([#210])
 - Implement `into_xxx` methods for partially erased pins ([#189])
 - Enable better GPIO internal resistor configuration ([#189])
 - Support for GPIO output slew rate configuration ([#189])
 - Support for GPIO interrupts ([#189])
-
-[embedded-time]: https://github.com/FluenTech/embedded-time/
 
 ### Changed
 
@@ -33,10 +29,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 
+- Replace custom time based units with types defined in the [embedded-time][]
+  crate ([#192])
 - The `rcc` public API now expects time based units in `Megahertz`.
   If the supplied frequency cannot be converted to `Hertz` the code
   will `panic`. This will occur if the supplied `Megahertz` frequency
-  cannot fit into `u32::MAX` when converting to `Hertz`
+  cannot fit into `u32::MAX` when converting to `Hertz` ([#192])
 
 ```rust
 // The supplied frequencies must be in `MHz`.
@@ -55,9 +53,10 @@ let clocks = rcc
   - `cortex-m` to 0.7
   - `stm32-usbd` to 0.6
   - `defmt` to 0.2
-
 - `into_afx` methods are splitted into `into_afx_push_pull` and
   `into_afx_open_drain` ([#189])
+- GPIO output mode (`PushPull` or `OpenDrain`) is encoded into pin typestate
+  in alternate function mode ([#189])
 - GPIO internal resistor configuration is no longer encoded into pin typestate
   in input mode ([#189])
 
@@ -95,9 +94,6 @@ let clocks = rcc
     The support of this feature is subject to change as the development
     of [defmt][] is advancing.
 
-[defmt]: https://github.com/knurling-rs/defmt
-[filter]: https://defmt.ferrous-systems.com/filtering.html
-
 ### Changed
 
 - Introduced auto-generated GPIO mappings based on the STM32CubeMX database
@@ -108,8 +104,6 @@ let clocks = rcc
 - Fixed [#151] not being able to generate 72 MHz HCLK for stm32f303xc devices
   ([#152])
 - Wrong I2C clock source ([#164])
-
-[#151]: https://github.com/stm32-rs/stm32f3xx-hal/issues/151
 
 ### Breaking Changes
 
@@ -314,6 +308,10 @@ let clocks = rcc
 ## [v0.1.0] - 2019-03-31
 
 - Support `stm32f303` device
+
+[embedded-time]: https://github.com/FluenTech/embedded-time/
+[defmt]: https://github.com/knurling-rs/defmt
+[filter]: https://defmt.ferrous-systems.com/filtering.html
 
 [#211]: https://github.com/stm32-rs/stm32f3xx-hal/pull/211
 [#210]: https://github.com/stm32-rs/stm32f3xx-hal/pull/210

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,10 @@ required-features = ["stm32f303xc"]
 name = "gpio_erased"
 required-features = ["rt", "stm32f303xc"]
 
+[[example]]
+name = "gpio_interrupts"
+required-features = ["rt", "stm32f303xc"]
+
 [[test]]
 name = "rcc"
 required-features = ["rt", "defmt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,23 +24,21 @@ features = ["stm32f303xc", "rt", "stm32-usbd", "can"]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
-cfg-if = "1.0"
+cfg-if = "1"
 cortex-m = "0.7"
 cortex-m-rt = "0.6"
 embedded-dma = "0.1"
 embedded-hal = "0.2"
-nb = "1.0"
+embedded-time = "0.10"
+nb = "1"
 paste = "1"
 rtcc = "0.2"
 stm32f3 = "0.13"
-embedded-time = "0.10"
+typenum = "1"
 
 [dependencies.embedded-hal-can]
 version = "0.1.0"
 optional = true
-
-[dependencies.bare-metal]
-version = "1.0"
 
 [dependencies.stm32-usbd]
 version = "0.6"
@@ -95,12 +93,12 @@ stm32f303xb = ["stm32f303", "gpio-f303", "device-selected"]
 stm32f303xc = ["stm32f303", "gpio-f303", "device-selected"]
 stm32f303xd = ["stm32f303", "gpio-f303e", "device-selected"]
 stm32f303xe = ["stm32f303", "gpio-f303e", "device-selected"]
-stm32f373 = ["gpio-f373", "stm32f3/stm32f373", "device-selected"]
-stm32f378 = ["gpio-f373", "stm32f3/stm32f373", "device-selected"]
-stm32f334 = ["gpio-f333", "stm32f3/stm32f3x4", "device-selected"]
 stm32f328 = ["gpio-f333", "stm32f3/stm32f303", "device-selected"]
 stm32f358 = ["gpio-f303", "stm32f3/stm32f303", "device-selected"]
 stm32f398 = ["gpio-f303e", "stm32f3/stm32f303", "device-selected"]
+stm32f373 = ["gpio-f373", "stm32f3/stm32f373", "device-selected"]
+stm32f378 = ["gpio-f373", "stm32f3/stm32f373", "device-selected"]
+stm32f334 = ["gpio-f333", "stm32f3/stm32f3x4", "device-selected"]
 
 defmt-default = ["defmt"]
 defmt-trace = ["defmt"]

--- a/codegen/src/codegen/gpio.rs
+++ b/codegen/src/codegen/gpio.rs
@@ -62,10 +62,7 @@ fn merge_pins_by_port(pins: &[gpio::Pin]) -> Result<Vec<Port>> {
 fn gen_gpio_macro_call(ports: &[Port], feature: &str) -> Result<()> {
     println!("gpio!({{");
 
-    let mut pac_modules: Vec<_> = ports.iter().map(|port| get_port_pac_module(port, feature)).collect();
-    pac_modules.sort();
-    pac_modules.dedup();
-    println!("    pacs: [{}],", pac_modules.join(", "));
+    gen_pac_list(ports, feature);
 
     println!("    ports: [");
     for port in ports {
@@ -75,6 +72,16 @@ fn gen_gpio_macro_call(ports: &[Port], feature: &str) -> Result<()> {
 
     println!("}});");
     Ok(())
+}
+
+fn gen_pac_list(ports: &[Port], feature: &str) {
+    let mut pac_modules: Vec<_> = ports
+        .iter()
+        .map(|port| get_port_pac_module(port, feature))
+        .collect();
+    pac_modules.sort_unstable();
+    pac_modules.dedup();
+    println!("    pacs: [{}],", pac_modules.join(", "));
 }
 
 fn gen_port(port: &Port, feature: &str) -> Result<()> {
@@ -117,10 +124,7 @@ fn gen_pin(pin: &gpio::Pin) -> Result<()> {
 
     println!(
         "                {} => {{ reset: {}, afr: {}, af: {:?} }},",
-        nr,
-        reset_mode,
-        afr,
-        af_numbers,
+        nr, reset_mode, afr, af_numbers,
     );
 
     Ok(())
@@ -142,7 +146,7 @@ fn get_pin_af_numbers(pin: &gpio::Pin) -> Result<Vec<u8>> {
         numbers.push(signal.af()?);
     }
 
-    numbers.sort();
+    numbers.sort_unstable();
     numbers.dedup();
 
     Ok(numbers)

--- a/codegen/src/codegen/gpio.rs
+++ b/codegen/src/codegen/gpio.rs
@@ -86,12 +86,24 @@ fn gen_pac_list(ports: &[Port], feature: &str) {
 
 fn gen_port(port: &Port, feature: &str) -> Result<()> {
     let pac_module = get_port_pac_module(port, feature);
+    let port_index = match port.id {
+        'A' => 0,
+        'B' => 1,
+        'C' => 2,
+        'D' => 3,
+        'E' => 4,
+        'F' => 5,
+        'G' => 6,
+        'H' => 7,
+        _ => unreachable!(),
+    };
 
     println!("        {{");
     println!(
-        "            port: ({}/{}, pac: {}),",
+        "            port: ({}/{}, {}, {}),",
         port.id,
         port.id.to_lowercase(),
+        port_index,
         pac_module,
     );
     println!("            pins: [");

--- a/codegen/src/codegen/gpio.rs
+++ b/codegen/src/codegen/gpio.rs
@@ -134,7 +134,7 @@ fn get_pin_reset_mode(pin: &gpio::Pin) -> Result<&'static str> {
     // Debug pins default to their debug function (AF0), everything else
     // defaults to floating input.
     let mode = match (pin.port()?, pin.number()?) {
-        ('A', 13) | ('A', 14) | ('A', 15) | ('B', 3) | ('B', 4) => "AF0",
+        ('A', 13) | ('A', 14) | ('A', 15) | ('B', 3) | ('B', 4) => "AF0<PushPull>",
         _ => "Input<Floating>",
     };
     Ok(mode)

--- a/codegen/src/codegen/gpio.rs
+++ b/codegen/src/codegen/gpio.rs
@@ -132,10 +132,10 @@ fn gen_pin(pin: &gpio::Pin) -> Result<()> {
 
 fn get_pin_reset_mode(pin: &gpio::Pin) -> Result<&'static str> {
     // Debug pins default to their debug function (AF0), everything else
-    // defaults to floating input.
+    // defaults to input.
     let mode = match (pin.port()?, pin.number()?) {
         ('A', 13) | ('A', 14) | ('A', 15) | ('B', 3) | ('B', 4) => "AF0<PushPull>",
-        _ => "Input<Floating>",
+        _ => "Input",
     };
     Ok(mode)
 }

--- a/examples/gpio_erased.rs
+++ b/examples/gpio_erased.rs
@@ -9,7 +9,7 @@ use cortex_m::asm;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::hprintln;
 
-use hal::gpio::{self, Floating, Input};
+use hal::gpio::{self, Input};
 use hal::pac;
 use hal::prelude::*;
 use stm32f3xx_hal as hal;
@@ -23,7 +23,7 @@ fn main() -> ! {
     let mut gpioc = dp.GPIOC.split(&mut rcc.ahb);
     let mut gpiod = dp.GPIOD.split(&mut rcc.ahb);
 
-    let mut pin_array: [gpio::PXx<Input<Floating>>; 4] = [
+    let mut pin_array: [gpio::PXx<Input>; 4] = [
         gpiob
             .pb11
             .into_floating_input(&mut gpiob.moder, &mut gpiob.pupdr)

--- a/examples/gpio_interrupts.rs
+++ b/examples/gpio_interrupts.rs
@@ -1,0 +1,86 @@
+#![no_main]
+#![no_std]
+
+use panic_semihosting as _;
+
+use stm32f3xx_hal as hal;
+
+use core::cell::RefCell;
+use cortex_m::asm;
+use cortex_m::interrupt::Mutex;
+use cortex_m_rt::entry;
+use hal::gpio::{gpioa, gpioe, Edge, Input, Output, PushPull};
+use hal::interrupt;
+use hal::pac;
+use hal::pac::{Interrupt, NVIC};
+use hal::prelude::*;
+
+type LedPin = gpioe::PE9<Output<PushPull>>;
+static LED: Mutex<RefCell<Option<LedPin>>> = Mutex::new(RefCell::new(None));
+
+type ButtonPin = gpioa::PA0<Input>;
+static BUTTON: Mutex<RefCell<Option<ButtonPin>>> = Mutex::new(RefCell::new(None));
+
+// When the user button is pressed. The north LED with toggle.
+#[entry]
+fn main() -> ! {
+    // Getting access to registers we will need for configuration.
+    let device_peripherals = pac::Peripherals::take().unwrap();
+    let mut rcc = device_peripherals.RCC.constrain();
+    let mut syscfg = device_peripherals.SYSCFG.constrain(&mut rcc.apb2);
+    let mut exti = device_peripherals.EXTI;
+    let mut gpioe = device_peripherals.GPIOE.split(&mut rcc.ahb);
+    let mut gpioa = device_peripherals.GPIOA.split(&mut rcc.ahb);
+
+    let mut led = gpioe
+        .pe9
+        .into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper);
+    // Turn the led on so we know the configuration step occurred.
+    led.toggle().expect("unable to toggle led in configuration");
+
+    // Move the ownership of the led to the global LED
+    cortex_m::interrupt::free(|cs| *LED.borrow(cs).borrow_mut() = Some(led));
+
+    // Configuring the user button to trigger an interrupt when the button is pressed.
+    let mut user_button = gpioa
+        .pa0
+        .into_pull_down_input(&mut gpioa.moder, &mut gpioa.pupdr);
+    user_button.make_interrupt_source(&mut syscfg);
+    user_button.trigger_on_edge(&mut exti, Edge::Rising);
+    user_button.enable_interrupt(&mut exti);
+    // Moving ownership to the global BUTTON so we can clear the interrupt pending bit.
+    cortex_m::interrupt::free(|cs| *BUTTON.borrow(cs).borrow_mut() = Some(user_button));
+
+    unsafe { NVIC::unmask(Interrupt::EXTI0) };
+
+    loop {
+        asm::wfi();
+    }
+}
+
+// Button Pressed interrupt.
+// The exti# maps to the pin number that is being used as an external interrupt.
+// See page 295 of the stm32f303 reference manual for proof:
+// http://www.st.com/resource/en/reference_manual/dm00043574.pdf
+//
+// This may be called more than once per button press from the user since the button may not be debounced.
+#[interrupt]
+fn EXTI0() {
+    cortex_m::interrupt::free(|cs| {
+        // Toggle the LED
+        LED.borrow(cs)
+            .borrow_mut()
+            .as_mut()
+            .unwrap()
+            .toggle()
+            .unwrap();
+
+        // Clear the interrupt pending bit so we don't infinitely call this routine
+        BUTTON
+            .borrow(cs)
+            .borrow_mut()
+            .as_mut()
+            .unwrap()
+            .clear_interrupt_pending_bit();
+    })
+}

--- a/examples/i2c_scanner.rs
+++ b/examples/i2c_scanner.rs
@@ -1,6 +1,5 @@
 //! Example of using I2C.
 //! Scans available I2C devices on bus and print the result.
-//! Appropriate pull-up registers should be installed on I2C bus.
 //! Target board: STM32F3DISCOVERY
 
 #![no_std]
@@ -29,14 +28,19 @@ fn main() -> ! {
     let mut gpiob = dp.GPIOB.split(&mut rcc.ahb);
 
     // Configure I2C1
-    let pins = (
-        gpiob.pb6.into_af4(&mut gpiob.moder, &mut gpiob.afrl), // SCL
-        gpiob.pb7.into_af4(&mut gpiob.moder, &mut gpiob.afrl), // SDA
-    );
-
+    let mut scl =
+        gpiob
+            .pb6
+            .into_af4_open_drain(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
+    let mut sda =
+        gpiob
+            .pb7
+            .into_af4_open_drain(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
+    scl.internal_pull_up(&mut gpiob.pupdr, true);
+    sda.internal_pull_up(&mut gpiob.pupdr, true);
     let mut i2c = hal::i2c::I2c::new(
         dp.I2C1,
-        pins,
+        (scl, sda),
         100u32.kHz().try_into().unwrap(),
         clocks,
         &mut rcc.apb1,

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -32,20 +32,40 @@ fn main() -> ! {
 
     // Prep the pins we need in their correct alternate function
     let mut gpioa = dp.GPIOA.split(&mut rcc.ahb);
-    let pa4 = gpioa.pa4.into_af2(&mut gpioa.moder, &mut gpioa.afrl);
-    let pa6 = gpioa.pa6.into_af2(&mut gpioa.moder, &mut gpioa.afrl);
-    let pa7 = gpioa.pa7.into_af2(&mut gpioa.moder, &mut gpioa.afrl);
+    let pa4 = gpioa
+        .pa4
+        .into_af2_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let pa6 = gpioa
+        .pa6
+        .into_af2_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let pa7 = gpioa
+        .pa7
+        .into_af2_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
 
     let mut gpiob = dp.GPIOB.split(&mut rcc.ahb);
-    let pb0 = gpiob.pb0.into_af2(&mut gpiob.moder, &mut gpiob.afrl);
-    let pb1 = gpiob.pb1.into_af2(&mut gpiob.moder, &mut gpiob.afrl);
-    let pb4 = gpiob.pb4.into_af2(&mut gpiob.moder, &mut gpiob.afrl);
-    let pb5 = gpiob.pb5.into_af2(&mut gpiob.moder, &mut gpiob.afrl);
-    let pb8 = gpiob.pb8.into_af1(&mut gpiob.moder, &mut gpiob.afrh);
-    let pb10 = gpiob.pb10.into_af1(&mut gpiob.moder, &mut gpiob.afrh);
+    let pb0 = gpiob
+        .pb0
+        .into_af2_push_pull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
+    let pb1 = gpiob
+        .pb1
+        .into_af2_push_pull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
+    let pb4 = gpiob
+        .pb4
+        .into_af2_push_pull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
+    let pb5 = gpiob
+        .pb5
+        .into_af2_push_pull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
+    let pb8 = gpiob
+        .pb8
+        .into_af1_push_pull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrh);
+    let pb10 = gpiob
+        .pb10
+        .into_af1_push_pull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrh);
 
     let mut gpioc = dp.GPIOC.split(&mut rcc.ahb);
-    let pc10 = gpioc.pc10.into_af4(&mut gpioc.moder, &mut gpioc.afrh);
+    let pc10 = gpioc
+        .pc10
+        .into_af4_push_pull(&mut gpioc.moder, &mut gpioc.otyper, &mut gpioc.afrh);
 
     // TIM3
     //

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -22,8 +22,12 @@ fn main() -> ! {
     let mut gpioa = dp.GPIOA.split(&mut rcc.ahb);
 
     let pins = (
-        gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh),
-        gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh),
+        gpioa
+            .pa9
+            .into_af7_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh),
+        gpioa
+            .pa10
+            .into_af7_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh),
     );
     let serial = Serial::usart1(dp.USART1, pins, 9600.Bd(), clocks, &mut rcc.apb2);
     let (tx, rx) = serial.split();

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -32,9 +32,15 @@ fn main() -> ! {
         .freeze(&mut flash.acr);
 
     // Configure pins for SPI
-    let sck = gpioa.pa5.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-    let miso = gpioa.pa6.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-    let mosi = gpioa.pa7.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
+    let sck = gpioa
+        .pa5
+        .into_af5_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let miso = gpioa
+        .pa6
+        .into_af5_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let mosi = gpioa
+        .pa7
+        .into_af5_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
 
     let spi_mode = Mode {
         polarity: Polarity::IdleLow,

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -53,8 +53,11 @@ fn main() -> ! {
     usb_dp.set_low().ok();
     delay(clocks.sysclk().0 / 100);
 
-    let usb_dm = gpioa.pa11.into_af14(&mut gpioa.moder, &mut gpioa.afrh);
-    let usb_dp = usb_dp.into_af14(&mut gpioa.moder, &mut gpioa.afrh);
+    let usb_dm =
+        gpioa
+            .pa11
+            .into_af14_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    let usb_dp = usb_dp.into_af14_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
 
     let usb = Peripheral {
         usb: dp.USB,

--- a/src/can.rs
+++ b/src/can.rs
@@ -14,7 +14,7 @@
 pub use embedded_hal_can::{self, Filter, Frame, Id, Receiver, Transmitter};
 
 use crate::gpio::gpioa;
-use crate::gpio::AF9;
+use crate::gpio::{PushPull, AF9};
 use crate::rcc::APB1;
 use crate::stm32;
 use nb::{self, Error};
@@ -148,8 +148,8 @@ static FILTER_INDEX: AtomicU8 = AtomicU8::new(0);
 /// Controll Area Network (CAN) Peripheral
 pub struct Can {
     can: stm32::CAN,
-    _rx: gpioa::PA11<AF9>,
-    _tx: gpioa::PA12<AF9>,
+    _rx: gpioa::PA11<AF9<PushPull>>,
+    _tx: gpioa::PA12<AF9<PushPull>>,
 }
 
 /// A CAN FIFO which is used to receive and buffer messages from the CAN
@@ -161,8 +161,8 @@ pub struct CanFifo {
 /// A CAN transmitter which is used to send messages to the CAN network.
 pub struct CanTransmitter {
     _can: stm32::CAN,
-    _rx: gpioa::PA11<AF9>,
-    _tx: gpioa::PA12<AF9>,
+    _rx: gpioa::PA11<AF9<PushPull>>,
+    _tx: gpioa::PA12<AF9<PushPull>>,
 }
 
 // TODO Use wrapper type around interal pac definition
@@ -317,8 +317,8 @@ impl Can {
     /// Initialize the CAN peripheral using the options specified by `opts`.
     pub fn new_with_opts(
         can: stm32::CAN,
-        rx: gpioa::PA11<AF9>,
-        tx: gpioa::PA12<AF9>,
+        rx: gpioa::PA11<AF9<PushPull>>,
+        tx: gpioa::PA12<AF9<PushPull>>,
         apb1: &mut APB1,
         opts: CanOpts,
     ) -> Can {
@@ -363,8 +363,8 @@ impl Can {
     /// Initialize the CAN Peripheral using default options from `CanOpts::default()`
     pub fn new(
         can: stm32::CAN,
-        rx: gpioa::PA11<AF9>,
-        tx: gpioa::PA12<AF9>,
+        rx: gpioa::PA11<AF9<PushPull>>,
+        tx: gpioa::PA12<AF9<PushPull>>,
         apb1: &mut APB1,
     ) -> Self {
         Can::new_with_opts(can, rx, tx, apb1, CanOpts::default())
@@ -396,7 +396,13 @@ impl Can {
     }
 
     /// Release owned peripherals
-    pub fn free(self) -> (stm32::CAN, gpioa::PA11<AF9>, gpioa::PA12<AF9>) {
+    pub fn free(
+        self,
+    ) -> (
+        stm32::CAN,
+        gpioa::PA11<AF9<PushPull>>,
+        gpioa::PA12<AF9<PushPull>>,
+    ) {
         (self.can, self._rx, self._tx)
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -67,6 +67,12 @@ mod private {
         fn open_drain(&mut self, i: u8);
     }
 
+    pub trait Ospeedr {
+        fn low(&mut self, i: u8);
+        fn medium(&mut self, i: u8);
+        fn high(&mut self, i: u8);
+    }
+
     pub trait Pupdr {
         fn floating(&mut self, i: u8);
         fn pull_up(&mut self, i: u8);
@@ -84,7 +90,7 @@ mod private {
     }
 }
 
-use private::{Afr, GpioRegExt, Moder, Otyper, Pupdr};
+use private::{Afr, GpioRegExt, Moder, Ospeedr, Otyper, Pupdr};
 
 /// Marker trait for GPIO ports
 pub trait Gpio: private::Gpio {}
@@ -95,6 +101,8 @@ pub trait GpioStatic: Gpio {
     type MODER: Moder;
     /// Associated OTYPER register
     type OTYPER: Otyper;
+    /// Associated OSPEEDR register
+    type OSPEEDR: Ospeedr;
     /// Associated PUPDR register
     type PUPDR: Pupdr;
 }
@@ -118,8 +126,11 @@ where
 /// Marker trait for readable pin modes
 pub trait Readable {}
 
-/// Marker trait for PullUppable pin modes
-pub trait PullUppable {} // TODO: better naming
+/// Marker trait for slew rate configurable pin modes
+pub trait OutputSpeed {}
+
+/// Marker trait for internal resistor enabled pin modes
+pub trait InternalResistor {}
 
 /// Runtime defined GPIO port (type state)
 pub struct Gpiox {
@@ -146,33 +157,46 @@ impl Index for Ux {
 }
 
 /// Input mode (type state)
-pub struct Input<MODE>(PhantomData<MODE>);
-
-/// Floating input (type state)
-pub struct Floating;
-/// Pulled up input (type state)
-pub struct PullUp;
-/// Pulled down input (type state)
-pub struct PullDown;
-
+pub struct Input;
 /// Output mode (type state)
-pub struct Output<MODE>(PhantomData<MODE>);
+pub struct Output<OTYPE>(PhantomData<OTYPE>);
+/// Alternate function (type state)
+pub struct Alternate<AF, OTYPE>(PhantomData<AF>, PhantomData<OTYPE>);
+/// Analog mode (type state)
+pub struct Analog;
 
 /// Push-pull output (type state)
 pub struct PushPull;
 /// Open-drain output (type state)
 pub struct OpenDrain;
 
-/// Alternate function (type state)
-pub struct Alternate<AF, MODE>(PhantomData<AF>, PhantomData<MODE>);
-
-/// Analog mode (type state)
-pub struct Analog;
-
-impl<MODE> Readable for Input<MODE> {}
+impl Readable for Input {}
 impl Readable for Output<OpenDrain> {}
-impl PullUppable for Output<OpenDrain> {}
-impl<AF> PullUppable for Alternate<AF, OpenDrain> {}
+impl<OTYPE> OutputSpeed for Output<OTYPE> {}
+impl<AF, OTYPE> OutputSpeed for Alternate<AF, OTYPE> {}
+impl InternalResistor for Input {}
+impl<OTYPE> InternalResistor for Output<OTYPE> {}
+impl<AF, OTYPE> InternalResistor for Alternate<AF, OTYPE> {}
+
+/// Slew rate configuration
+pub enum Speed {
+    /// Low speed
+    Low,
+    /// Medium speed
+    Medium,
+    /// High speed
+    High,
+}
+
+/// Internal pull-up and pull-down resistor configuration
+pub enum Resistor {
+    /// Floating
+    Floating,
+    /// Pulled up
+    PullUp,
+    /// Pulled down
+    PullDown,
+}
 
 /// Generic pin
 pub struct Pin<GPIO, INDEX, MODE> {
@@ -244,34 +268,43 @@ where
     GPIO: GpioStatic,
     INDEX: Index,
 {
-    /// Configures the pin to operate as a floating input pin
+    /// Configures the pin to operate as an input pin
+    pub fn into_input(self, moder: &mut GPIO::MODER) -> Pin<GPIO, INDEX, Input> {
+        moder.input(self.index.index());
+        self.into_mode()
+    }
+
+    /// Convenience method to configure the pin to operate as an input pin
+    /// and set the internal resistor floating
     pub fn into_floating_input(
         self,
         moder: &mut GPIO::MODER,
         pupdr: &mut GPIO::PUPDR,
-    ) -> Pin<GPIO, INDEX, Input<Floating>> {
+    ) -> Pin<GPIO, INDEX, Input> {
         moder.input(self.index.index());
         pupdr.floating(self.index.index());
         self.into_mode()
     }
 
-    /// Configures the pin to operate as a pulled up input pin
+    /// Convenience method to configure the pin to operate as an input pin
+    /// and set the internal resistor pull-up
     pub fn into_pull_up_input(
         self,
         moder: &mut GPIO::MODER,
         pupdr: &mut GPIO::PUPDR,
-    ) -> Pin<GPIO, INDEX, Input<PullUp>> {
+    ) -> Pin<GPIO, INDEX, Input> {
         moder.input(self.index.index());
         pupdr.pull_up(self.index.index());
         self.into_mode()
     }
 
-    /// Configures the pin to operate as a pulled down input pin
+    /// Convenience method to configure the pin to operate as an input pin
+    /// and set the internal resistor pull-down
     pub fn into_pull_down_input(
         self,
         moder: &mut GPIO::MODER,
         pupdr: &mut GPIO::PUPDR,
-    ) -> Pin<GPIO, INDEX, Input<PullDown>> {
+    ) -> Pin<GPIO, INDEX, Input> {
         moder.input(self.index.index());
         pupdr.pull_down(self.index.index());
         self.into_mode()
@@ -315,9 +348,34 @@ impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
 where
     GPIO: GpioStatic,
     INDEX: Index,
-    MODE: PullUppable,
+    MODE: OutputSpeed,
 {
-    /// Enables / disables the internal pull up
+    /// Set pin output slew rate
+    pub fn set_speed(&mut self, ospeedr: &mut GPIO::OSPEEDR, speed: Speed) {
+        match speed {
+            Speed::Low => ospeedr.low(self.index.index()),
+            Speed::Medium => ospeedr.medium(self.index.index()),
+            Speed::High => ospeedr.high(self.index.index()),
+        }
+    }
+}
+
+impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
+where
+    GPIO: GpioStatic,
+    INDEX: Index,
+    MODE: InternalResistor,
+{
+    /// Set the internal pull-up and pull-down resistor
+    pub fn set_internal_resistor(&mut self, pupdr: &mut GPIO::PUPDR, resistor: Resistor) {
+        match resistor {
+            Resistor::Floating => pupdr.floating(self.index.index()),
+            Resistor::PullUp => pupdr.pull_up(self.index.index()),
+            Resistor::PullDown => pupdr.pull_down(self.index.index()),
+        }
+    }
+
+    /// Enables / disables the internal pull up (Provided for compatibility with other stm32 HALs)
     pub fn internal_pull_up(&mut self, pupdr: &mut GPIO::PUPDR, on: bool) {
         if on {
             pupdr.pull_up(self.index.index());
@@ -557,6 +615,7 @@ macro_rules! gpio {
         impl GpioStatic for $Gpiox {
             type MODER = $gpiox::MODER;
             type OTYPER = $gpiox::OTYPER;
+            type OSPEEDR = $gpiox::OSPEEDR;
             type PUPDR = $gpiox::PUPDR;
         }
 
@@ -570,11 +629,11 @@ macro_rules! gpio {
                     rcc::AHB,
                 };
 
-                use super::{Afr, $Gpiox, GpioExt, Moder, Otyper, Pin, Pupdr, Ux};
+                use super::{Afr, $Gpiox, GpioExt, Moder, Ospeedr, Otyper, Pin, Pupdr, Ux};
 
                 #[allow(unused_imports)]
                 use super::{
-                    Input, Floating, PullUp, PullDown, Output, PushPull, OpenDrain, Analog,
+                    Input, Output, Analog, PushPull, OpenDrain,
                     IntoAf0, IntoAf1, IntoAf2, IntoAf3, IntoAf4, IntoAf5, IntoAf6, IntoAf7,
                     IntoAf8, IntoAf9, IntoAf10, IntoAf11, IntoAf12, IntoAf13, IntoAf14, IntoAf15,
                     AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10, AF11, AF12, AF13, AF14, AF15,
@@ -593,6 +652,8 @@ macro_rules! gpio {
                     pub afrl: AFRL,
                     /// Opaque MODER register
                     pub moder: MODER,
+                    /// Opaque OSPEEDR register
+                    pub ospeedr: OSPEEDR,
                     /// Opaque OTYPER register
                     pub otyper: OTYPER,
                     /// Opaque PUPDR register
@@ -615,6 +676,7 @@ macro_rules! gpio {
                             afrh: AFRH(()),
                             afrl: AFRL(()),
                             moder: MODER(()),
+                            ospeedr: OSPEEDR(()),
                             otyper: OTYPER(()),
                             pupdr: PUPDR(()),
                             $(
@@ -648,6 +710,18 @@ macro_rules! gpio {
                         fn output { OUTPUT }
                         fn alternate { ALTERNATE }
                         fn analog { ANALOG }
+                    }
+                }
+
+                /// Opaque OSPEEDR register
+                pub struct OSPEEDR(());
+
+                r_trait! {
+                    ($GPIOX, $gpioy::ospeedr::OSPEEDR15_A, 2);
+                    impl Ospeedr for OSPEEDR {
+                        fn low { LOWSPEED }
+                        fn medium { MEDIUMSPEED }
+                        fn high { HIGHSPEED }
                     }
                 }
 
@@ -737,19 +811,19 @@ gpio!({
         {
             port: (A/a, pac: gpioa),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [0, 1, 3, 7, 9, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 15] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
-                4 => { reset: Input<Floating>, afr: L, af: [3, 6, 7, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 3, 6, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 3, 6, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [0, 3, 4, 5, 6, 7, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [2, 3, 4, 5, 6, 7, 9, 10, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 5, 6, 7, 8, 10, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [5, 6, 7, 9, 11, 12, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 5, 6, 7, 8, 9, 11, 15] },
+                0 => { reset: Input, afr: L, af: [1, 3, 7, 15] },
+                1 => { reset: Input, afr: L, af: [0, 1, 3, 7, 9, 15] },
+                2 => { reset: Input, afr: L, af: [1, 3, 7, 8, 9, 15] },
+                3 => { reset: Input, afr: L, af: [1, 3, 7, 9, 15] },
+                4 => { reset: Input, afr: L, af: [3, 6, 7, 15] },
+                5 => { reset: Input, afr: L, af: [1, 3, 15] },
+                6 => { reset: Input, afr: L, af: [1, 3, 6, 15] },
+                7 => { reset: Input, afr: L, af: [1, 3, 6, 15] },
+                8 => { reset: Input, afr: H, af: [0, 3, 4, 5, 6, 7, 15] },
+                9 => { reset: Input, afr: H, af: [2, 3, 4, 5, 6, 7, 9, 10, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 4, 5, 6, 7, 8, 10, 15] },
+                11 => { reset: Input, afr: H, af: [5, 6, 7, 9, 11, 12, 15] },
+                12 => { reset: Input, afr: H, af: [1, 5, 6, 7, 8, 9, 11, 15] },
                 13 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 3, 5, 7, 15] },
                 14 => { reset: AF0<PushPull>, afr: H, af: [0, 3, 4, 6, 7, 15] },
                 15 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 3, 4, 6, 7, 9, 15] },
@@ -758,56 +832,56 @@ gpio!({
         {
             port: (B/b, pac: gpiob),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [3, 6, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [3, 6, 8, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [3, 15] },
+                0 => { reset: Input, afr: L, af: [3, 6, 15] },
+                1 => { reset: Input, afr: L, af: [3, 6, 8, 15] },
+                2 => { reset: Input, afr: L, af: [3, 15] },
                 3 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 3, 6, 7, 15] },
                 4 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 3, 6, 7, 10, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 4, 6, 7, 8, 10, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 3, 4, 7, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 3, 4, 7, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 7, 9, 12, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 4, 6, 7, 8, 9, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [3, 4, 5, 6, 7, 15] },
-                13 => { reset: Input<Floating>, afr: H, af: [3, 5, 6, 7, 15] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 6, 7, 15] },
-                15 => { reset: Input<Floating>, afr: H, af: [0, 1, 2, 4, 5, 15] },
+                5 => { reset: Input, afr: L, af: [1, 4, 6, 7, 8, 10, 15] },
+                6 => { reset: Input, afr: L, af: [1, 3, 4, 7, 15] },
+                7 => { reset: Input, afr: L, af: [1, 3, 4, 7, 15] },
+                8 => { reset: Input, afr: H, af: [1, 3, 4, 7, 9, 12, 15] },
+                9 => { reset: Input, afr: H, af: [1, 4, 6, 7, 8, 9, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 7, 15] },
+                11 => { reset: Input, afr: H, af: [1, 3, 7, 15] },
+                12 => { reset: Input, afr: H, af: [3, 4, 5, 6, 7, 15] },
+                13 => { reset: Input, afr: H, af: [3, 5, 6, 7, 15] },
+                14 => { reset: Input, afr: H, af: [1, 3, 5, 6, 7, 15] },
+                15 => { reset: Input, afr: H, af: [0, 1, 2, 4, 5, 15] },
             ],
         },
         {
             port: (C/c, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 6] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 6, 7] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 6] },
-                8 => { reset: Input<Floating>, afr: H, af: [1] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 3, 5] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 6, 7] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 6, 7] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 6, 7] },
-                13 => { reset: Input<Floating>, afr: H, af: [4] },
-                14 => { reset: Input<Floating>, afr: H, af: [] },
-                15 => { reset: Input<Floating>, afr: H, af: [] },
+                0 => { reset: Input, afr: L, af: [1, 2] },
+                1 => { reset: Input, afr: L, af: [1, 2] },
+                2 => { reset: Input, afr: L, af: [1, 2] },
+                3 => { reset: Input, afr: L, af: [1, 2, 6] },
+                4 => { reset: Input, afr: L, af: [1, 2, 7] },
+                5 => { reset: Input, afr: L, af: [1, 2, 3, 7] },
+                6 => { reset: Input, afr: L, af: [1, 6, 7] },
+                7 => { reset: Input, afr: L, af: [1, 6] },
+                8 => { reset: Input, afr: H, af: [1] },
+                9 => { reset: Input, afr: H, af: [1, 3, 5] },
+                10 => { reset: Input, afr: H, af: [1, 6, 7] },
+                11 => { reset: Input, afr: H, af: [1, 6, 7] },
+                12 => { reset: Input, afr: H, af: [1, 6, 7] },
+                13 => { reset: Input, afr: H, af: [4] },
+                14 => { reset: Input, afr: H, af: [] },
+                15 => { reset: Input, afr: H, af: [] },
             ],
         },
         {
             port: (D/d, pac: gpioc),
             pins: [
-                2 => { reset: Input<Floating>, afr: L, af: [1] },
+                2 => { reset: Input, afr: L, af: [1] },
             ],
         },
         {
             port: (F/f, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [4, 5, 6] },
-                1 => { reset: Input<Floating>, afr: L, af: [4, 5] },
+                0 => { reset: Input, afr: L, af: [4, 5, 6] },
+                1 => { reset: Input, afr: L, af: [4, 5] },
             ],
         },
     ],
@@ -820,19 +894,19 @@ gpio!({
         {
             port: (A/a, pac: gpioa),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 10, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [0, 1, 3, 7, 9, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 15] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
-                4 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 6, 7, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 5, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [0, 3, 4, 5, 6, 7, 8, 10, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [2, 3, 4, 5, 6, 7, 8, 9, 10, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 5, 6, 7, 8, 10, 11, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [5, 6, 7, 8, 9, 10, 11, 12, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 5, 6, 7, 8, 9, 10, 11, 15] },
+                0 => { reset: Input, afr: L, af: [1, 3, 7, 8, 9, 10, 15] },
+                1 => { reset: Input, afr: L, af: [0, 1, 3, 7, 9, 15] },
+                2 => { reset: Input, afr: L, af: [1, 3, 7, 8, 9, 15] },
+                3 => { reset: Input, afr: L, af: [1, 3, 7, 9, 15] },
+                4 => { reset: Input, afr: L, af: [2, 3, 5, 6, 7, 15] },
+                5 => { reset: Input, afr: L, af: [1, 3, 5, 15] },
+                6 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
+                7 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 6, 15] },
+                8 => { reset: Input, afr: H, af: [0, 3, 4, 5, 6, 7, 8, 10, 15] },
+                9 => { reset: Input, afr: H, af: [2, 3, 4, 5, 6, 7, 8, 9, 10, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 4, 5, 6, 7, 8, 10, 11, 15] },
+                11 => { reset: Input, afr: H, af: [5, 6, 7, 8, 9, 10, 11, 12, 15] },
+                12 => { reset: Input, afr: H, af: [1, 5, 6, 7, 8, 9, 10, 11, 15] },
                 13 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 3, 5, 7, 10, 15] },
                 14 => { reset: AF0<PushPull>, afr: H, af: [0, 3, 4, 5, 6, 7, 15] },
                 15 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 2, 3, 4, 5, 6, 7, 9, 15] },
@@ -841,135 +915,135 @@ gpio!({
         {
             port: (B/b, pac: gpiob),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [2, 3, 4, 6, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [2, 3, 4, 6, 8, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [3, 15] },
+                0 => { reset: Input, afr: L, af: [2, 3, 4, 6, 15] },
+                1 => { reset: Input, afr: L, af: [2, 3, 4, 6, 8, 15] },
+                2 => { reset: Input, afr: L, af: [3, 15] },
                 3 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
                 4 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 8, 10, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 7, 10, 12, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 4, 7, 8, 9, 10, 12, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 6, 7, 8, 9, 10, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [3, 4, 5, 6, 7, 15] },
-                13 => { reset: Input<Floating>, afr: H, af: [3, 5, 6, 7, 15] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 6, 7, 15] },
-                15 => { reset: Input<Floating>, afr: H, af: [0, 1, 2, 4, 5, 15] },
+                5 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 8, 10, 15] },
+                6 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                7 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 7, 10, 12, 15] },
+                8 => { reset: Input, afr: H, af: [1, 2, 3, 4, 7, 8, 9, 10, 12, 15] },
+                9 => { reset: Input, afr: H, af: [1, 2, 4, 6, 7, 8, 9, 10, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 7, 15] },
+                11 => { reset: Input, afr: H, af: [1, 3, 7, 15] },
+                12 => { reset: Input, afr: H, af: [3, 4, 5, 6, 7, 15] },
+                13 => { reset: Input, afr: H, af: [3, 5, 6, 7, 15] },
+                14 => { reset: Input, afr: H, af: [1, 3, 5, 6, 7, 15] },
+                15 => { reset: Input, afr: H, af: [0, 1, 2, 4, 5, 15] },
             ],
         },
         {
             port: (C/c, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 3] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 6] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 7] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 4, 5, 6] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
-                13 => { reset: Input<Floating>, afr: H, af: [1, 4] },
-                14 => { reset: Input<Floating>, afr: H, af: [1] },
-                15 => { reset: Input<Floating>, afr: H, af: [1] },
+                0 => { reset: Input, afr: L, af: [1, 2] },
+                1 => { reset: Input, afr: L, af: [1, 2] },
+                2 => { reset: Input, afr: L, af: [1, 2, 3] },
+                3 => { reset: Input, afr: L, af: [1, 2, 6] },
+                4 => { reset: Input, afr: L, af: [1, 2, 7] },
+                5 => { reset: Input, afr: L, af: [1, 2, 3, 7] },
+                6 => { reset: Input, afr: L, af: [1, 2, 4, 6, 7] },
+                7 => { reset: Input, afr: L, af: [1, 2, 4, 6, 7] },
+                8 => { reset: Input, afr: H, af: [1, 2, 4, 7] },
+                9 => { reset: Input, afr: H, af: [1, 2, 3, 4, 5, 6] },
+                10 => { reset: Input, afr: H, af: [1, 4, 5, 6, 7] },
+                11 => { reset: Input, afr: H, af: [1, 4, 5, 6, 7] },
+                12 => { reset: Input, afr: H, af: [1, 4, 5, 6, 7] },
+                13 => { reset: Input, afr: H, af: [1, 4] },
+                14 => { reset: Input, afr: H, af: [1] },
+                15 => { reset: Input, afr: H, af: [1] },
             ],
         },
         {
             port: (D/d, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 7, 12] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 6, 7, 12] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 7, 12] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7, 12] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 7, 12] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 7, 12] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 7, 12] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 7, 12] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 7, 12] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 7, 12] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 7, 12] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 7, 12] },
-                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 12] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 12] },
-                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 6, 12] },
+                0 => { reset: Input, afr: L, af: [1, 7, 12] },
+                1 => { reset: Input, afr: L, af: [1, 4, 6, 7, 12] },
+                2 => { reset: Input, afr: L, af: [1, 2, 4, 5] },
+                3 => { reset: Input, afr: L, af: [1, 2, 7, 12] },
+                4 => { reset: Input, afr: L, af: [1, 2, 7, 12] },
+                5 => { reset: Input, afr: L, af: [1, 7, 12] },
+                6 => { reset: Input, afr: L, af: [1, 2, 7, 12] },
+                7 => { reset: Input, afr: L, af: [1, 2, 7, 12] },
+                8 => { reset: Input, afr: H, af: [1, 7, 12] },
+                9 => { reset: Input, afr: H, af: [1, 7, 12] },
+                10 => { reset: Input, afr: H, af: [1, 7, 12] },
+                11 => { reset: Input, afr: H, af: [1, 7, 12] },
+                12 => { reset: Input, afr: H, af: [1, 2, 3, 7, 12] },
+                13 => { reset: Input, afr: H, af: [1, 2, 3, 12] },
+                14 => { reset: Input, afr: H, af: [1, 2, 3, 12] },
+                15 => { reset: Input, afr: H, af: [1, 2, 3, 6, 12] },
             ],
         },
         {
             port: (E/e, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7, 12] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 6, 7, 12] },
-                2 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
-                3 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
-                4 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
-                5 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
-                6 => { reset: Input<Floating>, afr: L, af: [0, 1, 5, 6, 12] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 2, 5, 12] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 5, 12] },
-                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 5, 12] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 5, 6, 12] },
-                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 7, 12] },
+                0 => { reset: Input, afr: L, af: [1, 2, 4, 6, 7, 12] },
+                1 => { reset: Input, afr: L, af: [1, 4, 6, 7, 12] },
+                2 => { reset: Input, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
+                3 => { reset: Input, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
+                4 => { reset: Input, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
+                5 => { reset: Input, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
+                6 => { reset: Input, afr: L, af: [0, 1, 5, 6, 12] },
+                7 => { reset: Input, afr: L, af: [1, 2, 12] },
+                8 => { reset: Input, afr: H, af: [1, 2, 12] },
+                9 => { reset: Input, afr: H, af: [1, 2, 12] },
+                10 => { reset: Input, afr: H, af: [1, 2, 12] },
+                11 => { reset: Input, afr: H, af: [1, 2, 5, 12] },
+                12 => { reset: Input, afr: H, af: [1, 2, 5, 12] },
+                13 => { reset: Input, afr: H, af: [1, 2, 5, 12] },
+                14 => { reset: Input, afr: H, af: [1, 2, 5, 6, 12] },
+                15 => { reset: Input, afr: H, af: [1, 2, 7, 12] },
             ],
         },
         {
             port: (F/f, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 4, 5, 6] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 5] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 12] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 7, 12] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 5, 12] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 5, 12] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 2] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
-                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
-                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+                0 => { reset: Input, afr: L, af: [1, 4, 5, 6] },
+                1 => { reset: Input, afr: L, af: [1, 4, 5] },
+                2 => { reset: Input, afr: L, af: [1, 2, 12] },
+                3 => { reset: Input, afr: L, af: [1, 2, 12] },
+                4 => { reset: Input, afr: L, af: [1, 2, 3, 12] },
+                5 => { reset: Input, afr: L, af: [1, 2, 12] },
+                6 => { reset: Input, afr: L, af: [1, 2, 4, 7, 12] },
+                7 => { reset: Input, afr: L, af: [1, 2, 12] },
+                8 => { reset: Input, afr: H, af: [1, 2, 12] },
+                9 => { reset: Input, afr: H, af: [1, 2, 3, 5, 12] },
+                10 => { reset: Input, afr: H, af: [1, 2, 3, 5, 12] },
+                11 => { reset: Input, afr: H, af: [1, 2] },
+                12 => { reset: Input, afr: H, af: [1, 2, 12] },
+                13 => { reset: Input, afr: H, af: [1, 2, 12] },
+                14 => { reset: Input, afr: H, af: [1, 2, 12] },
+                15 => { reset: Input, afr: H, af: [1, 2, 12] },
             ],
         },
         {
             port: (G/g, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 12] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 12] },
-                8 => { reset: Input<Floating>, afr: H, af: [1] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 12] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 12] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 12] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 12] },
-                13 => { reset: Input<Floating>, afr: H, af: [1, 12] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 12] },
-                15 => { reset: Input<Floating>, afr: H, af: [1] },
+                0 => { reset: Input, afr: L, af: [1, 2, 12] },
+                1 => { reset: Input, afr: L, af: [1, 2, 12] },
+                2 => { reset: Input, afr: L, af: [1, 2, 12] },
+                3 => { reset: Input, afr: L, af: [1, 2, 12] },
+                4 => { reset: Input, afr: L, af: [1, 2, 12] },
+                5 => { reset: Input, afr: L, af: [1, 2, 12] },
+                6 => { reset: Input, afr: L, af: [1, 12] },
+                7 => { reset: Input, afr: L, af: [1, 12] },
+                8 => { reset: Input, afr: H, af: [1] },
+                9 => { reset: Input, afr: H, af: [1, 12] },
+                10 => { reset: Input, afr: H, af: [1, 12] },
+                11 => { reset: Input, afr: H, af: [1, 12] },
+                12 => { reset: Input, afr: H, af: [1, 12] },
+                13 => { reset: Input, afr: H, af: [1, 12] },
+                14 => { reset: Input, afr: H, af: [1, 12] },
+                15 => { reset: Input, afr: H, af: [1] },
             ],
         },
         {
             port: (H/h, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
-                2 => { reset: Input<Floating>, afr: L, af: [1] },
+                0 => { reset: Input, afr: L, af: [1, 2, 12] },
+                1 => { reset: Input, afr: L, af: [1, 2, 12] },
+                2 => { reset: Input, afr: L, af: [1] },
             ],
         },
     ],
@@ -982,19 +1056,19 @@ gpio!({
         {
             port: (A/a, pac: gpioa),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 10, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [0, 1, 3, 7, 9, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 15] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
-                4 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 6, 7, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 5, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [0, 4, 5, 6, 7, 8, 10, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [3, 4, 5, 6, 7, 8, 9, 10, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 6, 7, 8, 10, 11, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [6, 7, 8, 9, 10, 11, 12, 14, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 6, 7, 8, 9, 10, 11, 14, 15] },
+                0 => { reset: Input, afr: L, af: [1, 3, 7, 8, 9, 10, 15] },
+                1 => { reset: Input, afr: L, af: [0, 1, 3, 7, 9, 15] },
+                2 => { reset: Input, afr: L, af: [1, 3, 7, 8, 9, 15] },
+                3 => { reset: Input, afr: L, af: [1, 3, 7, 9, 15] },
+                4 => { reset: Input, afr: L, af: [2, 3, 5, 6, 7, 15] },
+                5 => { reset: Input, afr: L, af: [1, 3, 5, 15] },
+                6 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
+                7 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
+                8 => { reset: Input, afr: H, af: [0, 4, 5, 6, 7, 8, 10, 15] },
+                9 => { reset: Input, afr: H, af: [3, 4, 5, 6, 7, 8, 9, 10, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 4, 6, 7, 8, 10, 11, 15] },
+                11 => { reset: Input, afr: H, af: [6, 7, 8, 9, 10, 11, 12, 14, 15] },
+                12 => { reset: Input, afr: H, af: [1, 6, 7, 8, 9, 10, 11, 14, 15] },
                 13 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 3, 5, 7, 10, 15] },
                 14 => { reset: AF0<PushPull>, afr: H, af: [0, 3, 4, 5, 6, 7, 15] },
                 15 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 2, 4, 5, 6, 7, 9, 15] },
@@ -1003,97 +1077,97 @@ gpio!({
         {
             port: (B/b, pac: gpiob),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [2, 3, 4, 6, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [2, 3, 4, 6, 8, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [3, 15] },
+                0 => { reset: Input, afr: L, af: [2, 3, 4, 6, 15] },
+                1 => { reset: Input, afr: L, af: [2, 3, 4, 6, 8, 15] },
+                2 => { reset: Input, afr: L, af: [3, 15] },
                 3 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
                 4 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 7, 10, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 4, 8, 9, 10, 12, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 6, 8, 9, 10, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [3, 4, 5, 6, 7, 15] },
-                13 => { reset: Input<Floating>, afr: H, af: [3, 5, 6, 7, 15] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 6, 7, 15] },
-                15 => { reset: Input<Floating>, afr: H, af: [0, 1, 2, 4, 5, 15] },
+                5 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                6 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                7 => { reset: Input, afr: L, af: [1, 2, 3, 4, 5, 7, 10, 15] },
+                8 => { reset: Input, afr: H, af: [1, 2, 3, 4, 8, 9, 10, 12, 15] },
+                9 => { reset: Input, afr: H, af: [1, 2, 4, 6, 8, 9, 10, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 7, 15] },
+                11 => { reset: Input, afr: H, af: [1, 3, 7, 15] },
+                12 => { reset: Input, afr: H, af: [3, 4, 5, 6, 7, 15] },
+                13 => { reset: Input, afr: H, af: [3, 5, 6, 7, 15] },
+                14 => { reset: Input, afr: H, af: [1, 3, 5, 6, 7, 15] },
+                15 => { reset: Input, afr: H, af: [0, 1, 2, 4, 5, 15] },
             ],
         },
         {
             port: (C/c, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1] },
-                1 => { reset: Input<Floating>, afr: L, af: [1] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 3] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 6] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 7] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 7] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 7] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 5, 6] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
-                13 => { reset: Input<Floating>, afr: H, af: [4] },
-                14 => { reset: Input<Floating>, afr: H, af: [] },
-                15 => { reset: Input<Floating>, afr: H, af: [] },
+                0 => { reset: Input, afr: L, af: [1] },
+                1 => { reset: Input, afr: L, af: [1] },
+                2 => { reset: Input, afr: L, af: [1, 3] },
+                3 => { reset: Input, afr: L, af: [1, 6] },
+                4 => { reset: Input, afr: L, af: [1, 7] },
+                5 => { reset: Input, afr: L, af: [1, 3, 7] },
+                6 => { reset: Input, afr: L, af: [1, 2, 4, 6, 7] },
+                7 => { reset: Input, afr: L, af: [1, 2, 4, 6, 7] },
+                8 => { reset: Input, afr: H, af: [1, 2, 4, 7] },
+                9 => { reset: Input, afr: H, af: [1, 2, 4, 5, 6] },
+                10 => { reset: Input, afr: H, af: [1, 4, 5, 6, 7] },
+                11 => { reset: Input, afr: H, af: [1, 4, 5, 6, 7] },
+                12 => { reset: Input, afr: H, af: [1, 4, 5, 6, 7] },
+                13 => { reset: Input, afr: H, af: [4] },
+                14 => { reset: Input, afr: H, af: [] },
+                15 => { reset: Input, afr: H, af: [] },
             ],
         },
         {
             port: (D/d, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 7] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 6, 7] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 7] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 7] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 7] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 7] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 7] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 7] },
-                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
-                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 6] },
+                0 => { reset: Input, afr: L, af: [1, 7] },
+                1 => { reset: Input, afr: L, af: [1, 4, 6, 7] },
+                2 => { reset: Input, afr: L, af: [1, 2, 4, 5] },
+                3 => { reset: Input, afr: L, af: [1, 2, 7] },
+                4 => { reset: Input, afr: L, af: [1, 2, 7] },
+                5 => { reset: Input, afr: L, af: [1, 7] },
+                6 => { reset: Input, afr: L, af: [1, 2, 7] },
+                7 => { reset: Input, afr: L, af: [1, 2, 7] },
+                8 => { reset: Input, afr: H, af: [1, 7] },
+                9 => { reset: Input, afr: H, af: [1, 7] },
+                10 => { reset: Input, afr: H, af: [1, 7] },
+                11 => { reset: Input, afr: H, af: [1, 7] },
+                12 => { reset: Input, afr: H, af: [1, 2, 3, 7] },
+                13 => { reset: Input, afr: H, af: [1, 2, 3] },
+                14 => { reset: Input, afr: H, af: [1, 2, 3] },
+                15 => { reset: Input, afr: H, af: [1, 2, 3, 6] },
             ],
         },
         {
             port: (E/e, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 7] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 7] },
-                2 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3] },
-                3 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3] },
-                4 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3] },
-                5 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3] },
-                6 => { reset: Input<Floating>, afr: L, af: [0, 1] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 2] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 2] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 2] },
-                13 => { reset: Input<Floating>, afr: H, af: [1, 2] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 6] },
-                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 7] },
+                0 => { reset: Input, afr: L, af: [1, 2, 4, 7] },
+                1 => { reset: Input, afr: L, af: [1, 4, 7] },
+                2 => { reset: Input, afr: L, af: [0, 1, 2, 3] },
+                3 => { reset: Input, afr: L, af: [0, 1, 2, 3] },
+                4 => { reset: Input, afr: L, af: [0, 1, 2, 3] },
+                5 => { reset: Input, afr: L, af: [0, 1, 2, 3] },
+                6 => { reset: Input, afr: L, af: [0, 1] },
+                7 => { reset: Input, afr: L, af: [1, 2] },
+                8 => { reset: Input, afr: H, af: [1, 2] },
+                9 => { reset: Input, afr: H, af: [1, 2] },
+                10 => { reset: Input, afr: H, af: [1, 2] },
+                11 => { reset: Input, afr: H, af: [1, 2] },
+                12 => { reset: Input, afr: H, af: [1, 2] },
+                13 => { reset: Input, afr: H, af: [1, 2] },
+                14 => { reset: Input, afr: H, af: [1, 2, 6] },
+                15 => { reset: Input, afr: H, af: [1, 2, 7] },
             ],
         },
         {
             port: (F/f, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [4, 6] },
-                1 => { reset: Input<Floating>, afr: L, af: [4] },
-                2 => { reset: Input<Floating>, afr: L, af: [1] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 7] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 3, 5] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 5] },
+                0 => { reset: Input, afr: L, af: [4, 6] },
+                1 => { reset: Input, afr: L, af: [4] },
+                2 => { reset: Input, afr: L, af: [1] },
+                4 => { reset: Input, afr: L, af: [1, 2] },
+                6 => { reset: Input, afr: L, af: [1, 2, 4, 7] },
+                9 => { reset: Input, afr: H, af: [1, 3, 5] },
+                10 => { reset: Input, afr: H, af: [1, 3, 5] },
             ],
         },
     ],
@@ -1106,19 +1180,19 @@ gpio!({
         {
             port: (A/a, pac: gpioa),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 15] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
-                4 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 7, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 5, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 5, 6, 13, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 5, 6, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [0, 6, 7, 13, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [3, 6, 7, 9, 10, 13, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 6, 7, 8, 10, 13, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [6, 7, 9, 11, 12, 13, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 6, 7, 8, 9, 11, 13, 15] },
+                0 => { reset: Input, afr: L, af: [1, 3, 7, 15] },
+                1 => { reset: Input, afr: L, af: [1, 3, 7, 9, 15] },
+                2 => { reset: Input, afr: L, af: [1, 3, 7, 8, 9, 15] },
+                3 => { reset: Input, afr: L, af: [1, 3, 7, 9, 15] },
+                4 => { reset: Input, afr: L, af: [2, 3, 5, 7, 15] },
+                5 => { reset: Input, afr: L, af: [1, 3, 5, 15] },
+                6 => { reset: Input, afr: L, af: [1, 2, 3, 5, 6, 13, 15] },
+                7 => { reset: Input, afr: L, af: [1, 2, 3, 5, 6, 15] },
+                8 => { reset: Input, afr: H, af: [0, 6, 7, 13, 15] },
+                9 => { reset: Input, afr: H, af: [3, 6, 7, 9, 10, 13, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 6, 7, 8, 10, 13, 15] },
+                11 => { reset: Input, afr: H, af: [6, 7, 9, 11, 12, 13, 15] },
+                12 => { reset: Input, afr: H, af: [1, 6, 7, 8, 9, 11, 13, 15] },
                 13 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 3, 5, 7, 15] },
                 14 => { reset: AF0<PushPull>, afr: H, af: [0, 3, 4, 6, 7, 15] },
                 15 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 3, 4, 5, 7, 9, 13, 15] },
@@ -1127,56 +1201,56 @@ gpio!({
         {
             port: (B/b, pac: gpiob),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [2, 3, 6, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [2, 3, 6, 8, 13, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [3, 13, 15] },
+                0 => { reset: Input, afr: L, af: [2, 3, 6, 15] },
+                1 => { reset: Input, afr: L, af: [2, 3, 6, 8, 13, 15] },
+                2 => { reset: Input, afr: L, af: [3, 13, 15] },
                 3 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 3, 5, 7, 10, 12, 13, 15] },
                 4 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 2, 3, 5, 7, 10, 13, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5, 7, 10, 13, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 3, 4, 7, 12, 13, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 3, 4, 7, 10, 13, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 7, 9, 12, 13, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 4, 6, 7, 8, 9, 13, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 13, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 13, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [3, 6, 7, 13, 15] },
-                13 => { reset: Input<Floating>, afr: H, af: [3, 6, 7, 13, 15] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 6, 7, 13, 15] },
-                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 13, 15] },
+                5 => { reset: Input, afr: L, af: [1, 2, 4, 5, 7, 10, 13, 15] },
+                6 => { reset: Input, afr: L, af: [1, 3, 4, 7, 12, 13, 15] },
+                7 => { reset: Input, afr: L, af: [1, 3, 4, 7, 10, 13, 15] },
+                8 => { reset: Input, afr: H, af: [1, 3, 4, 7, 9, 12, 13, 15] },
+                9 => { reset: Input, afr: H, af: [1, 4, 6, 7, 8, 9, 13, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 7, 13, 15] },
+                11 => { reset: Input, afr: H, af: [1, 3, 7, 13, 15] },
+                12 => { reset: Input, afr: H, af: [3, 6, 7, 13, 15] },
+                13 => { reset: Input, afr: H, af: [3, 6, 7, 13, 15] },
+                14 => { reset: Input, afr: H, af: [1, 3, 6, 7, 13, 15] },
+                15 => { reset: Input, afr: H, af: [1, 2, 4, 13, 15] },
             ],
         },
         {
             port: (C/c, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 6] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 7] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 3, 7] },
-                13 => { reset: Input<Floating>, afr: H, af: [4] },
-                14 => { reset: Input<Floating>, afr: H, af: [] },
-                15 => { reset: Input<Floating>, afr: H, af: [] },
+                0 => { reset: Input, afr: L, af: [1, 2] },
+                1 => { reset: Input, afr: L, af: [1, 2] },
+                2 => { reset: Input, afr: L, af: [1, 2] },
+                3 => { reset: Input, afr: L, af: [1, 2, 6] },
+                4 => { reset: Input, afr: L, af: [1, 2, 7] },
+                5 => { reset: Input, afr: L, af: [1, 2, 3, 7] },
+                6 => { reset: Input, afr: L, af: [1, 2, 3, 7] },
+                7 => { reset: Input, afr: L, af: [1, 2, 3] },
+                8 => { reset: Input, afr: H, af: [1, 2, 3] },
+                9 => { reset: Input, afr: H, af: [1, 2, 3] },
+                10 => { reset: Input, afr: H, af: [1, 7] },
+                11 => { reset: Input, afr: H, af: [1, 3, 7] },
+                12 => { reset: Input, afr: H, af: [1, 3, 7] },
+                13 => { reset: Input, afr: H, af: [4] },
+                14 => { reset: Input, afr: H, af: [] },
+                15 => { reset: Input, afr: H, af: [] },
             ],
         },
         {
             port: (D/d, pac: gpioc),
             pins: [
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                2 => { reset: Input, afr: L, af: [1, 2] },
             ],
         },
         {
             port: (F/f, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [6] },
-                1 => { reset: Input<Floating>, afr: L, af: [] },
+                0 => { reset: Input, afr: L, af: [6] },
+                1 => { reset: Input, afr: L, af: [] },
             ],
         },
     ],
@@ -1189,19 +1263,19 @@ gpio!({
         {
             port: (A/a, pac: gpioa),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7, 8, 11, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 6, 7, 9, 11, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 6, 7, 8, 9, 11, 15] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 6, 7, 9, 11, 15] },
-                4 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 6, 7, 10, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 5, 7, 9, 10, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 5, 8, 9, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 5, 8, 9, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [0, 2, 4, 5, 7, 10, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [2, 3, 4, 5, 7, 9, 10, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 5, 7, 9, 10, 15] },
-                11 => { reset: Input<Floating>, afr: H, af: [2, 5, 6, 7, 8, 9, 10, 14, 15] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 6, 7, 8, 9, 10, 14, 15] },
+                0 => { reset: Input, afr: L, af: [1, 2, 3, 7, 8, 11, 15] },
+                1 => { reset: Input, afr: L, af: [0, 1, 2, 3, 6, 7, 9, 11, 15] },
+                2 => { reset: Input, afr: L, af: [1, 2, 3, 6, 7, 8, 9, 11, 15] },
+                3 => { reset: Input, afr: L, af: [1, 2, 3, 6, 7, 9, 11, 15] },
+                4 => { reset: Input, afr: L, af: [2, 3, 5, 6, 7, 10, 15] },
+                5 => { reset: Input, afr: L, af: [1, 3, 5, 7, 9, 10, 15] },
+                6 => { reset: Input, afr: L, af: [1, 2, 3, 5, 8, 9, 15] },
+                7 => { reset: Input, afr: L, af: [1, 2, 3, 5, 8, 9, 15] },
+                8 => { reset: Input, afr: H, af: [0, 2, 4, 5, 7, 10, 15] },
+                9 => { reset: Input, afr: H, af: [2, 3, 4, 5, 7, 9, 10, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 4, 5, 7, 9, 10, 15] },
+                11 => { reset: Input, afr: H, af: [2, 5, 6, 7, 8, 9, 10, 14, 15] },
+                12 => { reset: Input, afr: H, af: [1, 2, 6, 7, 8, 9, 10, 14, 15] },
                 13 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 2, 3, 5, 6, 7, 10, 15] },
                 14 => { reset: AF0<PushPull>, afr: H, af: [0, 3, 4, 10, 15] },
                 15 => { reset: AF0<PushPull>, afr: H, af: [0, 1, 3, 4, 5, 6, 10, 15] },
@@ -1210,95 +1284,95 @@ gpio!({
         {
             port: (B/b, pac: gpiob),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 10, 15] },
-                1 => { reset: Input<Floating>, afr: L, af: [2, 3, 15] },
-                2 => { reset: Input<Floating>, afr: L, af: [15] },
+                0 => { reset: Input, afr: L, af: [2, 3, 5, 10, 15] },
+                1 => { reset: Input, afr: L, af: [2, 3, 15] },
+                2 => { reset: Input, afr: L, af: [15] },
                 3 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 2, 3, 5, 6, 7, 9, 10, 15] },
                 4 => { reset: AF0<PushPull>, afr: L, af: [0, 1, 2, 3, 5, 6, 7, 9, 10, 15] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5, 6, 7, 10, 11, 15] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 7, 9, 10, 11, 15] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 7, 9, 10, 11, 15] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 15] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 5, 6, 7, 8, 9, 11, 15] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 6, 7, 15] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 7, 9, 15] },
-                15 => { reset: Input<Floating>, afr: H, af: [0, 1, 2, 3, 5, 9, 15] },
+                5 => { reset: Input, afr: L, af: [1, 2, 4, 5, 6, 7, 10, 11, 15] },
+                6 => { reset: Input, afr: L, af: [1, 2, 3, 4, 7, 9, 10, 11, 15] },
+                7 => { reset: Input, afr: L, af: [1, 2, 3, 4, 7, 9, 10, 11, 15] },
+                8 => { reset: Input, afr: H, af: [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 15] },
+                9 => { reset: Input, afr: H, af: [1, 2, 4, 5, 6, 7, 8, 9, 11, 15] },
+                10 => { reset: Input, afr: H, af: [1, 3, 5, 6, 7, 15] },
+                14 => { reset: Input, afr: H, af: [1, 3, 5, 7, 9, 15] },
+                15 => { reset: Input, afr: H, af: [0, 1, 2, 3, 5, 9, 15] },
             ],
         },
         {
             port: (C/c, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 5] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 5] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 7] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 5] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 5] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 5] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 5] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 2, 6, 7] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 2, 6, 7] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 6, 7] },
-                13 => { reset: Input<Floating>, afr: H, af: [] },
-                14 => { reset: Input<Floating>, afr: H, af: [] },
-                15 => { reset: Input<Floating>, afr: H, af: [] },
+                0 => { reset: Input, afr: L, af: [1, 2] },
+                1 => { reset: Input, afr: L, af: [1, 2] },
+                2 => { reset: Input, afr: L, af: [1, 2, 5] },
+                3 => { reset: Input, afr: L, af: [1, 2, 5] },
+                4 => { reset: Input, afr: L, af: [1, 2, 3, 7] },
+                5 => { reset: Input, afr: L, af: [1, 3, 7] },
+                6 => { reset: Input, afr: L, af: [1, 2, 5] },
+                7 => { reset: Input, afr: L, af: [1, 2, 5] },
+                8 => { reset: Input, afr: H, af: [1, 2, 5] },
+                9 => { reset: Input, afr: H, af: [1, 2, 5] },
+                10 => { reset: Input, afr: H, af: [1, 2, 6, 7] },
+                11 => { reset: Input, afr: H, af: [1, 2, 6, 7] },
+                12 => { reset: Input, afr: H, af: [1, 2, 6, 7] },
+                13 => { reset: Input, afr: H, af: [] },
+                14 => { reset: Input, afr: H, af: [] },
+                15 => { reset: Input, afr: H, af: [] },
             ],
         },
         {
             port: (D/d, pac: gpiod),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 2] },
-                3 => { reset: Input<Floating>, afr: L, af: [1, 5, 7] },
-                4 => { reset: Input<Floating>, afr: L, af: [1, 5, 7] },
-                5 => { reset: Input<Floating>, afr: L, af: [1, 7] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 5, 7] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 5, 7] },
-                8 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 7] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 3, 7] },
-                10 => { reset: Input<Floating>, afr: H, af: [1, 7] },
-                11 => { reset: Input<Floating>, afr: H, af: [1, 7] },
-                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 7] },
-                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
-                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
-                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
+                0 => { reset: Input, afr: L, af: [1, 2, 7] },
+                1 => { reset: Input, afr: L, af: [1, 2, 7] },
+                2 => { reset: Input, afr: L, af: [1, 2] },
+                3 => { reset: Input, afr: L, af: [1, 5, 7] },
+                4 => { reset: Input, afr: L, af: [1, 5, 7] },
+                5 => { reset: Input, afr: L, af: [1, 7] },
+                6 => { reset: Input, afr: L, af: [1, 5, 7] },
+                7 => { reset: Input, afr: L, af: [1, 5, 7] },
+                8 => { reset: Input, afr: H, af: [1, 3, 5, 7] },
+                9 => { reset: Input, afr: H, af: [1, 3, 7] },
+                10 => { reset: Input, afr: H, af: [1, 7] },
+                11 => { reset: Input, afr: H, af: [1, 7] },
+                12 => { reset: Input, afr: H, af: [1, 2, 3, 7] },
+                13 => { reset: Input, afr: H, af: [1, 2, 3] },
+                14 => { reset: Input, afr: H, af: [1, 2, 3] },
+                15 => { reset: Input, afr: H, af: [1, 2, 3] },
             ],
         },
         {
             port: (E/e, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
-                1 => { reset: Input<Floating>, afr: L, af: [1, 7] },
-                2 => { reset: Input<Floating>, afr: L, af: [0, 1, 3] },
-                3 => { reset: Input<Floating>, afr: L, af: [0, 1, 3] },
-                4 => { reset: Input<Floating>, afr: L, af: [0, 1, 3] },
-                5 => { reset: Input<Floating>, afr: L, af: [0, 1, 3] },
-                6 => { reset: Input<Floating>, afr: L, af: [0, 1] },
-                7 => { reset: Input<Floating>, afr: L, af: [1] },
-                8 => { reset: Input<Floating>, afr: H, af: [1] },
-                9 => { reset: Input<Floating>, afr: H, af: [1] },
-                10 => { reset: Input<Floating>, afr: H, af: [1] },
-                11 => { reset: Input<Floating>, afr: H, af: [1] },
-                12 => { reset: Input<Floating>, afr: H, af: [1] },
-                13 => { reset: Input<Floating>, afr: H, af: [1] },
-                14 => { reset: Input<Floating>, afr: H, af: [1] },
-                15 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+                0 => { reset: Input, afr: L, af: [1, 2, 7] },
+                1 => { reset: Input, afr: L, af: [1, 7] },
+                2 => { reset: Input, afr: L, af: [0, 1, 3] },
+                3 => { reset: Input, afr: L, af: [0, 1, 3] },
+                4 => { reset: Input, afr: L, af: [0, 1, 3] },
+                5 => { reset: Input, afr: L, af: [0, 1, 3] },
+                6 => { reset: Input, afr: L, af: [0, 1] },
+                7 => { reset: Input, afr: L, af: [1] },
+                8 => { reset: Input, afr: H, af: [1] },
+                9 => { reset: Input, afr: H, af: [1] },
+                10 => { reset: Input, afr: H, af: [1] },
+                11 => { reset: Input, afr: H, af: [1] },
+                12 => { reset: Input, afr: H, af: [1] },
+                13 => { reset: Input, afr: H, af: [1] },
+                14 => { reset: Input, afr: H, af: [1] },
+                15 => { reset: Input, afr: H, af: [1, 7] },
             ],
         },
         {
             port: (F/f, pac: gpioc),
             pins: [
-                0 => { reset: Input<Floating>, afr: L, af: [4] },
-                1 => { reset: Input<Floating>, afr: L, af: [4] },
-                2 => { reset: Input<Floating>, afr: L, af: [1, 4] },
-                4 => { reset: Input<Floating>, afr: L, af: [1] },
-                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5, 7] },
-                7 => { reset: Input<Floating>, afr: L, af: [1, 4, 7] },
-                9 => { reset: Input<Floating>, afr: H, af: [1, 2] },
-                10 => { reset: Input<Floating>, afr: H, af: [1] },
+                0 => { reset: Input, afr: L, af: [4] },
+                1 => { reset: Input, afr: L, af: [4] },
+                2 => { reset: Input, afr: L, af: [1, 4] },
+                4 => { reset: Input, afr: L, af: [1] },
+                6 => { reset: Input, afr: L, af: [1, 2, 4, 5, 7] },
+                7 => { reset: Input, afr: L, af: [1, 4, 7] },
+                9 => { reset: Input, afr: H, af: [1, 2] },
+                10 => { reset: Input, afr: H, af: [1] },
             ],
         },
     ],

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -436,7 +436,7 @@ where
     }
 }
 
-impl<GPIO, INDEX, MODE> OutputPin for Pin<GPIO, INDEX, Output<MODE>>
+impl<GPIO, INDEX, OTYPE> OutputPin for Pin<GPIO, INDEX, Output<OTYPE>>
 where
     GPIO: Gpio,
     INDEX: Index,
@@ -476,7 +476,7 @@ where
 }
 
 #[cfg(feature = "unproven")]
-impl<GPIO, INDEX, MODE> StatefulOutputPin for Pin<GPIO, INDEX, Output<MODE>>
+impl<GPIO, INDEX, OTYPE> StatefulOutputPin for Pin<GPIO, INDEX, Output<OTYPE>>
 where
     GPIO: Gpio,
     INDEX: Index,
@@ -492,7 +492,7 @@ where
 }
 
 #[cfg(feature = "unproven")]
-impl<GPIO, INDEX, MODE> toggleable::Default for Pin<GPIO, INDEX, Output<MODE>>
+impl<GPIO, INDEX, OTYPE> toggleable::Default for Pin<GPIO, INDEX, Output<OTYPE>>
 where
     GPIO: Gpio,
     INDEX: Index,
@@ -582,7 +582,7 @@ macro_rules! af {
 
         paste::paste! {
             #[doc = "Alternate function " $i " (type state)"]
-            pub type $AFi<MODE> = Alternate<$Ui, MODE>;
+            pub type $AFi<OTYPE> = Alternate<$Ui, OTYPE>;
         }
 
         impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -30,7 +30,7 @@
 
 use core::{convert::Infallible, marker::PhantomData};
 
-use crate::{hal::digital::v2::OutputPin, rcc::AHB};
+use crate::{hal::digital::v2::OutputPin, pac::EXTI, rcc::AHB, syscfg::SysCfg};
 
 #[cfg(feature = "unproven")]
 use crate::hal::digital::v2::{toggleable, InputPin, StatefulOutputPin};
@@ -87,6 +87,7 @@ mod private {
         type Reg: GpioRegExt + ?Sized;
 
         fn ptr(&self) -> *const Self::Reg;
+        fn port_index(&self) -> u8;
     }
 }
 
@@ -129,12 +130,13 @@ pub trait Readable {}
 /// Marker trait for slew rate configurable pin modes
 pub trait OutputSpeed {}
 
-/// Marker trait for internal resistor enabled pin modes
-pub trait InternalResistor {}
+/// Marker trait for active pin modes
+pub trait Active {}
 
 /// Runtime defined GPIO port (type state)
 pub struct Gpiox {
     ptr: *const dyn GpioRegExt,
+    index: u8,
 }
 
 impl private::Gpio for Gpiox {
@@ -142,6 +144,10 @@ impl private::Gpio for Gpiox {
 
     fn ptr(&self) -> *const Self::Reg {
         self.ptr
+    }
+
+    fn port_index(&self) -> u8 {
+        self.index
     }
 }
 
@@ -174,9 +180,9 @@ impl Readable for Input {}
 impl Readable for Output<OpenDrain> {}
 impl<OTYPE> OutputSpeed for Output<OTYPE> {}
 impl<AF, OTYPE> OutputSpeed for Alternate<AF, OTYPE> {}
-impl InternalResistor for Input {}
-impl<OTYPE> InternalResistor for Output<OTYPE> {}
-impl<AF, OTYPE> InternalResistor for Alternate<AF, OTYPE> {}
+impl Active for Input {}
+impl<OTYPE> Active for Output<OTYPE> {}
+impl<AF, OTYPE> Active for Alternate<AF, OTYPE> {}
 
 /// Slew rate configuration
 pub enum Speed {
@@ -226,6 +232,14 @@ pub struct Pin<GPIO, INDEX, MODE> {
 /// [examples/gpio_erased.rs]: https://github.com/stm32-rs/stm32f3xx-hal/blob/v0.6.0/examples/gpio_erased.rs
 pub type PXx<MODE> = Pin<Gpiox, Ux, MODE>;
 
+macro_rules! modify_at {
+    ($xr:expr, $bits:expr, $i:expr, $val:expr) => {
+        $xr.modify(|r, w| {
+            w.bits(r.bits() & !(u32::MAX >> 32 - $bits << $bits * $i) | $val << $bits * $i)
+        });
+    };
+}
+
 impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
 where
     INDEX: Unsigned,
@@ -256,6 +270,7 @@ where
         PXx {
             gpio: Gpiox {
                 ptr: self.gpio.ptr(),
+                index: self.gpio.port_index(),
             },
             index: self.index,
             _mode: self._mode,
@@ -374,7 +389,7 @@ impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
 where
     GPIO: GpioStatic,
     INDEX: Index,
-    MODE: InternalResistor,
+    MODE: Active,
 {
     /// Set the internal pull-up and pull-down resistor
     pub fn set_internal_resistor(&mut self, pupdr: &mut GPIO::PUPDR, resistor: Resistor) {
@@ -456,6 +471,77 @@ where
     GPIO: Gpio,
     INDEX: Index,
 {
+}
+
+/// Return an EXTI register for the current CPU
+#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+macro_rules! reg_for_cpu {
+    ($exti:expr, $xr:ident) => {
+        $exti.$xr
+    };
+}
+
+/// Return an EXTI register for the current CPU
+#[cfg(not(any(feature = "stm32f373", feature = "stm32f378")))]
+macro_rules! reg_for_cpu {
+    ($exti:expr, $xr:ident) => {
+        paste::paste! {
+            $exti.[<$xr 1>]
+        }
+    };
+}
+
+impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
+where
+    GPIO: Gpio,
+    INDEX: Index,
+    MODE: Active,
+{
+    /// Make corresponding EXTI line sensitive to this pin
+    pub fn make_interrupt_source(&mut self, syscfg: &mut SysCfg) {
+        let i = self.index.index() % 4;
+        let extigpionr = self.gpio.port_index() as u32;
+        match self.index.index() {
+            0..=3 => unsafe { modify_at!(syscfg.exticr1, 4, i, extigpionr) },
+            4..=7 => unsafe { modify_at!(syscfg.exticr2, 4, i, extigpionr) },
+            8..=11 => unsafe { modify_at!(syscfg.exticr3, 4, i, extigpionr) },
+            12..=15 => unsafe { modify_at!(syscfg.exticr4, 4, i, extigpionr) },
+            _ => unreachable!(),
+        }
+    }
+
+    /// Generate interrupt on rising edge, falling edge, or both
+    pub fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
+        let (rise, fall) = match edge {
+            Edge::Rising => (true, false),
+            Edge::Falling => (false, true),
+            Edge::RisingFalling => (true, true),
+        };
+        unsafe {
+            modify_at!(reg_for_cpu!(exti, rtsr), 1, self.index.index(), rise as u32);
+            modify_at!(reg_for_cpu!(exti, ftsr), 1, self.index.index(), fall as u32);
+        }
+    }
+
+    /// Enable external interrupts from this pin.
+    pub fn enable_interrupt(&mut self, exti: &mut EXTI) {
+        unsafe { modify_at!(reg_for_cpu!(exti, imr), 1, self.index.index(), 1) };
+    }
+
+    /// Disable external interrupts from this pin
+    pub fn disable_interrupt(&mut self, exti: &mut EXTI) {
+        unsafe { modify_at!(reg_for_cpu!(exti, imr), 1, self.index.index(), 0) };
+    }
+
+    /// Clear the interrupt pending bit for this pin
+    pub fn clear_interrupt_pending_bit(&mut self) {
+        unsafe { reg_for_cpu!((*EXTI::ptr()), pr).write(|w| w.bits(1 << self.index.index())) };
+    }
+
+    /// Reads the interrupt pending bit for this pin
+    pub fn check_interrupt(&self) -> bool {
+        unsafe { reg_for_cpu!((*EXTI::ptr()), pr).read().bits() & (1 << self.index.index()) != 0 }
+    }
 }
 
 macro_rules! af {
@@ -545,22 +631,6 @@ macro_rules! gpio_trait {
                 }
             }
         )+
-    }
-}
-
-macro_rules! afr_trait {
-    ($GPIOX:ident, $AFR:ty, $afr:ident, $offset:expr) => {
-        impl Afr for $AFR {
-            #[inline]
-            fn afx(&mut self, i: u8, x: u8) {
-                let i = i - $offset;
-                unsafe {
-                    (*$GPIOX::ptr()).$afr.modify(|r, w| {
-                        w.bits(r.bits() & !(u32::MAX >> 32 - 4 << 4 * i) | (x as u32) << 4 * i)
-                    });
-                }
-            }
-        }
     };
 }
 
@@ -578,12 +648,7 @@ macro_rules! r_trait {
                 #[inline]
                 fn $fn(&mut self, i: u8) {
                     unsafe {
-                        (*$GPIOX::ptr()).$xr.modify(|r, w| {
-                            w.bits(
-                                r.bits() & !(u32::MAX >> 32 - $bits << $bits * i)
-                                    | ($gpioy::$xr::$enum::$VARIANT as u32) << $bits * i
-                            )
-                        });
+                        modify_at!((*$GPIOX::ptr()).$xr, $bits, i, $gpioy::$xr::$enum::$VARIANT as u32);
                     }
                 }
             )+
@@ -598,8 +663,8 @@ macro_rules! gpio {
         Gpio: $Gpiox:ty,
         port_index: $port_index:literal,
         gpio_mapped: $gpioy:ident,
-        gpio_mapped_ioen: $iopxen:ident,
-        gpio_mapped_iorst: $iopxrst:ident,
+        iopen: $iopxen:ident,
+        ioprst: $iopxrst:ident,
         partially_erased_pin: $PXx:ty,
         pins: {$(
             $PXi:ty: (
@@ -618,6 +683,11 @@ macro_rules! gpio {
             #[inline(always)]
             fn ptr(&self) -> *const Self::Reg {
                 crate::pac::$GPIOX::ptr()
+            }
+
+            #[inline(always)]
+            fn port_index(&self) -> u8 {
+                $port_index
             }
         }
 
@@ -704,12 +774,22 @@ macro_rules! gpio {
                 /// Opaque AFRH register
                 pub struct AFRH(());
 
-                afr_trait!($GPIOX, AFRH, afrh, 8);
+                impl Afr for AFRH {
+                    #[inline]
+                    fn afx(&mut self, i: u8, x: u8) {
+                        unsafe { modify_at!((*$GPIOX::ptr()).afrh, 4, i - 8, x as u32); }
+                    }
+                }
 
                 /// Opaque AFRL register
                 pub struct AFRL(());
 
-                afr_trait!($GPIOX, AFRL, afrl, 0);
+                impl Afr for AFRL {
+                    #[inline]
+                    fn afx(&mut self, i: u8, x: u8) {
+                        unsafe { modify_at!((*$GPIOX::ptr()).afrl, 4, i, x as u32); }
+                    }
+                }
 
                 /// Opaque MODER register
                 pub struct MODER(());
@@ -785,7 +865,7 @@ macro_rules! gpio {
                     $i:literal => {
                         reset: $MODE:ty,
                         afr: $LH:ident,
-                        af: [$( $af:literal ),*]
+                        af: [$($af:literal),*]
                     },
                 )+],
             },
@@ -800,8 +880,8 @@ macro_rules! gpio {
                     Gpio: [<Gpio $x>],
                     port_index: $port_index,
                     gpio_mapped: $gpioy,
-                    gpio_mapped_ioen: [<iop $x en>],
-                    gpio_mapped_iorst: [<iop $x rst>],
+                    iopen: [<iop $x en>],
+                    ioprst: [<iop $x rst>],
                     partially_erased_pin: [<P $X x>],
                     pins: {$(
                         [<P $X $i>]: (

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -198,6 +198,16 @@ pub enum Resistor {
     PullDown,
 }
 
+/// GPIO interrupt trigger edge selection
+pub enum Edge {
+    /// Rising edge of voltage
+    Rising,
+    /// Falling edge of voltage
+    Falling,
+    /// Rising and falling edge of voltage
+    RisingFalling,
+}
+
 /// Generic pin
 pub struct Pin<GPIO, INDEX, MODE> {
     gpio: GPIO,
@@ -586,6 +596,7 @@ macro_rules! gpio {
         GPIO: $GPIOX:ident,
         gpio: $gpiox:ident,
         Gpio: $Gpiox:ty,
+        port_index: $port_index:literal,
         gpio_mapped: $gpioy:ident,
         gpio_mapped_ioen: $iopxen:ident,
         gpio_mapped_iorst: $iopxrst:ident,
@@ -769,7 +780,7 @@ macro_rules! gpio {
         pacs: $pacs:tt,
         ports: [$(
             {
-                port: ($X:ident/$x:ident, pac: $gpioy:ident),
+                port: ($X:ident/$x:ident, $port_index:literal, $gpioy:ident),
                 pins: [$(
                     $i:literal => {
                         reset: $MODE:ty,
@@ -787,6 +798,7 @@ macro_rules! gpio {
                     GPIO: [<GPIO $X>],
                     gpio: [<gpio $x>],
                     Gpio: [<Gpio $x>],
+                    port_index: $port_index,
                     gpio_mapped: $gpioy,
                     gpio_mapped_ioen: [<iop $x en>],
                     gpio_mapped_iorst: [<iop $x rst>],
@@ -802,14 +814,14 @@ macro_rules! gpio {
     };
 }
 // auto-generated using codegen
-// STM32CubeMX DB release: DB.6.0.0
+// STM32CubeMX DB release: DB.6.0.10
 
 #[cfg(feature = "gpio-f302")]
 gpio!({
     pacs: [gpioa, gpiob, gpioc],
     ports: [
         {
-            port: (A/a, pac: gpioa),
+            port: (A/a, 0, gpioa),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 3, 7, 15] },
                 1 => { reset: Input, afr: L, af: [0, 1, 3, 7, 9, 15] },
@@ -830,7 +842,7 @@ gpio!({
             ],
         },
         {
-            port: (B/b, pac: gpiob),
+            port: (B/b, 1, gpiob),
             pins: [
                 0 => { reset: Input, afr: L, af: [3, 6, 15] },
                 1 => { reset: Input, afr: L, af: [3, 6, 8, 15] },
@@ -851,7 +863,7 @@ gpio!({
             ],
         },
         {
-            port: (C/c, pac: gpioc),
+            port: (C/c, 2, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2] },
                 1 => { reset: Input, afr: L, af: [1, 2] },
@@ -872,13 +884,13 @@ gpio!({
             ],
         },
         {
-            port: (D/d, pac: gpioc),
+            port: (D/d, 3, gpioc),
             pins: [
                 2 => { reset: Input, afr: L, af: [1] },
             ],
         },
         {
-            port: (F/f, pac: gpioc),
+            port: (F/f, 5, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [4, 5, 6] },
                 1 => { reset: Input, afr: L, af: [4, 5] },
@@ -892,7 +904,7 @@ gpio!({
     pacs: [gpioa, gpiob, gpioc],
     ports: [
         {
-            port: (A/a, pac: gpioa),
+            port: (A/a, 0, gpioa),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 3, 7, 8, 9, 10, 15] },
                 1 => { reset: Input, afr: L, af: [0, 1, 3, 7, 9, 15] },
@@ -913,7 +925,7 @@ gpio!({
             ],
         },
         {
-            port: (B/b, pac: gpiob),
+            port: (B/b, 1, gpiob),
             pins: [
                 0 => { reset: Input, afr: L, af: [2, 3, 4, 6, 15] },
                 1 => { reset: Input, afr: L, af: [2, 3, 4, 6, 8, 15] },
@@ -934,7 +946,7 @@ gpio!({
             ],
         },
         {
-            port: (C/c, pac: gpioc),
+            port: (C/c, 2, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2] },
                 1 => { reset: Input, afr: L, af: [1, 2] },
@@ -955,7 +967,7 @@ gpio!({
             ],
         },
         {
-            port: (D/d, pac: gpioc),
+            port: (D/d, 3, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 7, 12] },
                 1 => { reset: Input, afr: L, af: [1, 4, 6, 7, 12] },
@@ -976,7 +988,7 @@ gpio!({
             ],
         },
         {
-            port: (E/e, pac: gpioc),
+            port: (E/e, 4, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2, 4, 6, 7, 12] },
                 1 => { reset: Input, afr: L, af: [1, 4, 6, 7, 12] },
@@ -997,7 +1009,7 @@ gpio!({
             ],
         },
         {
-            port: (F/f, pac: gpioc),
+            port: (F/f, 5, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 4, 5, 6] },
                 1 => { reset: Input, afr: L, af: [1, 4, 5] },
@@ -1018,7 +1030,7 @@ gpio!({
             ],
         },
         {
-            port: (G/g, pac: gpioc),
+            port: (G/g, 6, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2, 12] },
                 1 => { reset: Input, afr: L, af: [1, 2, 12] },
@@ -1039,7 +1051,7 @@ gpio!({
             ],
         },
         {
-            port: (H/h, pac: gpioc),
+            port: (H/h, 7, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2, 12] },
                 1 => { reset: Input, afr: L, af: [1, 2, 12] },
@@ -1054,7 +1066,7 @@ gpio!({
     pacs: [gpioa, gpiob, gpioc],
     ports: [
         {
-            port: (A/a, pac: gpioa),
+            port: (A/a, 0, gpioa),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 3, 7, 8, 9, 10, 15] },
                 1 => { reset: Input, afr: L, af: [0, 1, 3, 7, 9, 15] },
@@ -1075,7 +1087,7 @@ gpio!({
             ],
         },
         {
-            port: (B/b, pac: gpiob),
+            port: (B/b, 1, gpiob),
             pins: [
                 0 => { reset: Input, afr: L, af: [2, 3, 4, 6, 15] },
                 1 => { reset: Input, afr: L, af: [2, 3, 4, 6, 8, 15] },
@@ -1096,7 +1108,7 @@ gpio!({
             ],
         },
         {
-            port: (C/c, pac: gpioc),
+            port: (C/c, 2, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1] },
                 1 => { reset: Input, afr: L, af: [1] },
@@ -1117,7 +1129,7 @@ gpio!({
             ],
         },
         {
-            port: (D/d, pac: gpioc),
+            port: (D/d, 3, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 7] },
                 1 => { reset: Input, afr: L, af: [1, 4, 6, 7] },
@@ -1138,7 +1150,7 @@ gpio!({
             ],
         },
         {
-            port: (E/e, pac: gpioc),
+            port: (E/e, 4, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2, 4, 7] },
                 1 => { reset: Input, afr: L, af: [1, 4, 7] },
@@ -1159,7 +1171,7 @@ gpio!({
             ],
         },
         {
-            port: (F/f, pac: gpioc),
+            port: (F/f, 5, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [4, 6] },
                 1 => { reset: Input, afr: L, af: [4] },
@@ -1178,7 +1190,7 @@ gpio!({
     pacs: [gpioa, gpiob, gpioc],
     ports: [
         {
-            port: (A/a, pac: gpioa),
+            port: (A/a, 0, gpioa),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 3, 7, 15] },
                 1 => { reset: Input, afr: L, af: [1, 3, 7, 9, 15] },
@@ -1199,7 +1211,7 @@ gpio!({
             ],
         },
         {
-            port: (B/b, pac: gpiob),
+            port: (B/b, 1, gpiob),
             pins: [
                 0 => { reset: Input, afr: L, af: [2, 3, 6, 15] },
                 1 => { reset: Input, afr: L, af: [2, 3, 6, 8, 13, 15] },
@@ -1220,7 +1232,7 @@ gpio!({
             ],
         },
         {
-            port: (C/c, pac: gpioc),
+            port: (C/c, 2, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2] },
                 1 => { reset: Input, afr: L, af: [1, 2] },
@@ -1241,13 +1253,13 @@ gpio!({
             ],
         },
         {
-            port: (D/d, pac: gpioc),
+            port: (D/d, 3, gpioc),
             pins: [
                 2 => { reset: Input, afr: L, af: [1, 2] },
             ],
         },
         {
-            port: (F/f, pac: gpioc),
+            port: (F/f, 5, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [6] },
                 1 => { reset: Input, afr: L, af: [] },
@@ -1261,7 +1273,7 @@ gpio!({
     pacs: [gpioa, gpiob, gpioc, gpiod],
     ports: [
         {
-            port: (A/a, pac: gpioa),
+            port: (A/a, 0, gpioa),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2, 3, 7, 8, 11, 15] },
                 1 => { reset: Input, afr: L, af: [0, 1, 2, 3, 6, 7, 9, 11, 15] },
@@ -1282,7 +1294,7 @@ gpio!({
             ],
         },
         {
-            port: (B/b, pac: gpiob),
+            port: (B/b, 1, gpiob),
             pins: [
                 0 => { reset: Input, afr: L, af: [2, 3, 5, 10, 15] },
                 1 => { reset: Input, afr: L, af: [2, 3, 15] },
@@ -1300,7 +1312,7 @@ gpio!({
             ],
         },
         {
-            port: (C/c, pac: gpioc),
+            port: (C/c, 2, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2] },
                 1 => { reset: Input, afr: L, af: [1, 2] },
@@ -1321,7 +1333,7 @@ gpio!({
             ],
         },
         {
-            port: (D/d, pac: gpiod),
+            port: (D/d, 3, gpiod),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2, 7] },
                 1 => { reset: Input, afr: L, af: [1, 2, 7] },
@@ -1342,7 +1354,7 @@ gpio!({
             ],
         },
         {
-            port: (E/e, pac: gpioc),
+            port: (E/e, 4, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [1, 2, 7] },
                 1 => { reset: Input, afr: L, af: [1, 7] },
@@ -1363,7 +1375,7 @@ gpio!({
             ],
         },
         {
-            port: (F/f, pac: gpioc),
+            port: (F/f, 5, gpioc),
             pins: [
                 0 => { reset: Input, afr: L, af: [4] },
                 1 => { reset: Input, afr: L, af: [4] },

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,6 +1,6 @@
 //! General Purpose Input / Output
 //!
-//! To use the GPIO pins, you first need to configure the GPIO bank (GPIOA, GPIOB, ...) that you
+//! To use the GPIO pins, you first need to configure the GPIO port (GPIOA, GPIOB, ...) that you
 //! are interested in. This is done using the [`GpioExt::split`] function.
 //!
 //! ```
@@ -13,7 +13,7 @@
 //! The resulting [Parts](gpioa::Parts) struct contains one field for each
 //! pin, as well as some shared registers.
 //!
-//! To use a pin, first use the relevant `into_...` method of the [pin](gpioa::PA0).
+//! To use a pin, first use the relevant `into_...` method of the [pin](Pin).
 //!
 //! ```rust
 //! let pa0 = gpioa.pa0.into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper);
@@ -28,18 +28,14 @@
 //! [OutputPin]: embedded_hal::digital::v2::OutputPin
 //! [examples/toggle.rs]: https://github.com/stm32-rs/stm32f3xx-hal/blob/v0.6.1/examples/toggle.rs
 
-use core::convert::Infallible;
-use core::marker::PhantomData;
+use core::{convert::Infallible, marker::PhantomData};
+
+use crate::{hal::digital::v2::OutputPin, rcc::AHB};
 
 #[cfg(feature = "unproven")]
-use crate::hal::digital::v2::toggleable;
-#[cfg(feature = "unproven")]
-use crate::hal::digital::v2::InputPin;
-#[cfg(feature = "unproven")]
-use crate::hal::digital::v2::OutputPin;
-#[cfg(feature = "unproven")]
-use crate::hal::digital::v2::StatefulOutputPin;
-use crate::rcc::AHB;
+use crate::hal::digital::v2::{toggleable, InputPin, StatefulOutputPin};
+
+use typenum::{Unsigned, U0, U1, U10, U11, U12, U13, U14, U15, U2, U3, U4, U5, U6, U7, U8, U9};
 
 /// Extension trait to split a GPIO peripheral in independent pins and registers
 pub trait GpioExt {
@@ -50,644 +46,663 @@ pub trait GpioExt {
     fn split(self, ahb: &mut AHB) -> Self::Parts;
 }
 
-/// Input mode (type state)
-pub struct Input<MODE> {
-    _mode: PhantomData<MODE>,
+/// GPIO Register interface traits private to this module
+mod private {
+    pub trait GpioRegExt {
+        fn is_low(&self, i: u8) -> bool;
+        fn is_set_low(&self, i: u8) -> bool;
+        fn set_high(&self, i: u8);
+        fn set_low(&self, i: u8);
+    }
+
+    pub trait Moder {
+        fn input(&mut self, i: u8);
+        fn output(&mut self, i: u8);
+        fn alternate(&mut self, i: u8);
+        fn analog(&mut self, i: u8);
+    }
+
+    pub trait Otyper {
+        fn push_pull(&mut self, i: u8);
+        fn open_drain(&mut self, i: u8);
+    }
+
+    pub trait Pupdr {
+        fn floating(&mut self, i: u8);
+        fn pull_up(&mut self, i: u8);
+        fn pull_down(&mut self, i: u8);
+    }
+
+    pub trait Afr {
+        fn afx(&mut self, i: u8, x: u8);
+    }
+
+    pub trait Gpio {
+        type Reg: GpioRegExt + ?Sized;
+
+        fn ptr(&self) -> *const Self::Reg;
+    }
 }
+
+use private::{Afr, GpioRegExt, Moder, Otyper, Pupdr};
+
+/// Marker trait for GPIO ports
+pub trait Gpio: private::Gpio {}
+
+/// Marker trait for compile time defined GPIO ports
+pub trait GpioStatic: Gpio {
+    /// Associated MODER register
+    type MODER: Moder;
+    /// Associated OTYPER register
+    type OTYPER: Otyper;
+    /// Associated PUPDR register
+    type PUPDR: Pupdr;
+}
+
+/// Marker trait for pin number
+pub trait Index {
+    #[doc(hidden)]
+    fn index(&self) -> u8;
+}
+
+impl<U> Index for U
+where
+    U: Unsigned,
+{
+    #[inline(always)]
+    fn index(&self) -> u8 {
+        Self::U8
+    }
+}
+
+/// Marker trait for readable pin modes
+pub trait Readable {}
+
+/// Runtime defined GPIO port (type state)
+pub struct Gpiox {
+    ptr: *const dyn GpioRegExt,
+}
+
+impl private::Gpio for Gpiox {
+    type Reg = dyn GpioRegExt;
+
+    fn ptr(&self) -> *const Self::Reg {
+        self.ptr
+    }
+}
+
+impl Gpio for Gpiox {}
+
+/// Runtime defined pin number (type state)
+pub struct Ux(u8);
+
+impl Index for Ux {
+    fn index(&self) -> u8 {
+        self.0
+    }
+}
+
+/// Input mode (type state)
+pub struct Input<MODE>(PhantomData<MODE>);
 
 /// Floating input (type state)
 pub struct Floating;
-/// Pulled down input (type state)
-pub struct PullDown;
 /// Pulled up input (type state)
 pub struct PullUp;
+/// Pulled down input (type state)
+pub struct PullDown;
 
 /// Output mode (type state)
-pub struct Output<MODE> {
-    _mode: PhantomData<MODE>,
-}
+pub struct Output<MODE>(PhantomData<MODE>);
 
 /// Push pull output (type state)
 pub struct PushPull;
 /// Open drain output (type state)
 pub struct OpenDrain;
 
+/// Alternate function (type state)
+pub struct Alternate<AF>(PhantomData<AF>);
+
 /// Analog mode (type state)
 pub struct Analog;
 
-/// Alternate function 0 (type state)
-pub struct AF0;
+impl<MODE> Readable for Input<MODE> {}
+impl Readable for Output<OpenDrain> {}
 
-/// Alternate function 1 (type state)
-pub struct AF1;
+/// Generic pin
+pub struct Pin<GPIO, INDEX, MODE> {
+    gpio: GPIO,
+    index: INDEX,
+    _mode: PhantomData<MODE>,
+}
 
-/// Alternate function 2 (type state)
-pub struct AF2;
+/// Fully erased pin
+///
+/// This moves the pin type information to be known
+/// at runtime, and erases the specific compile time type of the GPIO.
+/// It does only matter, that it is a GPIO pin with a specific MODE.
+///
+/// See [examples/gpio_erased.rs] as an example.
+///
+/// [examples/gpio_erased.rs]: https://github.com/stm32-rs/stm32f3xx-hal/blob/v0.6.0/examples/gpio_erased.rs
+pub type PXx<MODE> = Pin<Gpiox, Ux, MODE>;
 
-/// Alternate function 3 (type state)
-pub struct AF3;
+impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
+where
+    INDEX: Unsigned,
+{
+    /// Erases the pin number from the type
+    ///
+    /// This is useful when you want to collect the pins into an array where you
+    /// need all the elements to have the same type
+    pub fn downgrade(self) -> Pin<GPIO, Ux, MODE> {
+        Pin {
+            gpio: self.gpio,
+            index: Ux(INDEX::U8),
+            _mode: self._mode,
+        }
+    }
+}
 
-/// Alternate function 4 (type state)
-pub struct AF4;
+impl<GPIO, MODE> Pin<GPIO, Ux, MODE>
+where
+    GPIO: GpioStatic,
+    GPIO::Reg: 'static + Sized,
+{
+    /// Erases the port letter from the type
+    ///
+    /// This is useful when you want to collect the pins into an array where you
+    /// need all the elements to have the same type
+    pub fn downgrade(self) -> PXx<MODE> {
+        PXx {
+            gpio: Gpiox {
+                ptr: self.gpio.ptr(),
+            },
+            index: self.index,
+            _mode: self._mode,
+        }
+    }
+}
 
-/// Alternate function 5 (type state)
-pub struct AF5;
+impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE> {
+    fn into_mode<NEW_MODE>(self) -> Pin<GPIO, INDEX, NEW_MODE> {
+        Pin {
+            gpio: self.gpio,
+            index: self.index,
+            _mode: PhantomData,
+        }
+    }
+}
 
-/// Alternate function 6 (type state)
-pub struct AF6;
+impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
+where
+    GPIO: GpioStatic,
+    INDEX: Unsigned,
+{
+    /// Configures the pin to operate as a floating input pin
+    pub fn into_floating_input(
+        self,
+        moder: &mut GPIO::MODER,
+        pupdr: &mut GPIO::PUPDR,
+    ) -> Pin<GPIO, INDEX, Input<Floating>> {
+        moder.input(self.index.index());
+        pupdr.floating(self.index.index());
+        self.into_mode()
+    }
 
-/// Alternate function 7 (type state)
-pub struct AF7;
+    /// Configures the pin to operate as a pulled up input pin
+    pub fn into_pull_up_input(
+        self,
+        moder: &mut GPIO::MODER,
+        pupdr: &mut GPIO::PUPDR,
+    ) -> Pin<GPIO, INDEX, Input<PullUp>> {
+        moder.input(self.index.index());
+        pupdr.pull_up(self.index.index());
+        self.into_mode()
+    }
 
-/// Alternate function 8 (type state)
-pub struct AF8;
+    /// Configures the pin to operate as a pulled down input pin
+    pub fn into_pull_down_input(
+        self,
+        moder: &mut GPIO::MODER,
+        pupdr: &mut GPIO::PUPDR,
+    ) -> Pin<GPIO, INDEX, Input<PullDown>> {
+        moder.input(self.index.index());
+        pupdr.pull_down(self.index.index());
+        self.into_mode()
+    }
 
-/// Alternate function 9 (type state)
-pub struct AF9;
+    /// Configures the pin to operate as a push-pull output pin
+    pub fn into_push_pull_output(
+        self,
+        moder: &mut GPIO::MODER,
+        otyper: &mut GPIO::OTYPER,
+    ) -> Pin<GPIO, INDEX, Output<PushPull>> {
+        moder.output(self.index.index());
+        otyper.push_pull(self.index.index());
+        self.into_mode()
+    }
 
-/// Alternate function 10 (type state)
-pub struct AF10;
+    /// Configures the pin to operate as an open-drain output pin
+    pub fn into_open_drain_output(
+        self,
+        moder: &mut GPIO::MODER,
+        otyper: &mut GPIO::OTYPER,
+    ) -> Pin<GPIO, INDEX, Output<OpenDrain>> {
+        moder.output(self.index.index());
+        otyper.open_drain(self.index.index());
+        self.into_mode()
+    }
 
-/// Alternate function 11 (type state)
-pub struct AF11;
+    /// Configures the pin to operate as an analog pin, with disabled schmitt trigger.
+    pub fn into_analog(
+        self,
+        moder: &mut GPIO::MODER,
+        pupdr: &mut GPIO::PUPDR,
+    ) -> Pin<GPIO, INDEX, Analog> {
+        moder.analog(self.index.index());
+        pupdr.floating(self.index.index());
+        self.into_mode()
+    }
+}
 
-/// Alternate function 12 (type state)
-pub struct AF12;
+impl<GPIO, INDEX> Pin<GPIO, INDEX, Output<OpenDrain>>
+where
+    GPIO: GpioStatic,
+    INDEX: Unsigned,
+{
+    /// Enables / disables the internal pull up
+    pub fn internal_pull_up(&mut self, pupdr: &mut GPIO::PUPDR, on: bool) {
+        if on {
+            pupdr.pull_up(self.index.index());
+        } else {
+            pupdr.floating(self.index.index());
+        }
+    }
+}
 
-/// Alternate function 13 (type state)
-pub struct AF13;
+impl<GPIO, INDEX, MODE> OutputPin for Pin<GPIO, INDEX, Output<MODE>>
+where
+    GPIO: Gpio,
+    INDEX: Index,
+{
+    type Error = Infallible;
 
-/// Alternate function 14 (type state)
-pub struct AF14;
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        // NOTE(unsafe) atomic write to a stateless register
+        unsafe { (*self.gpio.ptr()).set_high(self.index.index()) };
+        Ok(())
+    }
 
-/// Alternate function 15 (type state)
-pub struct AF15;
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        // NOTE(unsafe) atomic write to a stateless register
+        unsafe { (*self.gpio.ptr()).set_low(self.index.index()) };
+        Ok(())
+    }
+}
 
-macro_rules! gpio {
-    ([
-        $({
-            GPIO: $GPIOX:ident,
-            gpio: $gpiox:ident,
-            gpio_mapped: $gpioy:ident,
-            gpio_mapped_ioenr: $iopxenr:ident,
-            gpio_mapped_iorst: $iopxrst:ident,
-            partially_erased_pin: $PXx:ident,
-            pins: [
-                $($PXi:ident: (
-                    $pxi:ident, $i:expr, $MODE:ty, $moderi:ident, $AFR:ident, $afri:ident,
-                    $bsi:ident, $bri:ident, $odri:ident, $idri:ident, $pupdri:ident, $oti:ident,
-                    { $( $AFi:ty: ($into_afi:ident, $afi:ident), )* },
-                ),)+
-            ],
-        },)+
-    ]) => {
-        $( use crate::pac::$GPIOX; )+
+#[cfg(feature = "unproven")]
+impl<GPIO, INDEX, MODE> InputPin for Pin<GPIO, INDEX, MODE>
+where
+    GPIO: Gpio,
+    INDEX: Index,
+    MODE: Readable,
+{
+    type Error = Infallible;
 
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(!self.is_low()?)
+    }
 
-        /// GPIO discriminator enum.
-        ///
-        /// Use to store the gpio bank, when using
-        /// fully erased pins [`PXx`]
-        pub enum Gpio {
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        // NOTE(unsafe) atomic read with no side effects
+        Ok(unsafe { (*self.gpio.ptr()).is_low(self.index.index()) })
+    }
+}
+
+#[cfg(feature = "unproven")]
+impl<GPIO, INDEX, MODE> StatefulOutputPin for Pin<GPIO, INDEX, Output<MODE>>
+where
+    GPIO: Gpio,
+    INDEX: Index,
+{
+    fn is_set_high(&self) -> Result<bool, Self::Error> {
+        Ok(!self.is_set_low()?)
+    }
+
+    fn is_set_low(&self) -> Result<bool, Self::Error> {
+        // NOTE(unsafe) atomic read with no side effects
+        Ok(unsafe { (*self.gpio.ptr()).is_set_low(self.index.index()) })
+    }
+}
+
+#[cfg(feature = "unproven")]
+impl<GPIO, INDEX, MODE> toggleable::Default for Pin<GPIO, INDEX, Output<MODE>>
+where
+    GPIO: Gpio,
+    INDEX: Index,
+{
+}
+
+macro_rules! af {
+    ($i:literal, $Ui:ty, $AFi:ty, $IntoAfi:ident, $into_afi:ident) => {
+        paste::paste! {
+            #[doc = "Alternate function " $i " (type state)"]
+            pub type $AFi = Alternate<$Ui>;
+        }
+
+        paste::paste! {
+            #[doc = "Marker trait for pins with alternate function " $i " mapping"]
+            pub trait $IntoAfi {
+                /// Associated AFR register
+                type AFR: Afr;
+            }
+        }
+
+        impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
+        where
+            Self: $IntoAfi,
+            GPIO: GpioStatic,
+            INDEX: Unsigned,
+        {
+            /// Configures the pin to operate as an alternate function pin
+            pub fn $into_afi(
+                self,
+                moder: &mut GPIO::MODER,
+                afr: &mut <Self as $IntoAfi>::AFR,
+            ) -> Pin<GPIO, INDEX, $AFi> {
+                moder.alternate(self.index.index());
+                afr.afx(self.index.index(), $i);
+                self.into_mode()
+            }
+        }
+    };
+
+    ([$($i:literal),+ $(,)?]) => {
+        paste::paste! {
             $(
-                /// GPIO Bank
-                $GPIOX,
+                af!($i, [<U $i>], [<AF $i>], [<IntoAf $i>],  [<into_af $i>]);
             )+
         }
+    };
+}
 
-        /// Fully erased pin
-        ///
-        /// This moves the pin type information to be known
-        /// at runtime, and erases the specific compile time type of the GPIO.
-        /// It does only matter, that it is a GPIO pin with a specific MODE.
-        ///
-        /// See [examples/gpio_erased.rs] as an example.
-        ///
-        /// [examples/gpio_erased.rs]: https://github.com/stm32-rs/stm32f3xx-hal/blob/v0.6.1/examples/gpio_erased.rs
-        pub struct PXx<MODE> {
-            i: u8,
-            gpio: Gpio,
-            _mode: PhantomData<MODE>,
-        }
+af!([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
 
-        impl<MODE> OutputPin for PXx<Output<MODE>> {
-            type Error = Infallible;
-
-            fn set_high(&mut self) -> Result<(), Self::Error> {
-                // NOTE(unsafe, write) atomic write to a stateless register
-                unsafe {
-                    match &self.gpio {
-                        $(
-                            Gpio::$GPIOX => (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << self.i)),
-                        )+
-                    }
-                }
-                Ok(())
-            }
-
-            fn set_low(&mut self) -> Result<(), Self::Error> {
-                // NOTE(unsafe, write) atomic write to a stateless register
-                unsafe {
-                    match &self.gpio {
-                        $(
-                            Gpio::$GPIOX => (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + self.i))),
-                        )+
-                    }
-                }
-                Ok(())
-            }
-        }
-
-        #[cfg(feature = "unproven")]
-        impl<MODE> InputPin for PXx<Input<MODE>> {
-            type Error = Infallible;
-
-            fn is_high(&self) -> Result<bool, Self::Error> {
-                Ok(!self.is_low()?)
-            }
-
-             fn is_low(&self) -> Result<bool, Self::Error> {
-                // NOTE(unsafe) atomic read with no side effects
-                Ok(unsafe {
-                    match &self.gpio {
-                        $(
-                            Gpio::$GPIOX => (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0,
-                        )+
-                    }
-                })
-            }
-        }
-
-        #[cfg(feature = "unproven")]
-        impl InputPin for PXx<Output<OpenDrain>> {
-            type Error = Infallible;
-
-            fn is_high(&self) -> Result<bool, Self::Error> {
-                Ok(!self.is_low()?)
-            }
-
-             fn is_low(&self) -> Result<bool, Self::Error> {
-                // NOTE(unsafe) atomic read with no side effects
-                Ok(unsafe {
-                    match &self.gpio {
-                        $(
-                            Gpio::$GPIOX => (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0,
-                        )+
-                    }
-                })
-            }
-        }
-
-        #[cfg(feature = "unproven")]
-        impl <MODE> StatefulOutputPin for PXx<Output<MODE>> {
-            fn is_set_high(&self) -> Result<bool, Self::Error> {
-                self.is_set_low().map(|b| !b)
-            }
-
-            fn is_set_low(&self) -> Result<bool, Self::Error> {
-                // NOTE(unsafe) atomic read with no side effects
-                Ok(unsafe {
-                    match &self.gpio {
-                        $(
-                            Gpio::$GPIOX => (*$GPIOX::ptr()).odr.read().bits() & (1 << self.i) == 0,
-                        )+
-                    }
-                })
-            }
-        }
-
-        #[cfg(feature = "unproven")]
-        impl <MODE> toggleable::Default for PXx<Output<MODE>> {}
-
+macro_rules! gpio_trait {
+    ([$($gpioy:ident),+ $(,)?]) => {
         $(
-            paste::paste!{
-                #[doc = "All Pins and associated functions for GPIO Bank: `" $GPIOX "`"]
-                pub mod $gpiox {
-                    use core::marker::PhantomData;
-                    use core::convert::Infallible;
+            impl GpioRegExt for crate::pac::$gpioy::RegisterBlock {
+                #[inline(always)]
+                fn is_low(&self, i: u8) -> bool {
+                    self.idr.read().bits() & (1 << i) == 0
+                }
 
-                    use crate::hal::digital::v2::OutputPin;
-                    #[cfg(feature = "unproven")]
-                    use crate::hal::digital::v2::InputPin;
-                    #[cfg(feature = "unproven")]
-                    use crate::hal::digital::v2::StatefulOutputPin;
-                    #[cfg(feature = "unproven")]
-                    use crate::hal::digital::v2::toggleable;
-                    use crate::pac::{$gpioy, $GPIOX};
+                #[inline(always)]
+                fn is_set_low(&self, i: u8) -> bool {
+                    self.odr.read().bits() & (1 << i) == 0
+                }
 
-                    use crate::rcc::AHB;
-                    #[allow(unused_imports)]
-                    use super::{AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10, AF11, AF12, AF13, AF14, AF15};
-                    use super::{
-                        Floating, GpioExt, Input, OpenDrain, Output, Analog,
-                        PullDown, PullUp, PushPull,
-                        PXx, Gpio,
-                    };
+                #[inline(always)]
+                fn set_high(&self, i: u8) {
+                    // NOTE(unsafe, write) atomic write to a stateless register
+                    unsafe { self.bsrr.write(|w| w.bits(1 << i)); }
+                }
 
-                    /// GPIO parts
-                    pub struct Parts {
-                        /// Opaque AFRH register
-                        pub afrh: AFRH,
-                        /// Opaque AFRL register
-                        pub afrl: AFRL,
-                        /// Opaque MODER register
-                        pub moder: MODER,
-                        /// Opaque OTYPER register
-                        pub otyper: OTYPER,
-                        /// Opaque PUPDR register
-                        pub pupdr: PUPDR,
-                        $(
-                            /// Pin
-                            pub $pxi: $PXi<$MODE>,
-                        )+
-                    }
-
-                    impl GpioExt for $GPIOX {
-                        type Parts = Parts;
-
-                        fn split(self, ahb: &mut AHB) -> Parts {
-                            ahb.enr().modify(|_, w| w.$iopxenr().set_bit());
-                            ahb.rstr().modify(|_, w| w.$iopxrst().set_bit());
-                            ahb.rstr().modify(|_, w| w.$iopxrst().clear_bit());
-
-                            Parts {
-                                afrh: AFRH { _0: () },
-                                afrl: AFRL { _0: () },
-                                moder: MODER { _0: () },
-                                otyper: OTYPER { _0: () },
-                                pupdr: PUPDR { _0: () },
-                                $(
-                                    $pxi: $PXi { _mode: PhantomData },
-                                )+
-                            }
-                        }
-                    }
-
-                    /// Opaque AFRL register
-                    pub struct AFRL {
-                        _0: (),
-                    }
-
-                    impl AFRL {
-                        // A couple device/port combos have no valid alternate functions:
-                        //   - stm32f303 GPIOG and GPIOH
-                        //   - stm32f318 GPIOC, GPIOD, and GPIOE
-                        //   - stm32f328 GPIOE
-                        #[allow(dead_code)]
-                        pub(crate) fn afr(&mut self) -> &$gpioy::AFRL {
-                            unsafe { &(*$GPIOX::ptr()).afrl }
-                        }
-                    }
-
-                    /// Opaque AFRH register
-                    pub struct AFRH {
-                        _0: (),
-                    }
-
-                    impl AFRH {
-                        // stm32f301 and stm32f318 don't have any high pins for GPIOF
-                        #[allow(dead_code)]
-                        pub(crate) fn afr(&mut self) -> &$gpioy::AFRH {
-                            unsafe { &(*$GPIOX::ptr()).afrh }
-                        }
-                    }
-
-                    /// Opaque MODER register
-                    pub struct MODER {
-                        _0: (),
-                    }
-
-                    impl MODER {
-                        pub(crate) fn moder(&mut self) -> &$gpioy::MODER {
-                            unsafe { &(*$GPIOX::ptr()).moder }
-                        }
-                    }
-
-                    /// Opaque OTYPER register
-                    pub struct OTYPER {
-                        _0: (),
-                    }
-
-                    impl OTYPER {
-                        pub(crate) fn otyper(&mut self) -> &$gpioy::OTYPER {
-                            unsafe { &(*$GPIOX::ptr()).otyper }
-                        }
-                    }
-
-                    /// Opaque PUPDR register
-                    pub struct PUPDR {
-                        _0: (),
-                    }
-
-                    impl PUPDR {
-                        pub(crate) fn pupdr(&mut self) -> &$gpioy::PUPDR {
-                            unsafe { &(*$GPIOX::ptr()).pupdr }
-                        }
-                    }
-
-                    /// Partially erased pin
-                    pub struct $PXx<MODE> {
-                        i: u8,
-                        _mode: PhantomData<MODE>,
-                    }
-
-                    impl<MODE> $PXx<MODE> {
-                        /// Erases the port letter from the type
-                        ///
-                        /// This is useful when you want to collect the pins into an array where you
-                        /// need all the elements to have the same type
-                        pub fn downgrade(self) -> PXx<MODE> {
-                            PXx {
-                                i: self.i,
-                                gpio: Gpio::$GPIOX,
-                                _mode: self._mode,
-                            }
-                        }
-                    }
-
-                    impl<MODE> OutputPin for $PXx<Output<MODE>> {
-                        type Error = Infallible;
-
-                        fn set_high(&mut self) -> Result<(), Self::Error> {
-                            // NOTE(unsafe, write) atomic write to a stateless register
-                            unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << self.i)) }
-                            Ok(())
-                        }
-
-                        fn set_low(&mut self) -> Result<(), Self::Error> {
-                            // NOTE(unsafe, write) atomic write to a stateless register
-                            unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + self.i))) }
-                            Ok(())
-                        }
-                    }
-
-                    #[cfg(feature = "unproven")]
-                    impl<MODE> InputPin for $PXx<Input<MODE>> {
-                        type Error = Infallible;
-
-                        fn is_high(&self) -> Result<bool, Self::Error> {
-                            Ok(!self.is_low()?)
-                        }
-
-                        fn is_low(&self) -> Result<bool, Self::Error> {
-                            // NOTE(unsafe) atomic read with no side effects
-                            Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 })
-                        }
-                    }
-
-                    #[cfg(feature = "unproven")]
-                    impl InputPin for $PXx<Output<OpenDrain>> {
-                        type Error = Infallible;
-
-                        fn is_high(&self) -> Result<bool, Self::Error> {
-                            Ok(!self.is_low()?)
-                        }
-
-                        fn is_low(&self) -> Result<bool, Self::Error> {
-                            // NOTE(unsafe) atomic read with no side effects
-                            Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 })
-                        }
-                    }
-
-                    #[cfg(feature = "unproven")]
-                    impl<MODE> StatefulOutputPin for $PXx<Output<MODE>> {
-                        fn is_set_high(&self) -> Result<bool, Self::Error> {
-                            self.is_set_low().map(|b| !b)
-                        }
-
-                        fn is_set_low(&self) -> Result<bool, Self::Error> {
-                            // NOTE(unsafe) atomic read with no side effects
-                            Ok(unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << self.i) == 0 })
-                        }
-                    }
-
-                    #[cfg(feature = "unproven")]
-                    impl<MODE> toggleable::Default for $PXx<Output<MODE>> {}
-
-                    $(
-                        paste::paste! {
-                            #[doc = "Pin `" $PXi "`"]
-                            pub struct $PXi<MODE> {
-                                _mode: PhantomData<MODE>,
-                            }
-                        }
-
-                        impl<MODE> $PXi<MODE> {
-                            $(
-                                // /// Configures the pin to serve as a specific alternate function
-                                paste::paste!{
-                                    #[doc = "Configures `" $PXi "` to serve as alternate function: `" $AFi "`"]
-                                    pub fn $into_afi(
-                                        self,
-                                        moder: &mut MODER,
-                                        afr: &mut $AFR,
-                                    ) -> $PXi<$AFi> {
-                                        moder.moder().modify(|_, w| w.$moderi().alternate());
-                                        afr.afr().modify(|_, w| w.$afri().$afi());
-                                        $PXi { _mode: PhantomData }
-                                    }
-                                }
-                            )*
-
-                            /// Configures the pin to operate as a floating input pin
-                            pub fn into_floating_input(
-                                self,
-                                moder: &mut MODER,
-                                pupdr: &mut PUPDR,
-                            ) -> $PXi<Input<Floating>> {
-                                moder.moder().modify(|_, w| w.$moderi().input());
-                                pupdr.pupdr().modify(|_,w| w.$pupdri().floating());
-                                $PXi { _mode: PhantomData }
-                            }
-
-                            /// Configures the pin to operate as a pulled down input pin
-                            pub fn into_pull_down_input(
-                                self,
-                                moder: &mut MODER,
-                                pupdr: &mut PUPDR,
-                            ) -> $PXi<Input<PullDown>> {
-                                moder.moder().modify(|_, w| w.$moderi().input());
-                                pupdr.pupdr().modify(|_,w| w.$pupdri().pull_down());
-                                $PXi { _mode: PhantomData }
-                            }
-
-                            /// Configures the pin to operate as a pulled up input pin
-                            pub fn into_pull_up_input(
-                                self,
-                                moder: &mut MODER,
-                                pupdr: &mut PUPDR,
-                            ) -> $PXi<Input<PullUp>> {
-                                moder.moder().modify(|_, w| w.$moderi().input());
-                                pupdr.pupdr().modify(|_,w| w.$pupdri().pull_up());
-                                $PXi { _mode: PhantomData }
-                            }
-
-                            /// Configures the pin to operate as an open drain output pin
-                            pub fn into_open_drain_output(
-                                self,
-                                moder: &mut MODER,
-                                otyper: &mut OTYPER,
-                            ) -> $PXi<Output<OpenDrain>> {
-                                moder.moder().modify(|_, w| w.$moderi().output());
-                                otyper.otyper().modify(|_, w| w.$oti().open_drain());
-                                $PXi { _mode: PhantomData }
-                            }
-
-                            /// Configures the pin to operate as an push pull output pin
-                            pub fn into_push_pull_output(
-                                self,
-                                moder: &mut MODER,
-                                otyper: &mut OTYPER,
-                            ) -> $PXi<Output<PushPull>> {
-                                moder.moder().modify(|_, w| w.$moderi().output());
-                                otyper.otyper().modify(|_, w| w.$oti().push_pull());
-                                $PXi { _mode: PhantomData }
-                            }
-
-                            /// Configures the pin to operate as analog, with disabled schmitt trigger.
-                            /// This mode is suitable when the pin is connected to the DAC or ADC.
-                            pub fn into_analog(
-                                self,
-                                moder: &mut MODER,
-                                pupdr: &mut PUPDR,
-                            ) -> $PXi<Analog> {
-                                moder.moder().modify(|_, w| w.$moderi().analog());
-                                pupdr.pupdr().modify(|_,w| w.$pupdri().floating());
-                                $PXi { _mode: PhantomData }
-                            }
-                        }
-
-                        impl $PXi<Output<OpenDrain>> {
-                            /// Enables / disables the internal pull up
-                            pub fn internal_pull_up(&mut self, pupdr: &mut PUPDR, on: bool) {
-                                pupdr.pupdr().modify(|_, w| if on {
-                                    w.$pupdri().pull_up()
-                                } else {
-                                    w.$pupdri().floating()
-                                });
-                            }
-                        }
-
-                        impl<MODE> $PXi<Output<MODE>> {
-                            /// Erases the pin number from the type
-                            ///
-                            /// This is useful when you want to collect the pins into an array where you
-                            /// need all the elements to have the same type
-                            pub fn downgrade(self) -> $PXx<Output<MODE>> {
-                                $PXx {
-                                    i: $i,
-                                    _mode: self._mode,
-                                }
-                            }
-                        }
-
-                        impl<MODE> $PXi<Input<MODE>> {
-                            /// Erases the pin number from the type
-                            ///
-                            /// This is useful when you want to collect the pins into an array where you
-                            /// need all the elements to have the same type
-                            pub fn downgrade(self) -> $PXx<Input<MODE>> {
-                                $PXx {
-                                    i: $i,
-                                    _mode: self._mode,
-                                }
-                            }
-                        }
-
-                        impl<MODE> OutputPin for $PXi<Output<MODE>> {
-                            type Error = Infallible;
-
-                            fn set_high(&mut self) -> Result<(), Self::Error> {
-                                // NOTE(unsafe, write) atomic write to a stateless register
-                                unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.$bsi().set()) }
-                                Ok(())
-                            }
-
-                            fn set_low(&mut self) -> Result<(), Self::Error> {
-                                // NOTE(unsafe, write) atomic write to a stateless register
-                                unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.$bri().reset()) }
-                                Ok(())
-                            }
-                        }
-
-                        #[cfg(feature = "unproven")]
-                        impl<MODE> InputPin for $PXi<Input<MODE>> {
-                            type Error = Infallible;
-
-                            fn is_high(&self) -> Result<bool, Self::Error> {
-                                Ok(!self.is_low()?)
-                            }
-
-                            fn is_low(&self) -> Result<bool, Self::Error> {
-                                // NOTE(unsafe) atomic read with no side effects
-                                Ok(unsafe { (*$GPIOX::ptr()).idr.read().$idri().is_low()})
-                            }
-                        }
-
-                        #[cfg(feature = "unproven")]
-                        impl InputPin for $PXi<Output<OpenDrain>> {
-                            type Error = Infallible;
-
-                            fn is_high(&self) -> Result<bool, Self::Error> {
-                                Ok(!self.is_low()?)
-                            }
-
-                            fn is_low(&self) -> Result<bool, Self::Error> {
-                                // NOTE(unsafe) atomic read with no side effects
-                                Ok(unsafe { (*$GPIOX::ptr()).idr.read().$idri().is_low()})
-                            }
-                        }
-
-                        #[cfg(feature = "unproven")]
-                        impl<MODE> StatefulOutputPin for $PXi<Output<MODE>> {
-                            fn is_set_high(&self) -> Result<bool, Self::Error> {
-                                self.is_set_low().map(|b| !b)
-                            }
-
-                            fn is_set_low(&self) -> Result<bool, Self::Error> {
-                                // NOTE(unsafe) atomic read with no side effects
-                                Ok(unsafe { (*$GPIOX::ptr()).odr.read().$odri().is_low()})
-                            }
-                        }
-
-                        #[cfg(feature = "unproven")]
-                        impl<MODE> toggleable::Default for $PXi<Output<MODE>> {}
-                    )+
+                #[inline(always)]
+                fn set_low(&self, i: u8) {
+                    // NOTE(unsafe, write) atomic write to a stateless register
+                    unsafe { self.bsrr.write(|w| w.bits(1 << (16 + i))); }
                 }
             }
         )+
+    }
+}
+
+macro_rules! afr_trait {
+    ($GPIOX:ident, $AFR:ty, $afr:ident, $offset:expr) => {
+        impl Afr for $AFR {
+            #[inline]
+            fn afx(&mut self, i: u8, x: u8) {
+                let i = i - $offset;
+                unsafe {
+                    (*$GPIOX::ptr()).$afr.modify(|r, w| {
+                        w.bits(r.bits() & !(u32::MAX >> 32 - 4 << 4 * i) | (x as u32) << 4 * i)
+                    });
+                }
+            }
+        }
+    };
+}
+
+macro_rules! r_trait {
+    (
+        ($GPIOX:ident, $gpioy:ident::$xr:ident::$enum:ident, $bits:expr);
+        impl $Xr:ident for $XR:ty {
+            $(
+                fn $fn:ident { $VARIANT:ident }
+            )+
+        }
+    ) => {
+        impl $Xr for $XR {
+            $(
+                #[inline]
+                fn $fn(&mut self, i: u8) {
+                    unsafe {
+                        (*$GPIOX::ptr()).$xr.modify(|r, w| {
+                            w.bits(
+                                r.bits() & !(u32::MAX >> 32 - $bits << $bits * i)
+                                    | ($gpioy::$xr::$enum::$VARIANT as u32) << $bits * i
+                            )
+                        });
+                    }
+                }
+            )+
+        }
+    };
+}
+
+macro_rules! gpio {
+    ({
+        GPIO: $GPIOX:ident,
+        gpio: $gpiox:ident,
+        Gpio: $Gpiox:ty,
+        gpio_mapped: $gpioy:ident,
+        gpio_mapped_ioen: $iopxen:ident,
+        gpio_mapped_iorst: $iopxrst:ident,
+        partially_erased_pin: $PXx:ty,
+        pins: {$(
+            $PXi:ty: (
+                $pxi:ident, $Ui:ty, $MODE:ty, $AFR:ident, [$($IntoAfi:ident),*],
+            ),
+        )+},
+    }) => {
+        paste::paste!{
+            #[doc = "GPIO port " $GPIOX " (type state)"]
+            pub struct $Gpiox;
+        }
+
+        impl private::Gpio for $Gpiox {
+            type Reg = crate::pac::$gpioy::RegisterBlock;
+
+            #[inline(always)]
+            fn ptr(&self) -> *const Self::Reg {
+                crate::pac::$GPIOX::ptr()
+            }
+        }
+
+        impl Gpio for $Gpiox {}
+
+        impl GpioStatic for $Gpiox {
+            type MODER = $gpiox::MODER;
+            type OTYPER = $gpiox::OTYPER;
+            type PUPDR = $gpiox::PUPDR;
+        }
+
+        paste::paste!{
+            #[doc = "All Pins and associated registers for GPIO port " $GPIOX]
+            pub mod $gpiox {
+                use core::marker::PhantomData;
+
+                use crate::{
+                    pac::{$gpioy, $GPIOX},
+                    rcc::AHB,
+                };
+
+                use super::{Afr, $Gpiox, GpioExt, Moder, Otyper, Pin, Pupdr, Ux};
+
+                #[allow(unused_imports)]
+                use super::{
+                    Input, Floating, PullUp, PullDown, Output, PushPull, OpenDrain, Analog,
+                    AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10, AF11, AF12, AF13, AF14, AF15,
+                    IntoAf0, IntoAf1, IntoAf2, IntoAf3, IntoAf4, IntoAf5, IntoAf6, IntoAf7,
+                    IntoAf8, IntoAf9, IntoAf10, IntoAf11, IntoAf12, IntoAf13, IntoAf14, IntoAf15,
+                };
+
+                #[allow(unused_imports)]
+                use typenum::{
+                    U0, U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15
+                };
+
+                /// GPIO parts
+                pub struct Parts {
+                    /// Opaque AFRH register
+                    pub afrh: AFRH,
+                    /// Opaque AFRL register
+                    pub afrl: AFRL,
+                    /// Opaque MODER register
+                    pub moder: MODER,
+                    /// Opaque OTYPER register
+                    pub otyper: OTYPER,
+                    /// Opaque PUPDR register
+                    pub pupdr: PUPDR,
+                    $(
+                        #[doc = "Pin " $PXi]
+                        pub $pxi: $PXi<$MODE>,
+                    )+
+                }
+
+                impl GpioExt for $GPIOX {
+                    type Parts = Parts;
+
+                    fn split(self, ahb: &mut AHB) -> Parts {
+                        ahb.enr().modify(|_, w| w.$iopxen().set_bit());
+                        ahb.rstr().modify(|_, w| w.$iopxrst().set_bit());
+                        ahb.rstr().modify(|_, w| w.$iopxrst().clear_bit());
+
+                        Parts {
+                            afrh: AFRH(()),
+                            afrl: AFRL(()),
+                            moder: MODER(()),
+                            otyper: OTYPER(()),
+                            pupdr: PUPDR(()),
+                            $(
+                                $pxi: $PXi {
+                                    gpio: $Gpiox,
+                                    index: $Ui::new(),
+                                    _mode: PhantomData,
+                                },
+                            )+
+                        }
+                    }
+                }
+
+                /// Opaque AFRH register
+                pub struct AFRH(());
+
+                afr_trait!($GPIOX, AFRH, afrh, 8);
+
+                /// Opaque AFRL register
+                pub struct AFRL(());
+
+                afr_trait!($GPIOX, AFRL, afrl, 0);
+
+                /// Opaque MODER register
+                pub struct MODER(());
+
+                r_trait! {
+                    ($GPIOX, $gpioy::moder::MODER15_A, 2);
+                    impl Moder for MODER {
+                        fn input { INPUT }
+                        fn output { OUTPUT }
+                        fn alternate { ALTERNATE }
+                        fn analog { ANALOG }
+                    }
+                }
+
+                /// Opaque OTYPER register
+                pub struct OTYPER(());
+
+                r_trait! {
+                    ($GPIOX, $gpioy::otyper::OT15_A, 1);
+                    impl Otyper for OTYPER {
+                        fn push_pull { PUSHPULL }
+                        fn open_drain { OPENDRAIN }
+                    }
+                }
+
+                /// Opaque PUPDR register
+                pub struct PUPDR(());
+
+                r_trait! {
+                    ($GPIOX, $gpioy::pupdr::PUPDR15_A, 2);
+                    impl Pupdr for PUPDR {
+                        fn floating { FLOATING }
+                        fn pull_up { PULLUP }
+                        fn pull_down { PULLDOWN }
+                    }
+                }
+
+                /// Partially erased pin
+                pub type $PXx<MODE> = Pin<$Gpiox, Ux, MODE>;
+
+                $(
+                    #[doc = "Pin " $PXi]
+                    pub type $PXi<MODE> = Pin<$Gpiox, $Ui, MODE>;
+
+                    $(
+                        impl<MODE> $IntoAfi for $PXi<MODE> {
+                            type AFR = $AFR;
+                        }
+                    )*
+                )+
+            }
+        }
     };
 
-    ([
-        $({
-            port: ($X:ident/$x:ident, pac: $gpioy:ident),
-            pins: [
-                $( $i:expr => {
-                    reset: $mode:ty,
-                    afr: $LH:ident/$lh:ident,
-                    af: [$( $af:expr ),*]
-                }, )+
-            ],
-        },)+
-    ]) => {
-        paste::item! {
-            gpio!([
-                $({
+    ({
+        pacs: $pacs:tt,
+        ports: [$(
+            {
+                port: ($X:ident/$x:ident, pac: $gpioy:ident),
+                pins: [$(
+                    $i:literal => {
+                        reset: $MODE:ty,
+                        afr: $LH:ident,
+                        af: [$( $af:literal ),*]
+                    },
+                )+],
+            },
+        )+],
+    }) => {
+        paste::paste! {
+            gpio_trait!($pacs);
+            $(
+                gpio!({
                     GPIO: [<GPIO $X>],
                     gpio: [<gpio $x>],
+                    Gpio: [<Gpio $x>],
                     gpio_mapped: $gpioy,
-                    gpio_mapped_ioenr: [<iop $x en>],
+                    gpio_mapped_ioen: [<iop $x en>],
                     gpio_mapped_iorst: [<iop $x rst>],
                     partially_erased_pin: [<P $X x>],
-                    pins: [
-                        $([<P $X $i>]: (
-                            [<p $x $i>], $i, $mode, [<moder $i>], [<AFR $LH>], [<afr $lh $i>],
-                            [<bs $i>], [<br $i>], [<odr $i>], [<idr $i>], [<pupdr $i>], [<ot $i>],
-                            { $( [<AF $af>]: ([<into_af $af>], [<af $af>]), )* },
-                        ),)+
-                    ],
-                },)+
-            ]);
+                    pins: {$(
+                        [<P $X $i>]: (
+                            [<p $x $i>], [<U $i>], $MODE, [<AFR $LH>], [$([<IntoAf $af>]),*],
+                        ),
+                    )+},
+                });
+            )+
         }
     };
 }
@@ -695,560 +710,575 @@ macro_rules! gpio {
 // STM32CubeMX DB release: DB.6.0.0
 
 #[cfg(feature = "gpio-f302")]
-gpio!([
-    {
-        port: (A/a, pac: gpioa),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 3, 7, 9, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 8, 9, 15] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 9, 15] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [3, 6, 7, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 6, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 6, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [0, 3, 4, 5, 6, 7, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [2, 3, 4, 5, 6, 7, 9, 10, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 4, 5, 6, 7, 8, 10, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [5, 6, 7, 9, 11, 12, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 5, 6, 7, 8, 9, 11, 15] },
-            13 => { reset: AF0, afr: H/h, af: [0, 1, 3, 5, 7, 15] },
-            14 => { reset: AF0, afr: H/h, af: [0, 3, 4, 6, 7, 15] },
-            15 => { reset: AF0, afr: H/h, af: [0, 1, 3, 4, 6, 7, 9, 15] },
-        ],
-    },
-    {
-        port: (B/b, pac: gpiob),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [3, 6, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [3, 6, 8, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [3, 15] },
-            3 => { reset: AF0, afr: L/l, af: [0, 1, 3, 6, 7, 15] },
-            4 => { reset: AF0, afr: L/l, af: [0, 1, 3, 6, 7, 10, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 4, 6, 7, 8, 10, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 4, 7, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 4, 7, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 4, 7, 9, 12, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 4, 6, 7, 8, 9, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [3, 4, 5, 6, 7, 15] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [3, 5, 6, 7, 15] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5, 6, 7, 15] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [0, 1, 2, 4, 5, 15] },
-        ],
-    },
-    {
-        port: (C/c, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 6] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 7] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 6, 7] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 6] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 6, 7] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 6, 7] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 6, 7] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [4] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [] },
-        ],
-    },
-    {
-        port: (D/d, pac: gpioc),
-        pins: [
-            2 => { reset: Input<Floating>, afr: L/l, af: [1] },
-        ],
-    },
-    {
-        port: (F/f, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [4, 5, 6] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [4, 5] },
-        ],
-    },
-]);
+gpio!({
+    pacs: [gpioa, gpiob, gpioc],
+    ports: [
+        {
+            port: (A/a, pac: gpioa),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [0, 1, 3, 7, 9, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 15] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
+                4 => { reset: Input<Floating>, afr: L, af: [3, 6, 7, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 3, 6, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 3, 6, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [0, 3, 4, 5, 6, 7, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [2, 3, 4, 5, 6, 7, 9, 10, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 5, 6, 7, 8, 10, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [5, 6, 7, 9, 11, 12, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 5, 6, 7, 8, 9, 11, 15] },
+                13 => { reset: AF0, afr: H, af: [0, 1, 3, 5, 7, 15] },
+                14 => { reset: AF0, afr: H, af: [0, 3, 4, 6, 7, 15] },
+                15 => { reset: AF0, afr: H, af: [0, 1, 3, 4, 6, 7, 9, 15] },
+            ],
+        },
+        {
+            port: (B/b, pac: gpiob),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [3, 6, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [3, 6, 8, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [3, 15] },
+                3 => { reset: AF0, afr: L, af: [0, 1, 3, 6, 7, 15] },
+                4 => { reset: AF0, afr: L, af: [0, 1, 3, 6, 7, 10, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 4, 6, 7, 8, 10, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 3, 4, 7, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 3, 4, 7, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 7, 9, 12, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 4, 6, 7, 8, 9, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [3, 4, 5, 6, 7, 15] },
+                13 => { reset: Input<Floating>, afr: H, af: [3, 5, 6, 7, 15] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 6, 7, 15] },
+                15 => { reset: Input<Floating>, afr: H, af: [0, 1, 2, 4, 5, 15] },
+            ],
+        },
+        {
+            port: (C/c, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 6] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 6, 7] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 6] },
+                8 => { reset: Input<Floating>, afr: H, af: [1] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 3, 5] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 6, 7] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 6, 7] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 6, 7] },
+                13 => { reset: Input<Floating>, afr: H, af: [4] },
+                14 => { reset: Input<Floating>, afr: H, af: [] },
+                15 => { reset: Input<Floating>, afr: H, af: [] },
+            ],
+        },
+        {
+            port: (D/d, pac: gpioc),
+            pins: [
+                2 => { reset: Input<Floating>, afr: L, af: [1] },
+            ],
+        },
+        {
+            port: (F/f, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [4, 5, 6] },
+                1 => { reset: Input<Floating>, afr: L, af: [4, 5] },
+            ],
+        },
+    ],
+});
 
 #[cfg(feature = "gpio-f303e")]
-gpio!([
-    {
-        port: (A/a, pac: gpioa),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 8, 9, 10, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 3, 7, 9, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 8, 9, 15] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 9, 15] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 5, 6, 7, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 5, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 6, 8, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 6, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [0, 3, 4, 5, 6, 7, 8, 10, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [2, 3, 4, 5, 6, 7, 8, 9, 10, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 4, 5, 6, 7, 8, 10, 11, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [5, 6, 7, 8, 9, 10, 11, 12, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 5, 6, 7, 8, 9, 10, 11, 15] },
-            13 => { reset: AF0, afr: H/h, af: [0, 1, 3, 5, 7, 10, 15] },
-            14 => { reset: AF0, afr: H/h, af: [0, 3, 4, 5, 6, 7, 15] },
-            15 => { reset: AF0, afr: H/h, af: [0, 1, 2, 3, 4, 5, 6, 7, 9, 15] },
-        ],
-    },
-    {
-        port: (B/b, pac: gpiob),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 4, 6, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 4, 6, 8, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [3, 15] },
-            3 => { reset: AF0, afr: L/l, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
-            4 => { reset: AF0, afr: L/l, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 6, 7, 8, 10, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 7, 10, 12, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 4, 7, 8, 9, 10, 12, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 4, 6, 7, 8, 9, 10, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [3, 4, 5, 6, 7, 15] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [3, 5, 6, 7, 15] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5, 6, 7, 15] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [0, 1, 2, 4, 5, 15] },
-        ],
-    },
-    {
-        port: (C/c, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 6] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 7] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 6, 7] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 6, 7] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 4, 7] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 4, 5, 6] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 4, 5, 6, 7] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 4, 5, 6, 7] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 4, 5, 6, 7] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1, 4] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1] },
-        ],
-    },
-    {
-        port: (D/d, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 7, 12] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 4, 6, 7, 12] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 5] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7, 12] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7, 12] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 7, 12] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7, 12] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7, 12] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 7, 12] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 7, 12] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 7, 12] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 7, 12] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 7, 12] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 12] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 12] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 6, 12] },
-        ],
-    },
-    {
-        port: (E/e, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 6, 7, 12] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 4, 6, 7, 12] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3, 5, 6, 12] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3, 5, 6, 12] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3, 5, 6, 12] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3, 5, 6, 12] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 5, 6, 12] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 12] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 12] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 12] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 5, 12] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 5, 12] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 5, 12] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 5, 6, 12] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 7, 12] },
-        ],
-    },
-    {
-        port: (F/f, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 4, 5, 6] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 4, 5] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 12] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 7, 12] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 12] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 5, 12] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 5, 12] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 2] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 12] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 12] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 12] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 12] },
-        ],
-    },
-    {
-        port: (G/g, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 12] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 12] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 12] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 12] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 12] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 12] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1, 12] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 12] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1] },
-        ],
-    },
-    {
-        port: (H/h, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 12] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1] },
-        ],
-    },
-]);
+gpio!({
+    pacs: [gpioa, gpiob, gpioc],
+    ports: [
+        {
+            port: (A/a, pac: gpioa),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 10, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [0, 1, 3, 7, 9, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 15] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
+                4 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 6, 7, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 5, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [0, 3, 4, 5, 6, 7, 8, 10, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [2, 3, 4, 5, 6, 7, 8, 9, 10, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 5, 6, 7, 8, 10, 11, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [5, 6, 7, 8, 9, 10, 11, 12, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 5, 6, 7, 8, 9, 10, 11, 15] },
+                13 => { reset: AF0, afr: H, af: [0, 1, 3, 5, 7, 10, 15] },
+                14 => { reset: AF0, afr: H, af: [0, 3, 4, 5, 6, 7, 15] },
+                15 => { reset: AF0, afr: H, af: [0, 1, 2, 3, 4, 5, 6, 7, 9, 15] },
+            ],
+        },
+        {
+            port: (B/b, pac: gpiob),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [2, 3, 4, 6, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [2, 3, 4, 6, 8, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [3, 15] },
+                3 => { reset: AF0, afr: L, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                4 => { reset: AF0, afr: L, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 8, 10, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 7, 10, 12, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 4, 7, 8, 9, 10, 12, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 6, 7, 8, 9, 10, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [3, 4, 5, 6, 7, 15] },
+                13 => { reset: Input<Floating>, afr: H, af: [3, 5, 6, 7, 15] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 6, 7, 15] },
+                15 => { reset: Input<Floating>, afr: H, af: [0, 1, 2, 4, 5, 15] },
+            ],
+        },
+        {
+            port: (C/c, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 3] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 6] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 7] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 4, 5, 6] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
+                13 => { reset: Input<Floating>, afr: H, af: [1, 4] },
+                14 => { reset: Input<Floating>, afr: H, af: [1] },
+                15 => { reset: Input<Floating>, afr: H, af: [1] },
+            ],
+        },
+        {
+            port: (D/d, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 7, 12] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 6, 7, 12] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 7, 12] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7, 12] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 7, 12] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 7, 12] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 7, 12] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 7, 12] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 7, 12] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 7, 12] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 7, 12] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 7, 12] },
+                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 12] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 12] },
+                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 6, 12] },
+            ],
+        },
+        {
+            port: (E/e, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7, 12] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 6, 7, 12] },
+                2 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
+                3 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
+                4 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
+                5 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 5, 6, 12] },
+                6 => { reset: Input<Floating>, afr: L, af: [0, 1, 5, 6, 12] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 2, 5, 12] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 5, 12] },
+                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 5, 12] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 5, 6, 12] },
+                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 7, 12] },
+            ],
+        },
+        {
+            port: (F/f, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 4, 5, 6] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 5] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 12] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 7, 12] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 5, 12] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 5, 12] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 2] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 12] },
+            ],
+        },
+        {
+            port: (G/g, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 12] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 12] },
+                8 => { reset: Input<Floating>, afr: H, af: [1] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 12] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 12] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 12] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 12] },
+                13 => { reset: Input<Floating>, afr: H, af: [1, 12] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 12] },
+                15 => { reset: Input<Floating>, afr: H, af: [1] },
+            ],
+        },
+        {
+            port: (H/h, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 2, 12] },
+                2 => { reset: Input<Floating>, afr: L, af: [1] },
+            ],
+        },
+    ],
+});
 
 #[cfg(feature = "gpio-f303")]
-gpio!([
-    {
-        port: (A/a, pac: gpioa),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 8, 9, 10, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 3, 7, 9, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 8, 9, 15] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 9, 15] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 5, 6, 7, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 5, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 6, 8, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 6, 8, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [0, 4, 5, 6, 7, 8, 10, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [3, 4, 5, 6, 7, 8, 9, 10, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 4, 6, 7, 8, 10, 11, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [6, 7, 8, 9, 10, 11, 12, 14, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 6, 7, 8, 9, 10, 11, 14, 15] },
-            13 => { reset: AF0, afr: H/h, af: [0, 1, 3, 5, 7, 10, 15] },
-            14 => { reset: AF0, afr: H/h, af: [0, 3, 4, 5, 6, 7, 15] },
-            15 => { reset: AF0, afr: H/h, af: [0, 1, 2, 4, 5, 6, 7, 9, 15] },
-        ],
-    },
-    {
-        port: (B/b, pac: gpiob),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 4, 6, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 4, 6, 8, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [3, 15] },
-            3 => { reset: AF0, afr: L/l, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
-            4 => { reset: AF0, afr: L/l, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 5, 7, 10, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 4, 8, 9, 10, 12, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 4, 6, 8, 9, 10, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [3, 4, 5, 6, 7, 15] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [3, 5, 6, 7, 15] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5, 6, 7, 15] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [0, 1, 2, 4, 5, 15] },
-        ],
-    },
-    {
-        port: (C/c, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 3] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 6] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 7] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 6, 7] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 6, 7] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 4, 7] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 4, 5, 6] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 4, 5, 6, 7] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 4, 5, 6, 7] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 4, 5, 6, 7] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [4] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [] },
-        ],
-    },
-    {
-        port: (D/d, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 7] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 4, 6, 7] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 5] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 7] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 7] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 7] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 7] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 7] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 7] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 6] },
-        ],
-    },
-    {
-        port: (E/e, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 7] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 4, 7] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [0, 1] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 2] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 2] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 2] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1, 2] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 6] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 7] },
-        ],
-    },
-    {
-        port: (F/f, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [4, 6] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [4] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 7] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5] },
-        ],
-    },
-]);
+gpio!({
+    pacs: [gpioa, gpiob, gpioc],
+    ports: [
+        {
+            port: (A/a, pac: gpioa),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 10, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [0, 1, 3, 7, 9, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 15] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
+                4 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 6, 7, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 5, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 8, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [0, 4, 5, 6, 7, 8, 10, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [3, 4, 5, 6, 7, 8, 9, 10, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 6, 7, 8, 10, 11, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [6, 7, 8, 9, 10, 11, 12, 14, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 6, 7, 8, 9, 10, 11, 14, 15] },
+                13 => { reset: AF0, afr: H, af: [0, 1, 3, 5, 7, 10, 15] },
+                14 => { reset: AF0, afr: H, af: [0, 3, 4, 5, 6, 7, 15] },
+                15 => { reset: AF0, afr: H, af: [0, 1, 2, 4, 5, 6, 7, 9, 15] },
+            ],
+        },
+        {
+            port: (B/b, pac: gpiob),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [2, 3, 4, 6, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [2, 3, 4, 6, 8, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [3, 15] },
+                3 => { reset: AF0, afr: L, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                4 => { reset: AF0, afr: L, af: [0, 1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 6, 7, 10, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 5, 7, 10, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 4, 8, 9, 10, 12, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 6, 8, 9, 10, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [3, 4, 5, 6, 7, 15] },
+                13 => { reset: Input<Floating>, afr: H, af: [3, 5, 6, 7, 15] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 6, 7, 15] },
+                15 => { reset: Input<Floating>, afr: H, af: [0, 1, 2, 4, 5, 15] },
+            ],
+        },
+        {
+            port: (C/c, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1] },
+                1 => { reset: Input<Floating>, afr: L, af: [1] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 3] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 6] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 7] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 7] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 6, 7] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 7] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 5, 6] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 4, 5, 6, 7] },
+                13 => { reset: Input<Floating>, afr: H, af: [4] },
+                14 => { reset: Input<Floating>, afr: H, af: [] },
+                15 => { reset: Input<Floating>, afr: H, af: [] },
+            ],
+        },
+        {
+            port: (D/d, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 7] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 6, 7] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 7] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 7] },
+                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
+                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 6] },
+            ],
+        },
+        {
+            port: (E/e, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 7] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 4, 7] },
+                2 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3] },
+                3 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3] },
+                4 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3] },
+                5 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3] },
+                6 => { reset: Input<Floating>, afr: L, af: [0, 1] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 2] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 2] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 2] },
+                13 => { reset: Input<Floating>, afr: H, af: [1, 2] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 6] },
+                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 7] },
+            ],
+        },
+        {
+            port: (F/f, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [4, 6] },
+                1 => { reset: Input<Floating>, afr: L, af: [4] },
+                2 => { reset: Input<Floating>, afr: L, af: [1] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 7] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 3, 5] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 5] },
+            ],
+        },
+    ],
+});
 
 #[cfg(feature = "gpio-f333")]
-gpio!([
-    {
-        port: (A/a, pac: gpioa),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 9, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 8, 9, 15] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7, 9, 15] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 5, 7, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 5, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 5, 6, 13, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 5, 6, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [0, 6, 7, 13, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [3, 6, 7, 9, 10, 13, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 6, 7, 8, 10, 13, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [6, 7, 9, 11, 12, 13, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 6, 7, 8, 9, 11, 13, 15] },
-            13 => { reset: AF0, afr: H/h, af: [0, 1, 3, 5, 7, 15] },
-            14 => { reset: AF0, afr: H/h, af: [0, 3, 4, 6, 7, 15] },
-            15 => { reset: AF0, afr: H/h, af: [0, 1, 3, 4, 5, 7, 9, 13, 15] },
-        ],
-    },
-    {
-        port: (B/b, pac: gpiob),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 6, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 6, 8, 13, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [3, 13, 15] },
-            3 => { reset: AF0, afr: L/l, af: [0, 1, 3, 5, 7, 10, 12, 13, 15] },
-            4 => { reset: AF0, afr: L/l, af: [0, 1, 2, 3, 5, 7, 10, 13, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 5, 7, 10, 13, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 4, 7, 12, 13, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 4, 7, 10, 13, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 4, 7, 9, 12, 13, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 4, 6, 7, 8, 9, 13, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7, 13, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7, 13, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [3, 6, 7, 13, 15] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [3, 6, 7, 13, 15] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 6, 7, 13, 15] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 4, 13, 15] },
-        ],
-    },
-    {
-        port: (C/c, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 6] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 7] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 7] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 7] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [4] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [] },
-        ],
-    },
-    {
-        port: (D/d, pac: gpioc),
-        pins: [
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-        ],
-    },
-    {
-        port: (F/f, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [6] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [] },
-        ],
-    },
-]);
+gpio!({
+    pacs: [gpioa, gpiob, gpioc],
+    ports: [
+        {
+            port: (A/a, pac: gpioa),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 8, 9, 15] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 3, 7, 9, 15] },
+                4 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 7, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 5, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 5, 6, 13, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 5, 6, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [0, 6, 7, 13, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [3, 6, 7, 9, 10, 13, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 6, 7, 8, 10, 13, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [6, 7, 9, 11, 12, 13, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 6, 7, 8, 9, 11, 13, 15] },
+                13 => { reset: AF0, afr: H, af: [0, 1, 3, 5, 7, 15] },
+                14 => { reset: AF0, afr: H, af: [0, 3, 4, 6, 7, 15] },
+                15 => { reset: AF0, afr: H, af: [0, 1, 3, 4, 5, 7, 9, 13, 15] },
+            ],
+        },
+        {
+            port: (B/b, pac: gpiob),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [2, 3, 6, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [2, 3, 6, 8, 13, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [3, 13, 15] },
+                3 => { reset: AF0, afr: L, af: [0, 1, 3, 5, 7, 10, 12, 13, 15] },
+                4 => { reset: AF0, afr: L, af: [0, 1, 2, 3, 5, 7, 10, 13, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5, 7, 10, 13, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 3, 4, 7, 12, 13, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 3, 4, 7, 10, 13, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 7, 9, 12, 13, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 4, 6, 7, 8, 9, 13, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 13, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7, 13, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [3, 6, 7, 13, 15] },
+                13 => { reset: Input<Floating>, afr: H, af: [3, 6, 7, 13, 15] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 6, 7, 13, 15] },
+                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 13, 15] },
+            ],
+        },
+        {
+            port: (C/c, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 6] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 3, 7] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 3, 7] },
+                13 => { reset: Input<Floating>, afr: H, af: [4] },
+                14 => { reset: Input<Floating>, afr: H, af: [] },
+                15 => { reset: Input<Floating>, afr: H, af: [] },
+            ],
+        },
+        {
+            port: (D/d, pac: gpioc),
+            pins: [
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+            ],
+        },
+        {
+            port: (F/f, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [6] },
+                1 => { reset: Input<Floating>, afr: L, af: [] },
+            ],
+        },
+    ],
+});
 
 #[cfg(feature = "gpio-f373")]
-gpio!([
-    {
-        port: (A/a, pac: gpioa),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 7, 8, 11, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 2, 3, 6, 7, 9, 11, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 6, 7, 8, 9, 11, 15] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 6, 7, 9, 11, 15] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 5, 6, 7, 10, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 5, 7, 9, 10, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 5, 8, 9, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 5, 8, 9, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [0, 2, 4, 5, 7, 10, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [2, 3, 4, 5, 7, 9, 10, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 4, 5, 7, 9, 10, 15] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [2, 5, 6, 7, 8, 9, 10, 14, 15] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 6, 7, 8, 9, 10, 14, 15] },
-            13 => { reset: AF0, afr: H/h, af: [0, 1, 2, 3, 5, 6, 7, 10, 15] },
-            14 => { reset: AF0, afr: H/h, af: [0, 3, 4, 10, 15] },
-            15 => { reset: AF0, afr: H/h, af: [0, 1, 3, 4, 5, 6, 10, 15] },
-        ],
-    },
-    {
-        port: (B/b, pac: gpiob),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 5, 10, 15] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [2, 3, 15] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [15] },
-            3 => { reset: AF0, afr: L/l, af: [0, 1, 2, 3, 5, 6, 7, 9, 10, 15] },
-            4 => { reset: AF0, afr: L/l, af: [0, 1, 2, 3, 5, 6, 7, 9, 10, 15] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 5, 6, 7, 10, 11, 15] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 7, 9, 10, 11, 15] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 4, 7, 9, 10, 11, 15] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 15] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 4, 5, 6, 7, 8, 9, 11, 15] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5, 6, 7, 15] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5, 7, 9, 15] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [0, 1, 2, 3, 5, 9, 15] },
-        ],
-    },
-    {
-        port: (C/c, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 5] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 5] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 3, 7] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 3, 7] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 5] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 5] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 5] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 5] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 6, 7] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 6, 7] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 6, 7] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [] },
-        ],
-    },
-    {
-        port: (D/d, pac: gpiod),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 2] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [1, 5, 7] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1, 5, 7] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [1, 7] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 5, 7] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 5, 7] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 5, 7] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 3, 7] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1, 7] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1, 7] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3, 7] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1, 2, 3] },
-        ],
-    },
-    {
-        port: (E/e, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 7] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [1, 7] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 3] },
-            3 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 3] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 3] },
-            5 => { reset: Input<Floating>, afr: L/l, af: [0, 1, 3] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [0, 1] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1] },
-            8 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            11 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            12 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            13 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            14 => { reset: Input<Floating>, afr: H/h, af: [1] },
-            15 => { reset: Input<Floating>, afr: H/h, af: [1, 7] },
-        ],
-    },
-    {
-        port: (F/f, pac: gpioc),
-        pins: [
-            0 => { reset: Input<Floating>, afr: L/l, af: [4] },
-            1 => { reset: Input<Floating>, afr: L/l, af: [4] },
-            2 => { reset: Input<Floating>, afr: L/l, af: [1, 4] },
-            4 => { reset: Input<Floating>, afr: L/l, af: [1] },
-            6 => { reset: Input<Floating>, afr: L/l, af: [1, 2, 4, 5, 7] },
-            7 => { reset: Input<Floating>, afr: L/l, af: [1, 4, 7] },
-            9 => { reset: Input<Floating>, afr: H/h, af: [1, 2] },
-            10 => { reset: Input<Floating>, afr: H/h, af: [1] },
-        ],
-    },
-]);
+gpio!({
+    pacs: [gpioa, gpiob, gpioc, gpiod],
+    ports: [
+        {
+            port: (A/a, pac: gpioa),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7, 8, 11, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [0, 1, 2, 3, 6, 7, 9, 11, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 6, 7, 8, 9, 11, 15] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 6, 7, 9, 11, 15] },
+                4 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 6, 7, 10, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 5, 7, 9, 10, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 5, 8, 9, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 5, 8, 9, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [0, 2, 4, 5, 7, 10, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [2, 3, 4, 5, 7, 9, 10, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 4, 5, 7, 9, 10, 15] },
+                11 => { reset: Input<Floating>, afr: H, af: [2, 5, 6, 7, 8, 9, 10, 14, 15] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 6, 7, 8, 9, 10, 14, 15] },
+                13 => { reset: AF0, afr: H, af: [0, 1, 2, 3, 5, 6, 7, 10, 15] },
+                14 => { reset: AF0, afr: H, af: [0, 3, 4, 10, 15] },
+                15 => { reset: AF0, afr: H, af: [0, 1, 3, 4, 5, 6, 10, 15] },
+            ],
+        },
+        {
+            port: (B/b, pac: gpiob),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [2, 3, 5, 10, 15] },
+                1 => { reset: Input<Floating>, afr: L, af: [2, 3, 15] },
+                2 => { reset: Input<Floating>, afr: L, af: [15] },
+                3 => { reset: AF0, afr: L, af: [0, 1, 2, 3, 5, 6, 7, 9, 10, 15] },
+                4 => { reset: AF0, afr: L, af: [0, 1, 2, 3, 5, 6, 7, 9, 10, 15] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5, 6, 7, 10, 11, 15] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 7, 9, 10, 11, 15] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 4, 7, 9, 10, 11, 15] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 15] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 4, 5, 6, 7, 8, 9, 11, 15] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 6, 7, 15] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 7, 9, 15] },
+                15 => { reset: Input<Floating>, afr: H, af: [0, 1, 2, 3, 5, 9, 15] },
+            ],
+        },
+        {
+            port: (C/c, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2, 5] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 2, 5] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 2, 3, 7] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 3, 7] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 5] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 2, 5] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 2, 5] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2, 5] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 2, 6, 7] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 2, 6, 7] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 6, 7] },
+                13 => { reset: Input<Floating>, afr: H, af: [] },
+                14 => { reset: Input<Floating>, afr: H, af: [] },
+                15 => { reset: Input<Floating>, afr: H, af: [] },
+            ],
+        },
+        {
+            port: (D/d, pac: gpiod),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 2] },
+                3 => { reset: Input<Floating>, afr: L, af: [1, 5, 7] },
+                4 => { reset: Input<Floating>, afr: L, af: [1, 5, 7] },
+                5 => { reset: Input<Floating>, afr: L, af: [1, 7] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 5, 7] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 5, 7] },
+                8 => { reset: Input<Floating>, afr: H, af: [1, 3, 5, 7] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 3, 7] },
+                10 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+                11 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+                12 => { reset: Input<Floating>, afr: H, af: [1, 2, 3, 7] },
+                13 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
+                14 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
+                15 => { reset: Input<Floating>, afr: H, af: [1, 2, 3] },
+            ],
+        },
+        {
+            port: (E/e, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [1, 2, 7] },
+                1 => { reset: Input<Floating>, afr: L, af: [1, 7] },
+                2 => { reset: Input<Floating>, afr: L, af: [0, 1, 3] },
+                3 => { reset: Input<Floating>, afr: L, af: [0, 1, 3] },
+                4 => { reset: Input<Floating>, afr: L, af: [0, 1, 3] },
+                5 => { reset: Input<Floating>, afr: L, af: [0, 1, 3] },
+                6 => { reset: Input<Floating>, afr: L, af: [0, 1] },
+                7 => { reset: Input<Floating>, afr: L, af: [1] },
+                8 => { reset: Input<Floating>, afr: H, af: [1] },
+                9 => { reset: Input<Floating>, afr: H, af: [1] },
+                10 => { reset: Input<Floating>, afr: H, af: [1] },
+                11 => { reset: Input<Floating>, afr: H, af: [1] },
+                12 => { reset: Input<Floating>, afr: H, af: [1] },
+                13 => { reset: Input<Floating>, afr: H, af: [1] },
+                14 => { reset: Input<Floating>, afr: H, af: [1] },
+                15 => { reset: Input<Floating>, afr: H, af: [1, 7] },
+            ],
+        },
+        {
+            port: (F/f, pac: gpioc),
+            pins: [
+                0 => { reset: Input<Floating>, afr: L, af: [4] },
+                1 => { reset: Input<Floating>, afr: L, af: [4] },
+                2 => { reset: Input<Floating>, afr: L, af: [1, 4] },
+                4 => { reset: Input<Floating>, afr: L, af: [1] },
+                6 => { reset: Input<Floating>, afr: L, af: [1, 2, 4, 5, 7] },
+                7 => { reset: Input<Floating>, afr: L, af: [1, 4, 7] },
+                9 => { reset: Input<Floating>, afr: H, af: [1, 2] },
+                10 => { reset: Input<Floating>, afr: H, af: [1] },
+            ],
+        },
+    ],
+});

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -10,8 +10,8 @@
 //! let mut gpioa = dp.GPIOA.split(&mut rcc.ahb);
 //! ```
 //!
-//! The resulting [Parts](gpioa::Parts) struct contains one field for each
-//! pin, as well as some shared registers.
+//! The resulting [Parts](gpioa::Parts) struct contains one field for each pin, as well as some
+//! shared registers. Every pin type is a specialized version of generic [pin](Pin) struct.
 //!
 //! To use a pin, first use the relevant `into_...` method of the [pin](Pin).
 //!
@@ -23,6 +23,32 @@
 //! `embedded_hal`
 //!
 //! For a complete example, see [examples/toggle.rs]
+//!
+//! ## Pin Configuration
+//!
+//! ### Mode
+//!
+//! Each GPIO pin can be set to various modes by corresponding `into_...` method:
+//!
+//! - **Input**: The output buffer is disabled and the schmitt trigger input is activated
+//! - **Output**: Both the output buffer and the schmitt trigger input is enabled
+//!     - **PushPull**: Output which either drives the pin high or low
+//!     - **OpenDrain**: Output which leaves the gate floating, or pulls it to ground in drain
+//!     mode. Can be used as an input in the `open` configuration
+//! - **Alternate**: Pin mode required when the pin is driven by other peripherals. The schmitt
+//! trigger input is activated. The Output buffer is automatically enabled and disabled by
+//! peripherals. Output behavior is same as the output mode
+//!     - **PushPull**: Output which either drives the pin high or low
+//!     - **OpenDrain**: Output which leaves the gate floating, or pulls it to ground in drain
+//!     mode
+//! - **Analog**: Pin mode required for ADC, DAC, OPAMP, and COMP peripherals. It is also suitable
+//! for minimize energy consumption as the output buffer and the schmitt trigger input is disabled
+//!
+//! ### Internal Resistor
+//!
+//! Weak internal pull-up and pull-down resistors are configurable by calling
+//! [`set_internal_resistor`](Pin::set_internal_resistor) method. `into_..._input` methods are also
+//! available for convenience.
 //!
 //! [InputPin]: embedded_hal::digital::v2::InputPin
 //! [OutputPin]: embedded_hal::digital::v2::OutputPin

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -237,7 +237,7 @@ impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE> {
 impl<GPIO, INDEX, MODE> Pin<GPIO, INDEX, MODE>
 where
     GPIO: GpioStatic,
-    INDEX: Unsigned,
+    INDEX: Index,
 {
     /// Configures the pin to operate as a floating input pin
     pub fn into_floating_input(
@@ -309,7 +309,7 @@ where
 impl<GPIO, INDEX> Pin<GPIO, INDEX, Output<OpenDrain>>
 where
     GPIO: GpioStatic,
-    INDEX: Unsigned,
+    INDEX: Index,
 {
     /// Enables / disables the internal pull up
     pub fn internal_pull_up(&mut self, pupdr: &mut GPIO::PUPDR, on: bool) {
@@ -403,7 +403,7 @@ macro_rules! af {
         where
             Self: $IntoAfi,
             GPIO: GpioStatic,
-            INDEX: Unsigned,
+            INDEX: Index,
         {
             /// Configures the pin to operate as an alternate function pin
             pub fn $into_afi(

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -4,11 +4,10 @@
 //!
 //! [examples/i2c_scanner.rs]: https://github.com/stm32-rs/stm32f3xx-hal/blob/v0.6.1/examples/i2c_scanner.rs
 
-use core::convert::TryFrom;
-use core::ops::Deref;
+use core::{convert::TryFrom, ops::Deref};
 
 use crate::{
-    gpio::{gpioa, gpiob, AF4},
+    gpio::{gpioa, gpiob, OpenDrain, AF4},
     hal::blocking::i2c::{Read, Write, WriteRead},
     pac::{i2c1::RegisterBlock, rcc::cfgr3::I2C1SW_A, I2C1, RCC},
     rcc::{Clocks, APB1},
@@ -51,31 +50,31 @@ pub unsafe trait SclPin<I2C> {}
 /// SDA pin -- DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait SdaPin<I2C> {}
 
-unsafe impl SclPin<I2C1> for gpioa::PA15<AF4> {}
-unsafe impl SclPin<I2C1> for gpiob::PB6<AF4> {}
-unsafe impl SclPin<I2C1> for gpiob::PB8<AF4> {}
-unsafe impl SdaPin<I2C1> for gpioa::PA14<AF4> {}
-unsafe impl SdaPin<I2C1> for gpiob::PB7<AF4> {}
-unsafe impl SdaPin<I2C1> for gpiob::PB9<AF4> {}
+unsafe impl SclPin<I2C1> for gpioa::PA15<AF4<OpenDrain>> {}
+unsafe impl SclPin<I2C1> for gpiob::PB6<AF4<OpenDrain>> {}
+unsafe impl SclPin<I2C1> for gpiob::PB8<AF4<OpenDrain>> {}
+unsafe impl SdaPin<I2C1> for gpioa::PA14<AF4<OpenDrain>> {}
+unsafe impl SdaPin<I2C1> for gpiob::PB7<AF4<OpenDrain>> {}
+unsafe impl SdaPin<I2C1> for gpiob::PB9<AF4<OpenDrain>> {}
 
 cfg_if! {
     if #[cfg(not(feature = "gpio-f333"))] {
-        unsafe impl SclPin<I2C2> for gpioa::PA9<AF4> {}
-        unsafe impl SclPin<I2C2> for gpiof::PF1<AF4> {}
+        unsafe impl SclPin<I2C2> for gpioa::PA9<AF4<OpenDrain>> {}
+        unsafe impl SclPin<I2C2> for gpiof::PF1<AF4<OpenDrain>> {}
         #[cfg(any(feature = "gpio-f303", feature = "gpio-f303e", feature = "gpio-f373"))]
-        unsafe impl SclPin<I2C2> for gpiof::PF6<AF4> {}
-        unsafe impl SdaPin<I2C2> for gpioa::PA10<AF4> {}
-        unsafe impl SdaPin<I2C2> for gpiof::PF0<AF4> {}
+        unsafe impl SclPin<I2C2> for gpiof::PF6<AF4<OpenDrain>> {}
+        unsafe impl SdaPin<I2C2> for gpioa::PA10<AF4<OpenDrain>> {}
+        unsafe impl SdaPin<I2C2> for gpiof::PF0<AF4<OpenDrain>> {}
         #[cfg(feature = "gpio-f373")]
-        unsafe impl SdaPin<I2C2> for gpiof::PF7<AF4> {}
+        unsafe impl SdaPin<I2C2> for gpiof::PF7<AF4<OpenDrain>> {}
     }
 }
 
 cfg_if! {
     if #[cfg(any(feature = "gpio-f302", feature = "gpio-f303e"))] {
-        unsafe impl SclPin<I2C3> for gpioa::PA8<AF3> {}
-        unsafe impl SdaPin<I2C3> for gpiob::PB5<AF8> {}
-        unsafe impl SdaPin<I2C3> for gpioc::PC9<AF3> {}
+        unsafe impl SclPin<I2C3> for gpioa::PA8<AF3<OpenDrain>> {}
+        unsafe impl SdaPin<I2C3> for gpiob::PB5<AF8<OpenDrain>> {}
+        unsafe impl SdaPin<I2C3> for gpioc::PC9<AF3<OpenDrain>> {}
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ cfg_if::cfg_if! {
         pub mod rtc;
         pub mod serial;
         pub mod spi;
+        pub mod syscfg;
         pub mod timer;
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,7 @@ pub use crate::flash::FlashExt as _stm32f3xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32f3xx_hal_gpio_GpioExt;
 pub use crate::hal::prelude::*;
 pub use crate::rcc::RccExt as _stm32f3xx_hal_rcc_RccExt;
+pub use crate::syscfg::SysCfgExt as _stm32f3xx_hal_syscfg_SysCfgExt;
 pub use crate::time::duration::Extensions as _stm32f3xx_hal_time_time_Extensions;
 pub use crate::time::rate::Extensions as _stm32f3xx_hal_time_rate_Extensions;
 #[cfg(feature = "unproven")]

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -351,9 +351,9 @@ macro_rules! pwm_channel_pin {
             /// is called.
             ///
             /// The pin is consumed and cannot be returned.
-            pub fn $output_to_pzv<OTYPE>(
+            pub fn $output_to_pzv<Otype>(
                 self,
-                _p: $gpioz::$PZv<gpio::$AFw<OTYPE>>,
+                _p: $gpioz::$PZv<gpio::$AFw<Otype>>,
             ) -> PwmChannel<$TIMx_CHy, $resulting_state> {
                 unsafe {
                     (*$TIMx::ptr()).$ccmrz_output().modify(|_, w| {
@@ -380,9 +380,9 @@ macro_rules! pwm_channel_pin {
             /// can be used (as long as they are compatible).
             ///
             /// The pin is consumed and cannot be returned.
-            pub fn $output_to_pzv<OTYPE>(
+            pub fn $output_to_pzv<Otype>(
                 self,
-                _p: $gpioz::$PZv<gpio::$AFw<OTYPE>>,
+                _p: $gpioz::$PZv<gpio::$AFw<Otype>>,
             ) -> PwmChannel<$TIMx_CHy, $resulting_state> {
                 self
             }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -155,14 +155,15 @@
   [examples/pwm.rs]: https://github.com/stm32-rs/stm32f3xx-hal/blob/v0.6.1/examples/pwm.rs
 */
 
+use core::marker::PhantomData;
+
 use crate::{
-    gpio::{self, gpioa, gpiob},
+    gpio::{self, gpioa, gpiob, PushPull},
     hal::PwmPin,
     pac::{RCC, TIM15, TIM16, TIM17, TIM2},
     rcc::Clocks,
     time::rate::*,
 };
-use core::marker::PhantomData;
 
 #[cfg(any(
     feature = "stm32f302xb",
@@ -179,6 +180,7 @@ use core::marker::PhantomData;
     feature = "stm32f398",
 ))]
 use crate::gpio::gpiod;
+
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -192,6 +194,7 @@ use crate::gpio::gpiod;
     feature = "stm32f398",
 ))]
 use crate::gpio::gpioe;
+
 #[cfg(any(
     feature = "stm32f318",
     feature = "stm32f302",
@@ -597,39 +600,129 @@ macro_rules! tim1_common {
         pwm_pin_for_pwm_channel!(TIM1, TIM1_CH4, u16, cc4e, ccr4, ccr);
 
         //Pins
-        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pa8, gpioa::PA8<gpio::AF6>);
+        pwm_channel1_pin!(
+            TIM1,
+            TIM1_CH1,
+            output_to_pa8,
+            gpioa::PA8<gpio::AF6<PushPull>>
+        );
 
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pa7, gpioa::PA7<gpio::AF6>);
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pa11, gpioa::PA11<gpio::AF6>);
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pb13, gpiob::PB13<gpio::AF6>);
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pc13, gpioc::PC13<gpio::AF4>);
+        pwm_channel1n_pin!(
+            TIM1,
+            TIM1_CH1,
+            output_to_pa7,
+            gpioa::PA7<gpio::AF6<PushPull>>
+        );
+        pwm_channel1n_pin!(
+            TIM1,
+            TIM1_CH1,
+            output_to_pa11,
+            gpioa::PA11<gpio::AF6<PushPull>>
+        );
+        pwm_channel1n_pin!(
+            TIM1,
+            TIM1_CH1,
+            output_to_pb13,
+            gpiob::PB13<gpio::AF6<PushPull>>
+        );
+        pwm_channel1n_pin!(
+            TIM1,
+            TIM1_CH1,
+            output_to_pc13,
+            gpioc::PC13<gpio::AF4<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pa9, gpioa::PA9<gpio::AF6>);
+        pwm_channel2_pin!(
+            TIM1,
+            TIM1_CH2,
+            output_to_pa9,
+            gpioa::PA9<gpio::AF6<PushPull>>
+        );
 
-        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pa12, gpioa::PA12<gpio::AF6>);
-        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pb0, gpiob::PB0<gpio::AF6>);
-        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pb14, gpiob::PB14<gpio::AF6>);
+        pwm_channel2n_pin!(
+            TIM1,
+            TIM1_CH2,
+            output_to_pa12,
+            gpioa::PA12<gpio::AF6<PushPull>>
+        );
+        pwm_channel2n_pin!(
+            TIM1,
+            TIM1_CH2,
+            output_to_pb0,
+            gpiob::PB0<gpio::AF6<PushPull>>
+        );
+        pwm_channel2n_pin!(
+            TIM1,
+            TIM1_CH2,
+            output_to_pb14,
+            gpiob::PB14<gpio::AF6<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pa10, gpioa::PA10<gpio::AF6>);
+        pwm_channel3_pin!(
+            TIM1,
+            TIM1_CH3,
+            output_to_pa10,
+            gpioa::PA10<gpio::AF6<PushPull>>
+        );
 
-        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pb1, gpiob::PB1<gpio::AF6>);
-        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pb15, gpiob::PB15<gpio::AF4>);
-        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pf0, gpiof::PF0<gpio::AF6>);
+        pwm_channel3n_pin!(
+            TIM1,
+            TIM1_CH3,
+            output_to_pb1,
+            gpiob::PB1<gpio::AF6<PushPull>>
+        );
+        pwm_channel3n_pin!(
+            TIM1,
+            TIM1_CH3,
+            output_to_pb15,
+            gpiob::PB15<gpio::AF4<PushPull>>
+        );
+        pwm_channel3n_pin!(
+            TIM1,
+            TIM1_CH3,
+            output_to_pf0,
+            gpiof::PF0<gpio::AF6<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pa11, gpioa::PA11<gpio::AF11>);
+        pwm_channel4_pin!(
+            TIM1,
+            TIM1_CH4,
+            output_to_pa11,
+            gpioa::PA11<gpio::AF11<PushPull>>
+        );
     };
 }
 
 #[cfg(any(feature = "stm32f334", feature = "stm32f398"))]
 macro_rules! tim1_ext1 {
     () => {
-        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pc0, gpioc::PC0<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM1,
+            TIM1_CH1,
+            output_to_pc0,
+            gpioc::PC0<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pc1, gpioc::PC1<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM1,
+            TIM1_CH2,
+            output_to_pc1,
+            gpioc::PC1<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pc2, gpioc::PC2<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM1,
+            TIM1_CH3,
+            output_to_pc2,
+            gpioc::PC2<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pc3, gpioc::PC3<gpio::AF2>);
+        pwm_channel4_pin!(
+            TIM1,
+            TIM1_CH4,
+            output_to_pc3,
+            gpioc::PC3<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -647,19 +740,54 @@ macro_rules! tim1_ext1 {
 ))]
 macro_rules! tim1_ext2 {
     () => {
-        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pe9, gpioe::PE9<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM1,
+            TIM1_CH1,
+            output_to_pe9,
+            gpioe::PE9<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pe8, gpioe::PE8<gpio::AF2>);
+        pwm_channel1n_pin!(
+            TIM1,
+            TIM1_CH1,
+            output_to_pe8,
+            gpioe::PE8<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pe11, gpioe::PE11<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM1,
+            TIM1_CH2,
+            output_to_pe11,
+            gpioe::PE11<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pe10, gpioe::PE10<gpio::AF2>);
+        pwm_channel2n_pin!(
+            TIM1,
+            TIM1_CH2,
+            output_to_pe10,
+            gpioe::PE10<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pe13, gpioe::PE13<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM1,
+            TIM1_CH3,
+            output_to_pe13,
+            gpioe::PE13<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pe12, gpioe::PE12<gpio::AF2>);
+        pwm_channel3n_pin!(
+            TIM1,
+            TIM1_CH3,
+            output_to_pe12,
+            gpioe::PE12<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pe14, gpioe::PE14<gpio::AF2>);
+        pwm_channel4_pin!(
+            TIM1,
+            TIM1_CH4,
+            output_to_pe14,
+            gpioe::PE14<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -713,9 +841,24 @@ pwm_pin_for_pwm_channel!(TIM2, TIM2_CH3, u32, cc3e, ccr3, ccr);
 pwm_pin_for_pwm_channel!(TIM2, TIM2_CH4, u32, cc4e, ccr4, ccr);
 
 // Pins
-pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa0, gpioa::PA0<gpio::AF1>);
-pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa5, gpioa::PA5<gpio::AF1>);
-pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa15, gpioa::PA15<gpio::AF1>);
+pwm_channel1_pin!(
+    TIM2,
+    TIM2_CH1,
+    output_to_pa0,
+    gpioa::PA0<gpio::AF1<PushPull>>
+);
+pwm_channel1_pin!(
+    TIM2,
+    TIM2_CH1,
+    output_to_pa5,
+    gpioa::PA5<gpio::AF1<PushPull>>
+);
+pwm_channel1_pin!(
+    TIM2,
+    TIM2_CH1,
+    output_to_pa15,
+    gpioa::PA15<gpio::AF1<PushPull>>
+);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -728,10 +871,25 @@ pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa15, gpioa::PA15<gpio::AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pd3, gpiod::PD3<gpio::AF2>);
+pwm_channel1_pin!(
+    TIM2,
+    TIM2_CH1,
+    output_to_pd3,
+    gpiod::PD3<gpio::AF2<PushPull>>
+);
 
-pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pa1, gpioa::PA1<gpio::AF1>);
-pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pb3, gpiob::PB3<gpio::AF1>);
+pwm_channel2_pin!(
+    TIM2,
+    TIM2_CH2,
+    output_to_pa1,
+    gpioa::PA1<gpio::AF1<PushPull>>
+);
+pwm_channel2_pin!(
+    TIM2,
+    TIM2_CH2,
+    output_to_pb3,
+    gpiob::PB3<gpio::AF1<PushPull>>
+);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -744,11 +902,31 @@ pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pb3, gpiob::PB3<gpio::AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pd4, gpiod::PD4<gpio::AF2>);
+pwm_channel2_pin!(
+    TIM2,
+    TIM2_CH2,
+    output_to_pd4,
+    gpiod::PD4<gpio::AF2<PushPull>>
+);
 
-pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pa2, gpioa::PA2<gpio::AF1>);
-pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pa9, gpioa::PA9<gpio::AF10>);
-pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pb10, gpiob::PB10<gpio::AF1>);
+pwm_channel3_pin!(
+    TIM2,
+    TIM2_CH3,
+    output_to_pa2,
+    gpioa::PA2<gpio::AF1<PushPull>>
+);
+pwm_channel3_pin!(
+    TIM2,
+    TIM2_CH3,
+    output_to_pa9,
+    gpioa::PA9<gpio::AF10<PushPull>>
+);
+pwm_channel3_pin!(
+    TIM2,
+    TIM2_CH3,
+    output_to_pb10,
+    gpiob::PB10<gpio::AF1<PushPull>>
+);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -761,12 +939,32 @@ pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pb10, gpiob::PB10<gpio::AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pd7, gpiod::PD7<gpio::AF2>);
+pwm_channel3_pin!(
+    TIM2,
+    TIM2_CH3,
+    output_to_pd7,
+    gpiod::PD7<gpio::AF2<PushPull>>
+);
 
-pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pa3, gpioa::PA3<gpio::AF1>);
-pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pa10, gpioa::PA10<gpio::AF1>);
+pwm_channel4_pin!(
+    TIM2,
+    TIM2_CH4,
+    output_to_pa3,
+    gpioa::PA3<gpio::AF1<PushPull>>
+);
+pwm_channel4_pin!(
+    TIM2,
+    TIM2_CH4,
+    output_to_pa10,
+    gpioa::PA10<gpio::AF1<PushPull>>
+);
 #[cfg(not(any(feature = "stm32f373", feature = "stm32f378")))]
-pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pb11, gpiob::PB11<gpio::AF1>);
+pwm_channel4_pin!(
+    TIM2,
+    TIM2_CH4,
+    output_to_pb11,
+    gpiob::PB11<gpio::AF1<PushPull>>
+);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -779,7 +977,12 @@ pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pb11, gpiob::PB11<gpio::AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pd6, gpiod::PD6<gpio::AF2>);
+pwm_channel4_pin!(
+    TIM2,
+    TIM2_CH4,
+    output_to_pd6,
+    gpiod::PD6<gpio::AF2<PushPull>>
+);
 
 // TIM3
 
@@ -826,17 +1029,57 @@ macro_rules! tim3_common {
         pwm_pin_for_pwm_channel!(TIM3, TIM3_CH4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pa6, gpioa::PA6<gpio::AF2>);
-        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pb4, gpiob::PB4<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM3,
+            TIM3_CH1,
+            output_to_pa6,
+            gpioa::PA6<gpio::AF2<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM3,
+            TIM3_CH1,
+            output_to_pb4,
+            gpiob::PB4<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pa4, gpioa::PA4<gpio::AF2>);
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pa7, gpioa::PA7<gpio::AF2>);
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pb5, gpiob::PB5<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM3,
+            TIM3_CH2,
+            output_to_pa4,
+            gpioa::PA4<gpio::AF2<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM3,
+            TIM3_CH2,
+            output_to_pa7,
+            gpioa::PA7<gpio::AF2<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM3,
+            TIM3_CH2,
+            output_to_pb5,
+            gpiob::PB5<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pb0, gpiob::PB0<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM3,
+            TIM3_CH3,
+            output_to_pb0,
+            gpiob::PB0<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pb1, gpiob::PB1<gpio::AF2>);
-        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pb7, gpiob::PB7<gpio::AF10>);
+        pwm_channel4_pin!(
+            TIM3,
+            TIM3_CH4,
+            output_to_pb1,
+            gpiob::PB1<gpio::AF2<PushPull>>
+        );
+        pwm_channel4_pin!(
+            TIM3,
+            TIM3_CH4,
+            output_to_pb7,
+            gpiob::PB7<gpio::AF10<PushPull>>
+        );
     };
 }
 
@@ -851,13 +1094,33 @@ macro_rules! tim3_common {
 ))]
 macro_rules! tim3_ext1 {
     () => {
-        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pc6, gpioc::PC6<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM3,
+            TIM3_CH1,
+            output_to_pc6,
+            gpioc::PC6<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pc7, gpioc::PC7<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM3,
+            TIM3_CH2,
+            output_to_pc7,
+            gpioc::PC7<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pc8, gpioc::PC8<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM3,
+            TIM3_CH3,
+            output_to_pc8,
+            gpioc::PC8<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pc9, gpioc::PC9<gpio::AF2>);
+        pwm_channel4_pin!(
+            TIM3,
+            TIM3_CH4,
+            output_to_pc9,
+            gpioc::PC9<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -875,13 +1138,33 @@ macro_rules! tim3_ext1 {
 ))]
 macro_rules! tim3_ext2 {
     () => {
-        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pe2, gpioe::PE6<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM3,
+            TIM3_CH1,
+            output_to_pe2,
+            gpioe::PE6<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pe3, gpioe::PE7<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM3,
+            TIM3_CH2,
+            output_to_pe3,
+            gpioe::PE7<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pe4, gpioe::PE8<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM3,
+            TIM3_CH3,
+            output_to_pe4,
+            gpioe::PE8<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pe5, gpioe::PE9<gpio::AF2>);
+        pwm_channel4_pin!(
+            TIM3,
+            TIM3_CH4,
+            output_to_pe5,
+            gpioe::PE9<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -923,10 +1206,20 @@ tim3_ext1!();
 tim3_ext2!();
 
 #[cfg(feature = "stm32f373")]
-pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pb0, gpiob::PB0<gpio::AF10>);
+pwm_channel2_pin!(
+    TIM3,
+    TIM3_CH2,
+    output_to_pb0,
+    gpiob::PB0<gpio::AF10<PushPull>>
+);
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pb6, gpiob::PB6<gpio::AF10>);
+pwm_channel3_pin!(
+    TIM3,
+    TIM3_CH3,
+    output_to_pb6,
+    gpiob::PB6<gpio::AF10<PushPull>>
+);
 
 // TIM4
 
@@ -971,16 +1264,51 @@ macro_rules! tim4_common {
         pwm_pin_for_pwm_channel!(TIM4, TIM4_CH4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pa11, gpioa::PA11<gpio::AF10>);
-        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pb6, gpiob::PB6<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM4,
+            TIM4_CH1,
+            output_to_pa11,
+            gpioa::PA11<gpio::AF10<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM4,
+            TIM4_CH1,
+            output_to_pb6,
+            gpiob::PB6<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pa12, gpioa::PA12<gpio::AF10>);
-        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pb7, gpiob::PB7<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM4,
+            TIM4_CH2,
+            output_to_pa12,
+            gpioa::PA12<gpio::AF10<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM4,
+            TIM4_CH2,
+            output_to_pb7,
+            gpiob::PB7<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pa13, gpioa::PA13<gpio::AF10>);
-        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pb8, gpiob::PB8<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM4,
+            TIM4_CH3,
+            output_to_pa13,
+            gpioa::PA13<gpio::AF10<PushPull>>
+        );
+        pwm_channel3_pin!(
+            TIM4,
+            TIM4_CH3,
+            output_to_pb8,
+            gpiob::PB8<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pb9, gpiob::PB9<gpio::AF2>);
+        pwm_channel4_pin!(
+            TIM4,
+            TIM4_CH4,
+            output_to_pb9,
+            gpiob::PB9<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -1000,14 +1328,39 @@ macro_rules! tim4_common {
 ))]
 macro_rules! tim4_ext {
     () => {
-        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pd12, gpiod::PD12<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM4,
+            TIM4_CH1,
+            output_to_pd12,
+            gpiod::PD12<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pd13, gpiod::PD13<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM4,
+            TIM4_CH2,
+            output_to_pd13,
+            gpiod::PD13<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pd14, gpiod::PD14<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM4,
+            TIM4_CH3,
+            output_to_pd14,
+            gpiod::PD14<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pd15, gpiod::PD15<gpio::AF2>);
-        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pf6, gpiof::PF6<gpio::AF2>);
+        pwm_channel4_pin!(
+            TIM4,
+            TIM4_CH4,
+            output_to_pd15,
+            gpiod::PD15<gpio::AF2<PushPull>>
+        );
+        pwm_channel4_pin!(
+            TIM4,
+            TIM4_CH4,
+            output_to_pf6,
+            gpiof::PF6<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -1073,21 +1426,81 @@ macro_rules! tim5 {
         pwm_pin_for_pwm_channel!(TIM5, TIM5_CH4, u32, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pa0, gpioa::PA0<gpio::AF2>);
-        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pa8, gpioa::PA8<gpio::AF2>);
-        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pc0, gpioc::PC0<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM5,
+            TIM5_CH1,
+            output_to_pa0,
+            gpioa::PA0<gpio::AF2<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM5,
+            TIM5_CH1,
+            output_to_pa8,
+            gpioa::PA8<gpio::AF2<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM5,
+            TIM5_CH1,
+            output_to_pc0,
+            gpioc::PC0<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pa1, gpioa::PA1<gpio::AF2>);
-        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pa11, gpioa::PA11<gpio::AF2>);
-        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pc1, gpioc::PC1<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM5,
+            TIM5_CH2,
+            output_to_pa1,
+            gpioa::PA1<gpio::AF2<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM5,
+            TIM5_CH2,
+            output_to_pa11,
+            gpioa::PA11<gpio::AF2<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM5,
+            TIM5_CH2,
+            output_to_pc1,
+            gpioc::PC1<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pa2, gpioa::PA2<gpio::AF2>);
-        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pa12, gpioa::PA12<gpio::AF2>);
-        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pc2, gpioc::PC2<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM5,
+            TIM5_CH3,
+            output_to_pa2,
+            gpioa::PA2<gpio::AF2<PushPull>>
+        );
+        pwm_channel3_pin!(
+            TIM5,
+            TIM5_CH3,
+            output_to_pa12,
+            gpioa::PA12<gpio::AF2<PushPull>>
+        );
+        pwm_channel3_pin!(
+            TIM5,
+            TIM5_CH3,
+            output_to_pc2,
+            gpioc::PC2<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pa3, gpioa::PA3<gpio::AF2>);
-        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pa13, gpioa::PA13<gpio::AF2>);
-        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pc3, gpioc::PC3<gpio::AF2>);
+        pwm_channel4_pin!(
+            TIM5,
+            TIM5_CH4,
+            output_to_pa3,
+            gpioa::PA3<gpio::AF2<PushPull>>
+        );
+        pwm_channel4_pin!(
+            TIM5,
+            TIM5_CH4,
+            output_to_pa13,
+            gpioa::PA13<gpio::AF2<PushPull>>
+        );
+        pwm_channel4_pin!(
+            TIM5,
+            TIM5_CH4,
+            output_to_pc3,
+            gpioc::PC3<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -1131,30 +1544,120 @@ macro_rules! tim8 {
         pwm_pin_for_pwm_channel!(TIM8, TIM8_CH4, u16, cc4e, ccr4, ccr);
 
         //Pins
-        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pa15, gpioa::PA15<gpio::AF2>);
-        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pb6, gpiob::PB6<gpio::AF2>);
-        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pc6, gpioc::PC6<gpio::AF4>);
+        pwm_channel1_pin!(
+            TIM8,
+            TIM8_CH1,
+            output_to_pa15,
+            gpioa::PA15<gpio::AF2<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM8,
+            TIM8_CH1,
+            output_to_pb6,
+            gpiob::PB6<gpio::AF2<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM8,
+            TIM8_CH1,
+            output_to_pc6,
+            gpioc::PC6<gpio::AF4<PushPull>>
+        );
 
-        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pa7, gpioa::PA7<gpio::AF4>);
-        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pb3, gpiob::PB3<gpio::AF4>);
-        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pc10, gpioc::PC10<gpio::AF4>);
+        pwm_channel1n_pin!(
+            TIM8,
+            TIM8_CH1,
+            output_to_pa7,
+            gpioa::PA7<gpio::AF4<PushPull>>
+        );
+        pwm_channel1n_pin!(
+            TIM8,
+            TIM8_CH1,
+            output_to_pb3,
+            gpiob::PB3<gpio::AF4<PushPull>>
+        );
+        pwm_channel1n_pin!(
+            TIM8,
+            TIM8_CH1,
+            output_to_pc10,
+            gpioc::PC10<gpio::AF4<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pa14, gpioa::PA14<gpio::AF5>);
-        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pb8, gpiob::PB8<gpio::AF10>);
-        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pc7, gpioc::PC7<gpio::AF4>);
+        pwm_channel2_pin!(
+            TIM8,
+            TIM8_CH2,
+            output_to_pa14,
+            gpioa::PA14<gpio::AF5<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM8,
+            TIM8_CH2,
+            output_to_pb8,
+            gpiob::PB8<gpio::AF10<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM8,
+            TIM8_CH2,
+            output_to_pc7,
+            gpioc::PC7<gpio::AF4<PushPull>>
+        );
 
-        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pb0, gpiob::PB0<gpio::AF4>);
-        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pb4, gpiob::PB4<gpio::AF4>);
-        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pc11, gpioc::PC11<gpio::AF4>);
+        pwm_channel2n_pin!(
+            TIM8,
+            TIM8_CH2,
+            output_to_pb0,
+            gpiob::PB0<gpio::AF4<PushPull>>
+        );
+        pwm_channel2n_pin!(
+            TIM8,
+            TIM8_CH2,
+            output_to_pb4,
+            gpiob::PB4<gpio::AF4<PushPull>>
+        );
+        pwm_channel2n_pin!(
+            TIM8,
+            TIM8_CH2,
+            output_to_pc11,
+            gpioc::PC11<gpio::AF4<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM8, TIM8_CH3, output_to_pb9, gpiob::PB9<gpio::AF10>);
-        pwm_channel3_pin!(TIM8, TIM8_CH3, output_to_pc8, gpioc::PC8<gpio::AF4>);
+        pwm_channel3_pin!(
+            TIM8,
+            TIM8_CH3,
+            output_to_pb9,
+            gpiob::PB9<gpio::AF10<PushPull>>
+        );
+        pwm_channel3_pin!(
+            TIM8,
+            TIM8_CH3,
+            output_to_pc8,
+            gpioc::PC8<gpio::AF4<PushPull>>
+        );
 
-        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pb1, gpiob::PB1<gpio::AF4>);
-        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pb5, gpiob::PB5<gpio::AF3>);
-        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pc12, gpioc::PC12<gpio::AF4>);
+        pwm_channel3n_pin!(
+            TIM8,
+            TIM8_CH3,
+            output_to_pb1,
+            gpiob::PB1<gpio::AF4<PushPull>>
+        );
+        pwm_channel3n_pin!(
+            TIM8,
+            TIM8_CH3,
+            output_to_pb5,
+            gpiob::PB5<gpio::AF3<PushPull>>
+        );
+        pwm_channel3n_pin!(
+            TIM8,
+            TIM8_CH3,
+            output_to_pc12,
+            gpioc::PC12<gpio::AF4<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM8, TIM8_CH4, output_to_pc9, gpioc::PC9<gpio::AF4>);
+        pwm_channel4_pin!(
+            TIM8,
+            TIM8_CH4,
+            output_to_pc9,
+            gpioc::PC9<gpio::AF4<PushPull>>
+        );
     };
 }
 
@@ -1169,7 +1672,12 @@ tim8!();
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel4_pin!(TIM8, TIM8_CH4, output_to_pd1, gpiod::PD1<gpio::AF4>);
+pwm_channel4_pin!(
+    TIM8,
+    TIM8_CH4,
+    output_to_pd1,
+    gpiod::PD1<gpio::AF4<PushPull>>
+);
 
 // TIM12
 
@@ -1205,13 +1713,43 @@ macro_rules! tim12 {
         pwm_pin_for_pwm_channel!(TIM12, TIM12_CH2, u16, cc2e, ccr2, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pa4, gpioa::PA4<gpio::AF10>);
-        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pa14, gpioa::PA14<gpio::AF10>);
-        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pb14, gpiob::PB14<gpio::AF10>);
+        pwm_channel1_pin!(
+            TIM12,
+            TIM12_CH1,
+            output_to_pa4,
+            gpioa::PA4<gpio::AF10<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM12,
+            TIM12_CH1,
+            output_to_pa14,
+            gpioa::PA14<gpio::AF10<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM12,
+            TIM12_CH1,
+            output_to_pb14,
+            gpiob::PB14<gpio::AF10<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pa5, gpioa::PA5<gpio::AF10>);
-        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pa15, gpioa::PA15<gpio::AF10>);
-        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pb15, gpiob::PB15<gpio::AF10>);
+        pwm_channel2_pin!(
+            TIM12,
+            TIM12_CH2,
+            output_to_pa5,
+            gpioa::PA5<gpio::AF10<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM12,
+            TIM12_CH2,
+            output_to_pa15,
+            gpioa::PA15<gpio::AF10<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM12,
+            TIM12_CH2,
+            output_to_pb15,
+            gpiob::PB15<gpio::AF10<PushPull>>
+        );
     };
 }
 
@@ -1252,10 +1790,30 @@ macro_rules! tim13 {
         pwm_pin_for_pwm_channel!(TIM13, TIM13_CH1, u16, cc1e, ccr1, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pa6, gpioa::PA6<gpio::AF9>);
-        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pa9, gpioa::PA9<gpio::AF2>);
-        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pb3, gpiob::PB3<gpio::AF9>);
-        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pc4, gpioc::PC4<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM13,
+            TIM13_CH1,
+            output_to_pa6,
+            gpioa::PA6<gpio::AF9<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM13,
+            TIM13_CH1,
+            output_to_pa9,
+            gpioa::PA9<gpio::AF2<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM13,
+            TIM13_CH1,
+            output_to_pb3,
+            gpiob::PB3<gpio::AF9<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM13,
+            TIM13_CH1,
+            output_to_pc4,
+            gpioc::PC4<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -1295,10 +1853,30 @@ macro_rules! tim14 {
         pwm_pin_for_pwm_channel!(TIM14, TIM14_CH1, u16, cc1e, ccr1, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa5, gpioa::PA5<gpio::AF9>);
-        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa7, gpioa::PA7<gpio::AF9>);
-        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa10, gpioa::PA10<gpio::AF9>);
-        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pf9, gpiof::PF9<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM14,
+            TIM14_CH1,
+            output_to_pa5,
+            gpioa::PA5<gpio::AF9<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM14,
+            TIM14_CH1,
+            output_to_pa7,
+            gpioa::PA7<gpio::AF9<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM14,
+            TIM14_CH1,
+            output_to_pa10,
+            gpioa::PA10<gpio::AF9<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM14,
+            TIM14_CH1,
+            output_to_pf9,
+            gpiof::PF9<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -1326,10 +1904,25 @@ pwm_pin_for_pwm_n_channel!(TIM15, TIM15_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
 pwm_pin_for_pwm_channel!(TIM15, TIM15_CH2, u16, cc2e, ccr2, ccr2);
 
 // Pins
-pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pa2, gpioa::PA2<gpio::AF9>);
+pwm_channel1_pin!(
+    TIM15,
+    TIM15_CH1,
+    output_to_pa2,
+    gpioa::PA2<gpio::AF9<PushPull>>
+);
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pb6, gpiob::PB6<gpio::AF9>);
-pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pb14, gpiob::PB14<gpio::AF1>);
+pwm_channel1_pin!(
+    TIM15,
+    TIM15_CH1,
+    output_to_pb6,
+    gpiob::PB6<gpio::AF9<PushPull>>
+);
+pwm_channel1_pin!(
+    TIM15,
+    TIM15_CH1,
+    output_to_pb14,
+    gpiob::PB14<gpio::AF1<PushPull>>
+);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1342,14 +1935,44 @@ pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pb14, gpiob::PB14<gpio::AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pf9, gpiof::PF9<gpio::AF3>);
+pwm_channel1_pin!(
+    TIM15,
+    TIM15_CH1,
+    output_to_pf9,
+    gpiof::PF9<gpio::AF3<PushPull>>
+);
 
-pwm_channel1n_pin!(TIM15, TIM15_CH1, output_to_pa1, gpioa::PA1<gpio::AF9>);
-pwm_channel1n_pin!(TIM15, TIM15_CH1, output_to_pb15, gpiob::PB15<gpio::AF2>);
-pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pa3, gpioa::PA3<gpio::AF9>);
+pwm_channel1n_pin!(
+    TIM15,
+    TIM15_CH1,
+    output_to_pa1,
+    gpioa::PA1<gpio::AF9<PushPull>>
+);
+pwm_channel1n_pin!(
+    TIM15,
+    TIM15_CH1,
+    output_to_pb15,
+    gpiob::PB15<gpio::AF2<PushPull>>
+);
+pwm_channel2_pin!(
+    TIM15,
+    TIM15_CH2,
+    output_to_pa3,
+    gpioa::PA3<gpio::AF9<PushPull>>
+);
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pb7, gpiob::PB7<gpio::AF9>);
-pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pb15, gpiob::PB15<gpio::AF2>);
+pwm_channel2_pin!(
+    TIM15,
+    TIM15_CH2,
+    output_to_pb7,
+    gpiob::PB7<gpio::AF9<PushPull>>
+);
+pwm_channel2_pin!(
+    TIM15,
+    TIM15_CH2,
+    output_to_pb15,
+    gpiob::PB15<gpio::AF2<PushPull>>
+);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1362,7 +1985,12 @@ pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pb15, gpiob::PB15<gpio::AF2>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pf10, gpiof::PF10<gpio::AF3>);
+pwm_channel2_pin!(
+    TIM15,
+    TIM15_CH2,
+    output_to_pf10,
+    gpiof::PF10<gpio::AF3<PushPull>>
+);
 
 // TIM16
 
@@ -1383,10 +2011,30 @@ pwm_timer_with_break!(
 pwm_pin_for_pwm_n_channel!(TIM16, TIM16_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
 
 // Pins
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pa9, gpioa::PA6<gpio::AF1>);
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pa12, gpioa::PA12<gpio::AF1>);
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pb4, gpiob::PB4<gpio::AF1>);
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pb8, gpiob::PB8<gpio::AF1>);
+pwm_channel1_pin!(
+    TIM16,
+    TIM16_CH1,
+    output_to_pa9,
+    gpioa::PA6<gpio::AF1<PushPull>>
+);
+pwm_channel1_pin!(
+    TIM16,
+    TIM16_CH1,
+    output_to_pa12,
+    gpioa::PA12<gpio::AF1<PushPull>>
+);
+pwm_channel1_pin!(
+    TIM16,
+    TIM16_CH1,
+    output_to_pb4,
+    gpiob::PB4<gpio::AF1<PushPull>>
+);
+pwm_channel1_pin!(
+    TIM16,
+    TIM16_CH1,
+    output_to_pb8,
+    gpiob::PB8<gpio::AF1<PushPull>>
+);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1399,10 +2047,25 @@ pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pb8, gpiob::PB8<gpio::AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pe0, gpioe::PE0<gpio::AF4>);
+pwm_channel1_pin!(
+    TIM16,
+    TIM16_CH1,
+    output_to_pe0,
+    gpioe::PE0<gpio::AF4<PushPull>>
+);
 
-pwm_channel1n_pin!(TIM16, TIM16_CH1, output_to_pa13, gpioa::PA13<gpio::AF1>);
-pwm_channel1n_pin!(TIM16, TIM16_CH1, output_to_pb6, gpiob::PB6<gpio::AF1>);
+pwm_channel1n_pin!(
+    TIM16,
+    TIM16_CH1,
+    output_to_pa13,
+    gpioa::PA13<gpio::AF1<PushPull>>
+);
+pwm_channel1n_pin!(
+    TIM16,
+    TIM16_CH1,
+    output_to_pb6,
+    gpiob::PB6<gpio::AF1<PushPull>>
+);
 
 // TIM17
 
@@ -1423,9 +2086,24 @@ pwm_timer_with_break!(
 pwm_pin_for_pwm_n_channel!(TIM17, TIM17_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
 
 // Pins
-pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pa7, gpioa::PA7<gpio::AF1>);
-pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pb5, gpiob::PB5<gpio::AF10>);
-pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pb9, gpiob::PB9<gpio::AF1>);
+pwm_channel1_pin!(
+    TIM17,
+    TIM17_CH1,
+    output_to_pa7,
+    gpioa::PA7<gpio::AF1<PushPull>>
+);
+pwm_channel1_pin!(
+    TIM17,
+    TIM17_CH1,
+    output_to_pb5,
+    gpiob::PB5<gpio::AF10<PushPull>>
+);
+pwm_channel1_pin!(
+    TIM17,
+    TIM17_CH1,
+    output_to_pb9,
+    gpiob::PB9<gpio::AF1<PushPull>>
+);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1438,9 +2116,19 @@ pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pb9, gpiob::PB9<gpio::AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pe1, gpioe::PE1<gpio::AF4>);
+pwm_channel1_pin!(
+    TIM17,
+    TIM17_CH1,
+    output_to_pe1,
+    gpioe::PE1<gpio::AF4<PushPull>>
+);
 
-pwm_channel1n_pin!(TIM17, TIM17_CH1, output_to_pa13, gpioa::PA13<gpio::AF1>);
+pwm_channel1n_pin!(
+    TIM17,
+    TIM17_CH1,
+    output_to_pa13,
+    gpioa::PA13<gpio::AF1<PushPull>>
+);
 
 // TIM19
 
@@ -1478,21 +2166,81 @@ macro_rules! tim19 {
         pwm_pin_for_pwm_channel!(TIM19, TIM19_CH4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pa0, gpioa::PA0<gpio::AF11>);
-        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pb6, gpiob::PB6<gpio::AF11>);
-        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pc10, gpioc::PC10<gpio::AF2>);
+        pwm_channel1_pin!(
+            TIM19,
+            TIM19_CH1,
+            output_to_pa0,
+            gpioa::PA0<gpio::AF11<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM19,
+            TIM19_CH1,
+            output_to_pb6,
+            gpiob::PB6<gpio::AF11<PushPull>>
+        );
+        pwm_channel1_pin!(
+            TIM19,
+            TIM19_CH1,
+            output_to_pc10,
+            gpioc::PC10<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pa1, gpioa::PA1<gpio::AF11>);
-        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pb7, gpiob::PB7<gpio::AF11>);
-        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pc11, gpioc::PC11<gpio::AF2>);
+        pwm_channel2_pin!(
+            TIM19,
+            TIM19_CH2,
+            output_to_pa1,
+            gpioa::PA1<gpio::AF11<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM19,
+            TIM19_CH2,
+            output_to_pb7,
+            gpiob::PB7<gpio::AF11<PushPull>>
+        );
+        pwm_channel2_pin!(
+            TIM19,
+            TIM19_CH2,
+            output_to_pc11,
+            gpioc::PC11<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pa2, gpioa::PA2<gpio::AF11>);
-        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pb8, gpiob::PB8<gpio::AF11>);
-        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pc12, gpioc::PC12<gpio::AF2>);
+        pwm_channel3_pin!(
+            TIM19,
+            TIM19_CH3,
+            output_to_pa2,
+            gpioa::PA2<gpio::AF11<PushPull>>
+        );
+        pwm_channel3_pin!(
+            TIM19,
+            TIM19_CH3,
+            output_to_pb8,
+            gpiob::PB8<gpio::AF11<PushPull>>
+        );
+        pwm_channel3_pin!(
+            TIM19,
+            TIM19_CH3,
+            output_to_pc12,
+            gpioc::PC12<gpio::AF2<PushPull>>
+        );
 
-        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pa3, gpioa::PA3<gpio::AF11>);
-        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pb9, gpiob::PB9<gpio::AF11>);
-        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pd0, gpiod::PD0<gpio::AF2>);
+        pwm_channel4_pin!(
+            TIM19,
+            TIM19_CH4,
+            output_to_pa3,
+            gpioa::PA3<gpio::AF11<PushPull>>
+        );
+        pwm_channel4_pin!(
+            TIM19,
+            TIM19_CH4,
+            output_to_pb9,
+            gpiob::PB9<gpio::AF11<PushPull>>
+        );
+        pwm_channel4_pin!(
+            TIM19,
+            TIM19_CH4,
+            output_to_pd0,
+            gpiod::PD0<gpio::AF2<PushPull>>
+        );
     };
 }
 
@@ -1534,9 +2282,19 @@ macro_rules! tim20 {
         pwm_pin_for_pwm_n_channel!(TIM20, TIM20_CH1, u16, cc1e, cc1ne, ccr1, ccr);
 
         //Pins
-        pwm_channel1_pin!(TIM20, TIM20_CH1, output_to_pe2, gpioe::PE2<gpio::AF6>);
+        pwm_channel1_pin!(
+            TIM20,
+            TIM20_CH1,
+            output_to_pe2,
+            gpioe::PE2<gpio::AF6<PushPull>>
+        );
 
-        pwm_channel1n_pin!(TIM20, TIM20_CH1, output_to_pe4, gpioe::PE4<gpio::AF6>);
+        pwm_channel1n_pin!(
+            TIM20,
+            TIM20_CH1,
+            output_to_pe4,
+            gpioe::PE4<gpio::AF6<PushPull>>
+        );
     };
 }
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -158,7 +158,7 @@
 use core::marker::PhantomData;
 
 use crate::{
-    gpio::{self, gpioa, gpiob, PushPull},
+    gpio::{self, gpioa, gpiob},
     hal::PwmPin,
     pac::{RCC, TIM15, TIM16, TIM17, TIM2},
     rcc::Clocks,
@@ -344,14 +344,17 @@ macro_rules! pwm_timer_with_break {
 }
 
 macro_rules! pwm_channel_pin {
-    ($resulting_state:ident, $TIMx:ident, $TIMx_CHy:ident, $output_to_pzx:ident, $Pin:ty, $ccmrz_output:ident, $ocym:ident, $ocype:ident) => {
+    ($resulting_state:ident, $TIMx:ident, $TIMx_CHy:ident, $output_to_pzv:ident, $gpioz:ident::$PZv:ident<$AFw:ident>, $ccmrz_output:ident, $ocym:ident, $ocype:ident) => {
         impl PwmChannel<$TIMx_CHy, NoPins> {
             /// Output to a specific pin from a channel that does not yet have
             /// any pins.  This channel cannot be enabled until this method
             /// is called.
             ///
             /// The pin is consumed and cannot be returned.
-            pub fn $output_to_pzx(self, _p: $Pin) -> PwmChannel<$TIMx_CHy, $resulting_state> {
+            pub fn $output_to_pzv<OTYPE>(
+                self,
+                _p: $gpioz::$PZv<gpio::$AFw<OTYPE>>,
+            ) -> PwmChannel<$TIMx_CHy, $resulting_state> {
                 unsafe {
                     (*$TIMx::ptr()).$ccmrz_output().modify(|_, w| {
                         w
@@ -377,7 +380,10 @@ macro_rules! pwm_channel_pin {
             /// can be used (as long as they are compatible).
             ///
             /// The pin is consumed and cannot be returned.
-            pub fn $output_to_pzx(self, _p: $Pin) -> PwmChannel<$TIMx_CHy, $resulting_state> {
+            pub fn $output_to_pzv<OTYPE>(
+                self,
+                _p: $gpioz::$PZv<gpio::$AFw<OTYPE>>,
+            ) -> PwmChannel<$TIMx_CHy, $resulting_state> {
                 self
             }
         }
@@ -385,13 +391,13 @@ macro_rules! pwm_channel_pin {
 }
 
 macro_rules! pwm_channel1_pin {
-    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzx:ident, $Pin:ty) => {
+    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzv:ident, $gpioz:ident::$PZv:ident<$AFw:ident>) => {
         pwm_channel_pin!(
             WithPins,
             $TIMx,
             $TIMx_CHy,
-            $output_to_pzx,
-            $Pin,
+            $output_to_pzv,
+            $gpioz::$PZv<$AFw>,
             ccmr1_output,
             oc1m,
             oc1pe
@@ -400,13 +406,13 @@ macro_rules! pwm_channel1_pin {
 }
 
 macro_rules! pwm_channel1n_pin {
-    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzx:ident, $Pin:ty) => {
+    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzv:ident, $gpioz:ident::$PZv:ident<$AFw:ident>) => {
         pwm_channel_pin!(
             WithNPins,
             $TIMx,
             $TIMx_CHy,
-            $output_to_pzx,
-            $Pin,
+            $output_to_pzv,
+            $gpioz::$PZv<$AFw>,
             ccmr1_output,
             oc1m,
             oc1pe
@@ -415,13 +421,13 @@ macro_rules! pwm_channel1n_pin {
 }
 
 macro_rules! pwm_channel2_pin {
-    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzx:ident, $Pin:ty) => {
+    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzv:ident, $gpioz:ident::$PZv:ident<$AFw:ident>) => {
         pwm_channel_pin!(
             WithPins,
             $TIMx,
             $TIMx_CHy,
-            $output_to_pzx,
-            $Pin,
+            $output_to_pzv,
+            $gpioz::$PZv<$AFw>,
             ccmr1_output,
             oc2m,
             oc2pe
@@ -438,13 +444,13 @@ macro_rules! pwm_channel2_pin {
     feature = "stm32f398"
 ))]
 macro_rules! pwm_channel2n_pin {
-    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzx:ident, $Pin:ty) => {
+    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzv:ident, $gpioz:ident::$PZv:ident<$AFw:ident>) => {
         pwm_channel_pin!(
             WithNPins,
             $TIMx,
             $TIMx_CHy,
-            $output_to_pzx,
-            $Pin,
+            $output_to_pzv,
+            $gpioz::$PZv<$AFw>,
             ccmr1_output,
             oc2m,
             oc2pe
@@ -453,13 +459,13 @@ macro_rules! pwm_channel2n_pin {
 }
 
 macro_rules! pwm_channel3_pin {
-    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzx:ident, $Pin:ty) => {
+    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzv:ident, $gpioz:ident::$PZv:ident<$AFw:ident>) => {
         pwm_channel_pin!(
             WithPins,
             $TIMx,
             $TIMx_CHy,
-            $output_to_pzx,
-            $Pin,
+            $output_to_pzv,
+            $gpioz::$PZv<$AFw>,
             ccmr2_output,
             oc3m,
             oc3pe
@@ -476,13 +482,13 @@ macro_rules! pwm_channel3_pin {
     feature = "stm32f398"
 ))]
 macro_rules! pwm_channel3n_pin {
-    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzx:ident, $Pin:ty) => {
+    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzv:ident, $gpioz:ident::$PZv:ident<$AFw:ident>) => {
         pwm_channel_pin!(
             WithNPins,
             $TIMx,
             $TIMx_CHy,
-            $output_to_pzx,
-            $Pin,
+            $output_to_pzv,
+            $gpioz::$PZv<$AFw>,
             ccmr2_output,
             oc3m,
             oc3pe
@@ -491,13 +497,13 @@ macro_rules! pwm_channel3n_pin {
 }
 
 macro_rules! pwm_channel4_pin {
-    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzx:ident, $Pin:ty) => {
+    ($TIMx:ident, $TIMx_CHy:ident, $output_to_pzv:ident, $gpioz:ident::$PZv:ident<$AFw:ident>) => {
         pwm_channel_pin!(
             WithPins,
             $TIMx,
             $TIMx_CHy,
-            $output_to_pzx,
-            $Pin,
+            $output_to_pzv,
+            $gpioz::$PZv<$AFw>,
             ccmr2_output,
             oc4m,
             oc4pe
@@ -600,129 +606,39 @@ macro_rules! tim1_common {
         pwm_pin_for_pwm_channel!(TIM1, TIM1_CH4, u16, cc4e, ccr4, ccr);
 
         //Pins
-        pwm_channel1_pin!(
-            TIM1,
-            TIM1_CH1,
-            output_to_pa8,
-            gpioa::PA8<gpio::AF6<PushPull>>
-        );
+        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pa8, gpioa::PA8<AF6>);
 
-        pwm_channel1n_pin!(
-            TIM1,
-            TIM1_CH1,
-            output_to_pa7,
-            gpioa::PA7<gpio::AF6<PushPull>>
-        );
-        pwm_channel1n_pin!(
-            TIM1,
-            TIM1_CH1,
-            output_to_pa11,
-            gpioa::PA11<gpio::AF6<PushPull>>
-        );
-        pwm_channel1n_pin!(
-            TIM1,
-            TIM1_CH1,
-            output_to_pb13,
-            gpiob::PB13<gpio::AF6<PushPull>>
-        );
-        pwm_channel1n_pin!(
-            TIM1,
-            TIM1_CH1,
-            output_to_pc13,
-            gpioc::PC13<gpio::AF4<PushPull>>
-        );
+        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pa7, gpioa::PA7<AF6>);
+        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pa11, gpioa::PA11<AF6>);
+        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pb13, gpiob::PB13<AF6>);
+        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pc13, gpioc::PC13<AF4>);
 
-        pwm_channel2_pin!(
-            TIM1,
-            TIM1_CH2,
-            output_to_pa9,
-            gpioa::PA9<gpio::AF6<PushPull>>
-        );
+        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pa9, gpioa::PA9<AF6>);
 
-        pwm_channel2n_pin!(
-            TIM1,
-            TIM1_CH2,
-            output_to_pa12,
-            gpioa::PA12<gpio::AF6<PushPull>>
-        );
-        pwm_channel2n_pin!(
-            TIM1,
-            TIM1_CH2,
-            output_to_pb0,
-            gpiob::PB0<gpio::AF6<PushPull>>
-        );
-        pwm_channel2n_pin!(
-            TIM1,
-            TIM1_CH2,
-            output_to_pb14,
-            gpiob::PB14<gpio::AF6<PushPull>>
-        );
+        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pa12, gpioa::PA12<AF6>);
+        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pb0, gpiob::PB0<AF6>);
+        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pb14, gpiob::PB14<AF6>);
 
-        pwm_channel3_pin!(
-            TIM1,
-            TIM1_CH3,
-            output_to_pa10,
-            gpioa::PA10<gpio::AF6<PushPull>>
-        );
+        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pa10, gpioa::PA10<AF6>);
 
-        pwm_channel3n_pin!(
-            TIM1,
-            TIM1_CH3,
-            output_to_pb1,
-            gpiob::PB1<gpio::AF6<PushPull>>
-        );
-        pwm_channel3n_pin!(
-            TIM1,
-            TIM1_CH3,
-            output_to_pb15,
-            gpiob::PB15<gpio::AF4<PushPull>>
-        );
-        pwm_channel3n_pin!(
-            TIM1,
-            TIM1_CH3,
-            output_to_pf0,
-            gpiof::PF0<gpio::AF6<PushPull>>
-        );
+        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pb1, gpiob::PB1<AF6>);
+        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pb15, gpiob::PB15<AF4>);
+        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pf0, gpiof::PF0<AF6>);
 
-        pwm_channel4_pin!(
-            TIM1,
-            TIM1_CH4,
-            output_to_pa11,
-            gpioa::PA11<gpio::AF11<PushPull>>
-        );
+        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pa11, gpioa::PA11<AF11>);
     };
 }
 
 #[cfg(any(feature = "stm32f334", feature = "stm32f398"))]
 macro_rules! tim1_ext1 {
     () => {
-        pwm_channel1_pin!(
-            TIM1,
-            TIM1_CH1,
-            output_to_pc0,
-            gpioc::PC0<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pc0, gpioc::PC0<AF2>);
 
-        pwm_channel2_pin!(
-            TIM1,
-            TIM1_CH2,
-            output_to_pc1,
-            gpioc::PC1<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pc1, gpioc::PC1<AF2>);
 
-        pwm_channel3_pin!(
-            TIM1,
-            TIM1_CH3,
-            output_to_pc2,
-            gpioc::PC2<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pc2, gpioc::PC2<AF2>);
 
-        pwm_channel4_pin!(
-            TIM1,
-            TIM1_CH4,
-            output_to_pc3,
-            gpioc::PC3<gpio::AF2<PushPull>>
-        );
+        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pc3, gpioc::PC3<AF2>);
     };
 }
 
@@ -740,54 +656,19 @@ macro_rules! tim1_ext1 {
 ))]
 macro_rules! tim1_ext2 {
     () => {
-        pwm_channel1_pin!(
-            TIM1,
-            TIM1_CH1,
-            output_to_pe9,
-            gpioe::PE9<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pe9, gpioe::PE9<AF2>);
 
-        pwm_channel1n_pin!(
-            TIM1,
-            TIM1_CH1,
-            output_to_pe8,
-            gpioe::PE8<gpio::AF2<PushPull>>
-        );
+        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pe8, gpioe::PE8<AF2>);
 
-        pwm_channel2_pin!(
-            TIM1,
-            TIM1_CH2,
-            output_to_pe11,
-            gpioe::PE11<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pe11, gpioe::PE11<AF2>);
 
-        pwm_channel2n_pin!(
-            TIM1,
-            TIM1_CH2,
-            output_to_pe10,
-            gpioe::PE10<gpio::AF2<PushPull>>
-        );
+        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pe10, gpioe::PE10<AF2>);
 
-        pwm_channel3_pin!(
-            TIM1,
-            TIM1_CH3,
-            output_to_pe13,
-            gpioe::PE13<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pe13, gpioe::PE13<AF2>);
 
-        pwm_channel3n_pin!(
-            TIM1,
-            TIM1_CH3,
-            output_to_pe12,
-            gpioe::PE12<gpio::AF2<PushPull>>
-        );
+        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pe12, gpioe::PE12<AF2>);
 
-        pwm_channel4_pin!(
-            TIM1,
-            TIM1_CH4,
-            output_to_pe14,
-            gpioe::PE14<gpio::AF2<PushPull>>
-        );
+        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pe14, gpioe::PE14<AF2>);
     };
 }
 
@@ -841,24 +722,9 @@ pwm_pin_for_pwm_channel!(TIM2, TIM2_CH3, u32, cc3e, ccr3, ccr);
 pwm_pin_for_pwm_channel!(TIM2, TIM2_CH4, u32, cc4e, ccr4, ccr);
 
 // Pins
-pwm_channel1_pin!(
-    TIM2,
-    TIM2_CH1,
-    output_to_pa0,
-    gpioa::PA0<gpio::AF1<PushPull>>
-);
-pwm_channel1_pin!(
-    TIM2,
-    TIM2_CH1,
-    output_to_pa5,
-    gpioa::PA5<gpio::AF1<PushPull>>
-);
-pwm_channel1_pin!(
-    TIM2,
-    TIM2_CH1,
-    output_to_pa15,
-    gpioa::PA15<gpio::AF1<PushPull>>
-);
+pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa0, gpioa::PA0<AF1>);
+pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa5, gpioa::PA5<AF1>);
+pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa15, gpioa::PA15<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -871,25 +737,10 @@ pwm_channel1_pin!(
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(
-    TIM2,
-    TIM2_CH1,
-    output_to_pd3,
-    gpiod::PD3<gpio::AF2<PushPull>>
-);
+pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pd3, gpiod::PD3<AF2>);
 
-pwm_channel2_pin!(
-    TIM2,
-    TIM2_CH2,
-    output_to_pa1,
-    gpioa::PA1<gpio::AF1<PushPull>>
-);
-pwm_channel2_pin!(
-    TIM2,
-    TIM2_CH2,
-    output_to_pb3,
-    gpiob::PB3<gpio::AF1<PushPull>>
-);
+pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pa1, gpioa::PA1<AF1>);
+pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pb3, gpiob::PB3<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -902,31 +753,11 @@ pwm_channel2_pin!(
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel2_pin!(
-    TIM2,
-    TIM2_CH2,
-    output_to_pd4,
-    gpiod::PD4<gpio::AF2<PushPull>>
-);
+pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pd4, gpiod::PD4<AF2>);
 
-pwm_channel3_pin!(
-    TIM2,
-    TIM2_CH3,
-    output_to_pa2,
-    gpioa::PA2<gpio::AF1<PushPull>>
-);
-pwm_channel3_pin!(
-    TIM2,
-    TIM2_CH3,
-    output_to_pa9,
-    gpioa::PA9<gpio::AF10<PushPull>>
-);
-pwm_channel3_pin!(
-    TIM2,
-    TIM2_CH3,
-    output_to_pb10,
-    gpiob::PB10<gpio::AF1<PushPull>>
-);
+pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pa2, gpioa::PA2<AF1>);
+pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pa9, gpioa::PA9<AF10>);
+pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pb10, gpiob::PB10<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -939,32 +770,12 @@ pwm_channel3_pin!(
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel3_pin!(
-    TIM2,
-    TIM2_CH3,
-    output_to_pd7,
-    gpiod::PD7<gpio::AF2<PushPull>>
-);
+pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pd7, gpiod::PD7<AF2>);
 
-pwm_channel4_pin!(
-    TIM2,
-    TIM2_CH4,
-    output_to_pa3,
-    gpioa::PA3<gpio::AF1<PushPull>>
-);
-pwm_channel4_pin!(
-    TIM2,
-    TIM2_CH4,
-    output_to_pa10,
-    gpioa::PA10<gpio::AF1<PushPull>>
-);
+pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pa3, gpioa::PA3<AF1>);
+pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pa10, gpioa::PA10<AF1>);
 #[cfg(not(any(feature = "stm32f373", feature = "stm32f378")))]
-pwm_channel4_pin!(
-    TIM2,
-    TIM2_CH4,
-    output_to_pb11,
-    gpiob::PB11<gpio::AF1<PushPull>>
-);
+pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pb11, gpiob::PB11<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -977,12 +788,7 @@ pwm_channel4_pin!(
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel4_pin!(
-    TIM2,
-    TIM2_CH4,
-    output_to_pd6,
-    gpiod::PD6<gpio::AF2<PushPull>>
-);
+pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pd6, gpiod::PD6<AF2>);
 
 // TIM3
 
@@ -1029,57 +835,17 @@ macro_rules! tim3_common {
         pwm_pin_for_pwm_channel!(TIM3, TIM3_CH4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(
-            TIM3,
-            TIM3_CH1,
-            output_to_pa6,
-            gpioa::PA6<gpio::AF2<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM3,
-            TIM3_CH1,
-            output_to_pb4,
-            gpiob::PB4<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pa6, gpioa::PA6<AF2>);
+        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pb4, gpiob::PB4<AF2>);
 
-        pwm_channel2_pin!(
-            TIM3,
-            TIM3_CH2,
-            output_to_pa4,
-            gpioa::PA4<gpio::AF2<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM3,
-            TIM3_CH2,
-            output_to_pa7,
-            gpioa::PA7<gpio::AF2<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM3,
-            TIM3_CH2,
-            output_to_pb5,
-            gpiob::PB5<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pa4, gpioa::PA4<AF2>);
+        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pa7, gpioa::PA7<AF2>);
+        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pb5, gpiob::PB5<AF2>);
 
-        pwm_channel3_pin!(
-            TIM3,
-            TIM3_CH3,
-            output_to_pb0,
-            gpiob::PB0<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pb0, gpiob::PB0<AF2>);
 
-        pwm_channel4_pin!(
-            TIM3,
-            TIM3_CH4,
-            output_to_pb1,
-            gpiob::PB1<gpio::AF2<PushPull>>
-        );
-        pwm_channel4_pin!(
-            TIM3,
-            TIM3_CH4,
-            output_to_pb7,
-            gpiob::PB7<gpio::AF10<PushPull>>
-        );
+        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pb1, gpiob::PB1<AF2>);
+        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pb7, gpiob::PB7<AF10>);
     };
 }
 
@@ -1094,33 +860,13 @@ macro_rules! tim3_common {
 ))]
 macro_rules! tim3_ext1 {
     () => {
-        pwm_channel1_pin!(
-            TIM3,
-            TIM3_CH1,
-            output_to_pc6,
-            gpioc::PC6<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pc6, gpioc::PC6<AF2>);
 
-        pwm_channel2_pin!(
-            TIM3,
-            TIM3_CH2,
-            output_to_pc7,
-            gpioc::PC7<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pc7, gpioc::PC7<AF2>);
 
-        pwm_channel3_pin!(
-            TIM3,
-            TIM3_CH3,
-            output_to_pc8,
-            gpioc::PC8<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pc8, gpioc::PC8<AF2>);
 
-        pwm_channel4_pin!(
-            TIM3,
-            TIM3_CH4,
-            output_to_pc9,
-            gpioc::PC9<gpio::AF2<PushPull>>
-        );
+        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pc9, gpioc::PC9<AF2>);
     };
 }
 
@@ -1138,33 +884,13 @@ macro_rules! tim3_ext1 {
 ))]
 macro_rules! tim3_ext2 {
     () => {
-        pwm_channel1_pin!(
-            TIM3,
-            TIM3_CH1,
-            output_to_pe2,
-            gpioe::PE6<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pe2, gpioe::PE6<AF2>);
 
-        pwm_channel2_pin!(
-            TIM3,
-            TIM3_CH2,
-            output_to_pe3,
-            gpioe::PE7<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pe3, gpioe::PE7<AF2>);
 
-        pwm_channel3_pin!(
-            TIM3,
-            TIM3_CH3,
-            output_to_pe4,
-            gpioe::PE8<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pe4, gpioe::PE8<AF2>);
 
-        pwm_channel4_pin!(
-            TIM3,
-            TIM3_CH4,
-            output_to_pe5,
-            gpioe::PE9<gpio::AF2<PushPull>>
-        );
+        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pe5, gpioe::PE9<AF2>);
     };
 }
 
@@ -1206,20 +932,10 @@ tim3_ext1!();
 tim3_ext2!();
 
 #[cfg(feature = "stm32f373")]
-pwm_channel2_pin!(
-    TIM3,
-    TIM3_CH2,
-    output_to_pb0,
-    gpiob::PB0<gpio::AF10<PushPull>>
-);
+pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pb0, gpiob::PB0<AF10>);
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel3_pin!(
-    TIM3,
-    TIM3_CH3,
-    output_to_pb6,
-    gpiob::PB6<gpio::AF10<PushPull>>
-);
+pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pb6, gpiob::PB6<AF10>);
 
 // TIM4
 
@@ -1264,51 +980,16 @@ macro_rules! tim4_common {
         pwm_pin_for_pwm_channel!(TIM4, TIM4_CH4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(
-            TIM4,
-            TIM4_CH1,
-            output_to_pa11,
-            gpioa::PA11<gpio::AF10<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM4,
-            TIM4_CH1,
-            output_to_pb6,
-            gpiob::PB6<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pa11, gpioa::PA11<AF10>);
+        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pb6, gpiob::PB6<AF2>);
 
-        pwm_channel2_pin!(
-            TIM4,
-            TIM4_CH2,
-            output_to_pa12,
-            gpioa::PA12<gpio::AF10<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM4,
-            TIM4_CH2,
-            output_to_pb7,
-            gpiob::PB7<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pa12, gpioa::PA12<AF10>);
+        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pb7, gpiob::PB7<AF2>);
 
-        pwm_channel3_pin!(
-            TIM4,
-            TIM4_CH3,
-            output_to_pa13,
-            gpioa::PA13<gpio::AF10<PushPull>>
-        );
-        pwm_channel3_pin!(
-            TIM4,
-            TIM4_CH3,
-            output_to_pb8,
-            gpiob::PB8<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pa13, gpioa::PA13<AF10>);
+        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pb8, gpiob::PB8<AF2>);
 
-        pwm_channel4_pin!(
-            TIM4,
-            TIM4_CH4,
-            output_to_pb9,
-            gpiob::PB9<gpio::AF2<PushPull>>
-        );
+        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pb9, gpiob::PB9<AF2>);
     };
 }
 
@@ -1328,39 +1009,14 @@ macro_rules! tim4_common {
 ))]
 macro_rules! tim4_ext {
     () => {
-        pwm_channel1_pin!(
-            TIM4,
-            TIM4_CH1,
-            output_to_pd12,
-            gpiod::PD12<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pd12, gpiod::PD12<AF2>);
 
-        pwm_channel2_pin!(
-            TIM4,
-            TIM4_CH2,
-            output_to_pd13,
-            gpiod::PD13<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pd13, gpiod::PD13<AF2>);
 
-        pwm_channel3_pin!(
-            TIM4,
-            TIM4_CH3,
-            output_to_pd14,
-            gpiod::PD14<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pd14, gpiod::PD14<AF2>);
 
-        pwm_channel4_pin!(
-            TIM4,
-            TIM4_CH4,
-            output_to_pd15,
-            gpiod::PD15<gpio::AF2<PushPull>>
-        );
-        pwm_channel4_pin!(
-            TIM4,
-            TIM4_CH4,
-            output_to_pf6,
-            gpiof::PF6<gpio::AF2<PushPull>>
-        );
+        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pd15, gpiod::PD15<AF2>);
+        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pf6, gpiof::PF6<AF2>);
     };
 }
 
@@ -1426,81 +1082,21 @@ macro_rules! tim5 {
         pwm_pin_for_pwm_channel!(TIM5, TIM5_CH4, u32, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(
-            TIM5,
-            TIM5_CH1,
-            output_to_pa0,
-            gpioa::PA0<gpio::AF2<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM5,
-            TIM5_CH1,
-            output_to_pa8,
-            gpioa::PA8<gpio::AF2<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM5,
-            TIM5_CH1,
-            output_to_pc0,
-            gpioc::PC0<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pa0, gpioa::PA0<AF2>);
+        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pa8, gpioa::PA8<AF2>);
+        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pc0, gpioc::PC0<AF2>);
 
-        pwm_channel2_pin!(
-            TIM5,
-            TIM5_CH2,
-            output_to_pa1,
-            gpioa::PA1<gpio::AF2<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM5,
-            TIM5_CH2,
-            output_to_pa11,
-            gpioa::PA11<gpio::AF2<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM5,
-            TIM5_CH2,
-            output_to_pc1,
-            gpioc::PC1<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pa1, gpioa::PA1<AF2>);
+        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pa11, gpioa::PA11<AF2>);
+        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pc1, gpioc::PC1<AF2>);
 
-        pwm_channel3_pin!(
-            TIM5,
-            TIM5_CH3,
-            output_to_pa2,
-            gpioa::PA2<gpio::AF2<PushPull>>
-        );
-        pwm_channel3_pin!(
-            TIM5,
-            TIM5_CH3,
-            output_to_pa12,
-            gpioa::PA12<gpio::AF2<PushPull>>
-        );
-        pwm_channel3_pin!(
-            TIM5,
-            TIM5_CH3,
-            output_to_pc2,
-            gpioc::PC2<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pa2, gpioa::PA2<AF2>);
+        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pa12, gpioa::PA12<AF2>);
+        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pc2, gpioc::PC2<AF2>);
 
-        pwm_channel4_pin!(
-            TIM5,
-            TIM5_CH4,
-            output_to_pa3,
-            gpioa::PA3<gpio::AF2<PushPull>>
-        );
-        pwm_channel4_pin!(
-            TIM5,
-            TIM5_CH4,
-            output_to_pa13,
-            gpioa::PA13<gpio::AF2<PushPull>>
-        );
-        pwm_channel4_pin!(
-            TIM5,
-            TIM5_CH4,
-            output_to_pc3,
-            gpioc::PC3<gpio::AF2<PushPull>>
-        );
+        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pa3, gpioa::PA3<AF2>);
+        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pa13, gpioa::PA13<AF2>);
+        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pc3, gpioc::PC3<AF2>);
     };
 }
 
@@ -1544,120 +1140,30 @@ macro_rules! tim8 {
         pwm_pin_for_pwm_channel!(TIM8, TIM8_CH4, u16, cc4e, ccr4, ccr);
 
         //Pins
-        pwm_channel1_pin!(
-            TIM8,
-            TIM8_CH1,
-            output_to_pa15,
-            gpioa::PA15<gpio::AF2<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM8,
-            TIM8_CH1,
-            output_to_pb6,
-            gpiob::PB6<gpio::AF2<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM8,
-            TIM8_CH1,
-            output_to_pc6,
-            gpioc::PC6<gpio::AF4<PushPull>>
-        );
+        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pa15, gpioa::PA15<AF2>);
+        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pb6, gpiob::PB6<AF2>);
+        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pc6, gpioc::PC6<AF4>);
 
-        pwm_channel1n_pin!(
-            TIM8,
-            TIM8_CH1,
-            output_to_pa7,
-            gpioa::PA7<gpio::AF4<PushPull>>
-        );
-        pwm_channel1n_pin!(
-            TIM8,
-            TIM8_CH1,
-            output_to_pb3,
-            gpiob::PB3<gpio::AF4<PushPull>>
-        );
-        pwm_channel1n_pin!(
-            TIM8,
-            TIM8_CH1,
-            output_to_pc10,
-            gpioc::PC10<gpio::AF4<PushPull>>
-        );
+        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pa7, gpioa::PA7<AF4>);
+        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pb3, gpiob::PB3<AF4>);
+        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pc10, gpioc::PC10<AF4>);
 
-        pwm_channel2_pin!(
-            TIM8,
-            TIM8_CH2,
-            output_to_pa14,
-            gpioa::PA14<gpio::AF5<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM8,
-            TIM8_CH2,
-            output_to_pb8,
-            gpiob::PB8<gpio::AF10<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM8,
-            TIM8_CH2,
-            output_to_pc7,
-            gpioc::PC7<gpio::AF4<PushPull>>
-        );
+        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pa14, gpioa::PA14<AF5>);
+        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pb8, gpiob::PB8<AF10>);
+        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pc7, gpioc::PC7<AF4>);
 
-        pwm_channel2n_pin!(
-            TIM8,
-            TIM8_CH2,
-            output_to_pb0,
-            gpiob::PB0<gpio::AF4<PushPull>>
-        );
-        pwm_channel2n_pin!(
-            TIM8,
-            TIM8_CH2,
-            output_to_pb4,
-            gpiob::PB4<gpio::AF4<PushPull>>
-        );
-        pwm_channel2n_pin!(
-            TIM8,
-            TIM8_CH2,
-            output_to_pc11,
-            gpioc::PC11<gpio::AF4<PushPull>>
-        );
+        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pb0, gpiob::PB0<AF4>);
+        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pb4, gpiob::PB4<AF4>);
+        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pc11, gpioc::PC11<AF4>);
 
-        pwm_channel3_pin!(
-            TIM8,
-            TIM8_CH3,
-            output_to_pb9,
-            gpiob::PB9<gpio::AF10<PushPull>>
-        );
-        pwm_channel3_pin!(
-            TIM8,
-            TIM8_CH3,
-            output_to_pc8,
-            gpioc::PC8<gpio::AF4<PushPull>>
-        );
+        pwm_channel3_pin!(TIM8, TIM8_CH3, output_to_pb9, gpiob::PB9<AF10>);
+        pwm_channel3_pin!(TIM8, TIM8_CH3, output_to_pc8, gpioc::PC8<AF4>);
 
-        pwm_channel3n_pin!(
-            TIM8,
-            TIM8_CH3,
-            output_to_pb1,
-            gpiob::PB1<gpio::AF4<PushPull>>
-        );
-        pwm_channel3n_pin!(
-            TIM8,
-            TIM8_CH3,
-            output_to_pb5,
-            gpiob::PB5<gpio::AF3<PushPull>>
-        );
-        pwm_channel3n_pin!(
-            TIM8,
-            TIM8_CH3,
-            output_to_pc12,
-            gpioc::PC12<gpio::AF4<PushPull>>
-        );
+        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pb1, gpiob::PB1<AF4>);
+        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pb5, gpiob::PB5<AF3>);
+        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pc12, gpioc::PC12<AF4>);
 
-        pwm_channel4_pin!(
-            TIM8,
-            TIM8_CH4,
-            output_to_pc9,
-            gpioc::PC9<gpio::AF4<PushPull>>
-        );
+        pwm_channel4_pin!(TIM8, TIM8_CH4, output_to_pc9, gpioc::PC9<AF4>);
     };
 }
 
@@ -1672,12 +1178,7 @@ tim8!();
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel4_pin!(
-    TIM8,
-    TIM8_CH4,
-    output_to_pd1,
-    gpiod::PD1<gpio::AF4<PushPull>>
-);
+pwm_channel4_pin!(TIM8, TIM8_CH4, output_to_pd1, gpiod::PD1<AF4>);
 
 // TIM12
 
@@ -1713,43 +1214,13 @@ macro_rules! tim12 {
         pwm_pin_for_pwm_channel!(TIM12, TIM12_CH2, u16, cc2e, ccr2, ccr);
 
         // Pins
-        pwm_channel1_pin!(
-            TIM12,
-            TIM12_CH1,
-            output_to_pa4,
-            gpioa::PA4<gpio::AF10<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM12,
-            TIM12_CH1,
-            output_to_pa14,
-            gpioa::PA14<gpio::AF10<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM12,
-            TIM12_CH1,
-            output_to_pb14,
-            gpiob::PB14<gpio::AF10<PushPull>>
-        );
+        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pa4, gpioa::PA4<AF10>);
+        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pa14, gpioa::PA14<AF10>);
+        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pb14, gpiob::PB14<AF10>);
 
-        pwm_channel2_pin!(
-            TIM12,
-            TIM12_CH2,
-            output_to_pa5,
-            gpioa::PA5<gpio::AF10<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM12,
-            TIM12_CH2,
-            output_to_pa15,
-            gpioa::PA15<gpio::AF10<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM12,
-            TIM12_CH2,
-            output_to_pb15,
-            gpiob::PB15<gpio::AF10<PushPull>>
-        );
+        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pa5, gpioa::PA5<AF10>);
+        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pa15, gpioa::PA15<AF10>);
+        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pb15, gpiob::PB15<AF10>);
     };
 }
 
@@ -1790,30 +1261,10 @@ macro_rules! tim13 {
         pwm_pin_for_pwm_channel!(TIM13, TIM13_CH1, u16, cc1e, ccr1, ccr);
 
         // Pins
-        pwm_channel1_pin!(
-            TIM13,
-            TIM13_CH1,
-            output_to_pa6,
-            gpioa::PA6<gpio::AF9<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM13,
-            TIM13_CH1,
-            output_to_pa9,
-            gpioa::PA9<gpio::AF2<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM13,
-            TIM13_CH1,
-            output_to_pb3,
-            gpiob::PB3<gpio::AF9<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM13,
-            TIM13_CH1,
-            output_to_pc4,
-            gpioc::PC4<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pa6, gpioa::PA6<AF9>);
+        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pa9, gpioa::PA9<AF2>);
+        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pb3, gpiob::PB3<AF9>);
+        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pc4, gpioc::PC4<AF2>);
     };
 }
 
@@ -1853,30 +1304,10 @@ macro_rules! tim14 {
         pwm_pin_for_pwm_channel!(TIM14, TIM14_CH1, u16, cc1e, ccr1, ccr);
 
         // Pins
-        pwm_channel1_pin!(
-            TIM14,
-            TIM14_CH1,
-            output_to_pa5,
-            gpioa::PA5<gpio::AF9<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM14,
-            TIM14_CH1,
-            output_to_pa7,
-            gpioa::PA7<gpio::AF9<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM14,
-            TIM14_CH1,
-            output_to_pa10,
-            gpioa::PA10<gpio::AF9<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM14,
-            TIM14_CH1,
-            output_to_pf9,
-            gpiof::PF9<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa5, gpioa::PA5<AF9>);
+        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa7, gpioa::PA7<AF9>);
+        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa10, gpioa::PA10<AF9>);
+        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pf9, gpiof::PF9<AF2>);
     };
 }
 
@@ -1904,25 +1335,10 @@ pwm_pin_for_pwm_n_channel!(TIM15, TIM15_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
 pwm_pin_for_pwm_channel!(TIM15, TIM15_CH2, u16, cc2e, ccr2, ccr2);
 
 // Pins
-pwm_channel1_pin!(
-    TIM15,
-    TIM15_CH1,
-    output_to_pa2,
-    gpioa::PA2<gpio::AF9<PushPull>>
-);
+pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pa2, gpioa::PA2<AF9>);
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel1_pin!(
-    TIM15,
-    TIM15_CH1,
-    output_to_pb6,
-    gpiob::PB6<gpio::AF9<PushPull>>
-);
-pwm_channel1_pin!(
-    TIM15,
-    TIM15_CH1,
-    output_to_pb14,
-    gpiob::PB14<gpio::AF1<PushPull>>
-);
+pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pb6, gpiob::PB6<AF9>);
+pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pb14, gpiob::PB14<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1935,44 +1351,14 @@ pwm_channel1_pin!(
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(
-    TIM15,
-    TIM15_CH1,
-    output_to_pf9,
-    gpiof::PF9<gpio::AF3<PushPull>>
-);
+pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pf9, gpiof::PF9<AF3>);
 
-pwm_channel1n_pin!(
-    TIM15,
-    TIM15_CH1,
-    output_to_pa1,
-    gpioa::PA1<gpio::AF9<PushPull>>
-);
-pwm_channel1n_pin!(
-    TIM15,
-    TIM15_CH1,
-    output_to_pb15,
-    gpiob::PB15<gpio::AF2<PushPull>>
-);
-pwm_channel2_pin!(
-    TIM15,
-    TIM15_CH2,
-    output_to_pa3,
-    gpioa::PA3<gpio::AF9<PushPull>>
-);
+pwm_channel1n_pin!(TIM15, TIM15_CH1, output_to_pa1, gpioa::PA1<AF9>);
+pwm_channel1n_pin!(TIM15, TIM15_CH1, output_to_pb15, gpiob::PB15<AF2>);
+pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pa3, gpioa::PA3<AF9>);
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel2_pin!(
-    TIM15,
-    TIM15_CH2,
-    output_to_pb7,
-    gpiob::PB7<gpio::AF9<PushPull>>
-);
-pwm_channel2_pin!(
-    TIM15,
-    TIM15_CH2,
-    output_to_pb15,
-    gpiob::PB15<gpio::AF2<PushPull>>
-);
+pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pb7, gpiob::PB7<AF9>);
+pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pb15, gpiob::PB15<AF2>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1985,12 +1371,7 @@ pwm_channel2_pin!(
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel2_pin!(
-    TIM15,
-    TIM15_CH2,
-    output_to_pf10,
-    gpiof::PF10<gpio::AF3<PushPull>>
-);
+pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pf10, gpiof::PF10<AF3>);
 
 // TIM16
 
@@ -2011,30 +1392,10 @@ pwm_timer_with_break!(
 pwm_pin_for_pwm_n_channel!(TIM16, TIM16_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
 
 // Pins
-pwm_channel1_pin!(
-    TIM16,
-    TIM16_CH1,
-    output_to_pa9,
-    gpioa::PA6<gpio::AF1<PushPull>>
-);
-pwm_channel1_pin!(
-    TIM16,
-    TIM16_CH1,
-    output_to_pa12,
-    gpioa::PA12<gpio::AF1<PushPull>>
-);
-pwm_channel1_pin!(
-    TIM16,
-    TIM16_CH1,
-    output_to_pb4,
-    gpiob::PB4<gpio::AF1<PushPull>>
-);
-pwm_channel1_pin!(
-    TIM16,
-    TIM16_CH1,
-    output_to_pb8,
-    gpiob::PB8<gpio::AF1<PushPull>>
-);
+pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pa9, gpioa::PA6<AF1>);
+pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pa12, gpioa::PA12<AF1>);
+pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pb4, gpiob::PB4<AF1>);
+pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pb8, gpiob::PB8<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -2047,25 +1408,10 @@ pwm_channel1_pin!(
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(
-    TIM16,
-    TIM16_CH1,
-    output_to_pe0,
-    gpioe::PE0<gpio::AF4<PushPull>>
-);
+pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pe0, gpioe::PE0<AF4>);
 
-pwm_channel1n_pin!(
-    TIM16,
-    TIM16_CH1,
-    output_to_pa13,
-    gpioa::PA13<gpio::AF1<PushPull>>
-);
-pwm_channel1n_pin!(
-    TIM16,
-    TIM16_CH1,
-    output_to_pb6,
-    gpiob::PB6<gpio::AF1<PushPull>>
-);
+pwm_channel1n_pin!(TIM16, TIM16_CH1, output_to_pa13, gpioa::PA13<AF1>);
+pwm_channel1n_pin!(TIM16, TIM16_CH1, output_to_pb6, gpiob::PB6<AF1>);
 
 // TIM17
 
@@ -2086,24 +1432,9 @@ pwm_timer_with_break!(
 pwm_pin_for_pwm_n_channel!(TIM17, TIM17_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
 
 // Pins
-pwm_channel1_pin!(
-    TIM17,
-    TIM17_CH1,
-    output_to_pa7,
-    gpioa::PA7<gpio::AF1<PushPull>>
-);
-pwm_channel1_pin!(
-    TIM17,
-    TIM17_CH1,
-    output_to_pb5,
-    gpiob::PB5<gpio::AF10<PushPull>>
-);
-pwm_channel1_pin!(
-    TIM17,
-    TIM17_CH1,
-    output_to_pb9,
-    gpiob::PB9<gpio::AF1<PushPull>>
-);
+pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pa7, gpioa::PA7<AF1>);
+pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pb5, gpiob::PB5<AF10>);
+pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pb9, gpiob::PB9<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -2116,19 +1447,9 @@ pwm_channel1_pin!(
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(
-    TIM17,
-    TIM17_CH1,
-    output_to_pe1,
-    gpioe::PE1<gpio::AF4<PushPull>>
-);
+pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pe1, gpioe::PE1<AF4>);
 
-pwm_channel1n_pin!(
-    TIM17,
-    TIM17_CH1,
-    output_to_pa13,
-    gpioa::PA13<gpio::AF1<PushPull>>
-);
+pwm_channel1n_pin!(TIM17, TIM17_CH1, output_to_pa13, gpioa::PA13<AF1>);
 
 // TIM19
 
@@ -2166,81 +1487,21 @@ macro_rules! tim19 {
         pwm_pin_for_pwm_channel!(TIM19, TIM19_CH4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(
-            TIM19,
-            TIM19_CH1,
-            output_to_pa0,
-            gpioa::PA0<gpio::AF11<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM19,
-            TIM19_CH1,
-            output_to_pb6,
-            gpiob::PB6<gpio::AF11<PushPull>>
-        );
-        pwm_channel1_pin!(
-            TIM19,
-            TIM19_CH1,
-            output_to_pc10,
-            gpioc::PC10<gpio::AF2<PushPull>>
-        );
+        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pa0, gpioa::PA0<AF11>);
+        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pb6, gpiob::PB6<AF11>);
+        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pc10, gpioc::PC10<AF2>);
 
-        pwm_channel2_pin!(
-            TIM19,
-            TIM19_CH2,
-            output_to_pa1,
-            gpioa::PA1<gpio::AF11<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM19,
-            TIM19_CH2,
-            output_to_pb7,
-            gpiob::PB7<gpio::AF11<PushPull>>
-        );
-        pwm_channel2_pin!(
-            TIM19,
-            TIM19_CH2,
-            output_to_pc11,
-            gpioc::PC11<gpio::AF2<PushPull>>
-        );
+        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pa1, gpioa::PA1<AF11>);
+        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pb7, gpiob::PB7<AF11>);
+        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pc11, gpioc::PC11<AF2>);
 
-        pwm_channel3_pin!(
-            TIM19,
-            TIM19_CH3,
-            output_to_pa2,
-            gpioa::PA2<gpio::AF11<PushPull>>
-        );
-        pwm_channel3_pin!(
-            TIM19,
-            TIM19_CH3,
-            output_to_pb8,
-            gpiob::PB8<gpio::AF11<PushPull>>
-        );
-        pwm_channel3_pin!(
-            TIM19,
-            TIM19_CH3,
-            output_to_pc12,
-            gpioc::PC12<gpio::AF2<PushPull>>
-        );
+        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pa2, gpioa::PA2<AF11>);
+        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pb8, gpiob::PB8<AF11>);
+        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pc12, gpioc::PC12<AF2>);
 
-        pwm_channel4_pin!(
-            TIM19,
-            TIM19_CH4,
-            output_to_pa3,
-            gpioa::PA3<gpio::AF11<PushPull>>
-        );
-        pwm_channel4_pin!(
-            TIM19,
-            TIM19_CH4,
-            output_to_pb9,
-            gpiob::PB9<gpio::AF11<PushPull>>
-        );
-        pwm_channel4_pin!(
-            TIM19,
-            TIM19_CH4,
-            output_to_pd0,
-            gpiod::PD0<gpio::AF2<PushPull>>
-        );
+        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pa3, gpioa::PA3<AF11>);
+        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pb9, gpiob::PB9<AF11>);
+        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pd0, gpiod::PD0<AF2>);
     };
 }
 
@@ -2282,19 +1543,9 @@ macro_rules! tim20 {
         pwm_pin_for_pwm_n_channel!(TIM20, TIM20_CH1, u16, cc1e, cc1ne, ccr1, ccr);
 
         //Pins
-        pwm_channel1_pin!(
-            TIM20,
-            TIM20_CH1,
-            output_to_pe2,
-            gpioe::PE2<gpio::AF6<PushPull>>
-        );
+        pwm_channel1_pin!(TIM20, TIM20_CH1, output_to_pe2, gpioe::PE2<AF6>);
 
-        pwm_channel1n_pin!(
-            TIM20,
-            TIM20_CH1,
-            output_to_pe4,
-            gpioe::PE4<gpio::AF6<PushPull>>
-        );
+        pwm_channel1n_pin!(TIM20, TIM20_CH1, output_to_pe4, gpioe::PE4<AF6>);
     };
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,7 +1,9 @@
 //! Serial
 
+use core::{convert::Infallible, marker::PhantomData, ptr};
+
 use crate::{
-    gpio::{gpioa, gpiob, gpioc, AF7},
+    gpio::{gpioa, gpiob, gpioc, PushPull, AF7},
     hal::{blocking, serial},
     pac::{USART1, USART2, USART3},
     rcc::{Clocks, APB1, APB2},
@@ -9,7 +11,6 @@ use crate::{
 };
 
 use cfg_if::cfg_if;
-use core::{convert::Infallible, marker::PhantomData, ptr};
 
 cfg_if! {
     if #[cfg(any(feature = "stm32f302", feature = "stm32f303"))] {
@@ -47,42 +48,42 @@ pub unsafe trait TxPin<USART> {}
 /// RX pin - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait RxPin<USART> {}
 
-unsafe impl TxPin<USART1> for gpioa::PA9<AF7> {}
-unsafe impl TxPin<USART1> for gpiob::PB6<AF7> {}
-unsafe impl TxPin<USART1> for gpioc::PC4<AF7> {}
-unsafe impl RxPin<USART1> for gpioa::PA10<AF7> {}
-unsafe impl RxPin<USART1> for gpiob::PB7<AF7> {}
-unsafe impl RxPin<USART1> for gpioc::PC5<AF7> {}
+unsafe impl TxPin<USART1> for gpioa::PA9<AF7<PushPull>> {}
+unsafe impl TxPin<USART1> for gpiob::PB6<AF7<PushPull>> {}
+unsafe impl TxPin<USART1> for gpioc::PC4<AF7<PushPull>> {}
+unsafe impl RxPin<USART1> for gpioa::PA10<AF7<PushPull>> {}
+unsafe impl RxPin<USART1> for gpiob::PB7<AF7<PushPull>> {}
+unsafe impl RxPin<USART1> for gpioc::PC5<AF7<PushPull>> {}
 
-unsafe impl TxPin<USART2> for gpioa::PA2<AF7> {}
-unsafe impl TxPin<USART2> for gpiob::PB3<AF7> {}
-unsafe impl RxPin<USART2> for gpioa::PA3<AF7> {}
-unsafe impl RxPin<USART2> for gpiob::PB4<AF7> {}
+unsafe impl TxPin<USART2> for gpioa::PA2<AF7<PushPull>> {}
+unsafe impl TxPin<USART2> for gpiob::PB3<AF7<PushPull>> {}
+unsafe impl RxPin<USART2> for gpioa::PA3<AF7<PushPull>> {}
+unsafe impl RxPin<USART2> for gpiob::PB4<AF7<PushPull>> {}
 
-unsafe impl TxPin<USART3> for gpiob::PB10<AF7> {}
-unsafe impl TxPin<USART3> for gpioc::PC10<AF7> {}
-unsafe impl RxPin<USART3> for gpioc::PC11<AF7> {}
+unsafe impl TxPin<USART3> for gpiob::PB10<AF7<PushPull>> {}
+unsafe impl TxPin<USART3> for gpioc::PC10<AF7<PushPull>> {}
+unsafe impl RxPin<USART3> for gpioc::PC11<AF7<PushPull>> {}
 
 cfg_if! {
     if #[cfg(any(feature = "gpio-f303", feature = "gpio-f303e", feature = "gpio-f373"))] {
         use crate::gpio::{gpiod, gpioe};
 
-        unsafe impl TxPin<USART1> for gpioe::PE0<AF7> {}
-        unsafe impl RxPin<USART1> for gpioe::PE1<AF7> {}
+        unsafe impl TxPin<USART1> for gpioe::PE0<AF7<PushPull>> {}
+        unsafe impl RxPin<USART1> for gpioe::PE1<AF7<PushPull>> {}
 
-        unsafe impl TxPin<USART2> for gpiod::PD5<AF7> {}
-        unsafe impl RxPin<USART2> for gpiod::PD6<AF7> {}
+        unsafe impl TxPin<USART2> for gpiod::PD5<AF7<PushPull>> {}
+        unsafe impl RxPin<USART2> for gpiod::PD6<AF7<PushPull>> {}
 
-        unsafe impl TxPin<USART3> for gpiod::PD8<AF7> {}
-        unsafe impl RxPin<USART3> for gpiod::PD9<AF7> {}
-        unsafe impl RxPin<USART3> for gpioe::PE15<AF7> {}
+        unsafe impl TxPin<USART3> for gpiod::PD8<AF7<PushPull>> {}
+        unsafe impl RxPin<USART3> for gpiod::PD9<AF7<PushPull>> {}
+        unsafe impl RxPin<USART3> for gpioe::PE15<AF7<PushPull>> {}
     }
 }
 cfg_if! {
     if #[cfg(not(feature = "gpio-f373"))] {
-        unsafe impl TxPin<USART2> for gpioa::PA14<AF7> {}
-        unsafe impl RxPin<USART2> for gpioa::PA15<AF7> {}
-        unsafe impl RxPin<USART3> for gpiob::PB11<AF7> {}
+        unsafe impl TxPin<USART2> for gpioa::PA14<AF7<PushPull>> {}
+        unsafe impl RxPin<USART2> for gpioa::PA15<AF7<PushPull>> {}
+        unsafe impl RxPin<USART3> for gpiob::PB11<AF7<PushPull>> {}
     }
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -48,44 +48,44 @@ pub unsafe trait TxPin<USART> {}
 /// RX pin - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait RxPin<USART> {}
 
-unsafe impl<OTYPE> TxPin<USART1> for gpioa::PA9<AF7<OTYPE>> {}
-unsafe impl<OTYPE> TxPin<USART1> for gpiob::PB6<AF7<OTYPE>> {}
-unsafe impl<OTYPE> TxPin<USART1> for gpioc::PC4<AF7<OTYPE>> {}
-unsafe impl<OTYPE> RxPin<USART1> for gpioa::PA10<AF7<OTYPE>> {}
-unsafe impl<OTYPE> RxPin<USART1> for gpiob::PB7<AF7<OTYPE>> {}
-unsafe impl<OTYPE> RxPin<USART1> for gpioc::PC5<AF7<OTYPE>> {}
+unsafe impl<Otype> TxPin<USART1> for gpioa::PA9<AF7<Otype>> {}
+unsafe impl<Otype> TxPin<USART1> for gpiob::PB6<AF7<Otype>> {}
+unsafe impl<Otype> TxPin<USART1> for gpioc::PC4<AF7<Otype>> {}
+unsafe impl<Otype> RxPin<USART1> for gpioa::PA10<AF7<Otype>> {}
+unsafe impl<Otype> RxPin<USART1> for gpiob::PB7<AF7<Otype>> {}
+unsafe impl<Otype> RxPin<USART1> for gpioc::PC5<AF7<Otype>> {}
 
-unsafe impl<OTYPE> TxPin<USART2> for gpioa::PA2<AF7<OTYPE>> {}
-unsafe impl<OTYPE> TxPin<USART2> for gpiob::PB3<AF7<OTYPE>> {}
-unsafe impl<OTYPE> RxPin<USART2> for gpioa::PA3<AF7<OTYPE>> {}
-unsafe impl<OTYPE> RxPin<USART2> for gpiob::PB4<AF7<OTYPE>> {}
+unsafe impl<Otype> TxPin<USART2> for gpioa::PA2<AF7<Otype>> {}
+unsafe impl<Otype> TxPin<USART2> for gpiob::PB3<AF7<Otype>> {}
+unsafe impl<Otype> RxPin<USART2> for gpioa::PA3<AF7<Otype>> {}
+unsafe impl<Otype> RxPin<USART2> for gpiob::PB4<AF7<Otype>> {}
 
-unsafe impl<OTYPE> TxPin<USART3> for gpiob::PB10<AF7<OTYPE>> {}
-unsafe impl<OTYPE> TxPin<USART3> for gpioc::PC10<AF7<OTYPE>> {}
-unsafe impl<OTYPE> RxPin<USART3> for gpioc::PC11<AF7<OTYPE>> {}
+unsafe impl<Otype> TxPin<USART3> for gpiob::PB10<AF7<Otype>> {}
+unsafe impl<Otype> TxPin<USART3> for gpioc::PC10<AF7<Otype>> {}
+unsafe impl<Otype> RxPin<USART3> for gpioc::PC11<AF7<Otype>> {}
 
 cfg_if! {
     if #[cfg(any(feature = "gpio-f303", feature = "gpio-f303e", feature = "gpio-f373"))] {
         use crate::gpio::{gpiod, gpioe};
 
-        unsafe impl<OTYPE> TxPin<USART1> for gpioe::PE0<AF7<OTYPE>> {}
-        unsafe impl<OTYPE> RxPin<USART1> for gpioe::PE1<AF7<OTYPE>> {}
+        unsafe impl<Otype> TxPin<USART1> for gpioe::PE0<AF7<Otype>> {}
+        unsafe impl<Otype> RxPin<USART1> for gpioe::PE1<AF7<Otype>> {}
 
-        unsafe impl<OTYPE> TxPin<USART2> for gpiod::PD5<AF7<OTYPE>> {}
-        unsafe impl<OTYPE> RxPin<USART2> for gpiod::PD6<AF7<OTYPE>> {}
+        unsafe impl<Otype> TxPin<USART2> for gpiod::PD5<AF7<Otype>> {}
+        unsafe impl<Otype> RxPin<USART2> for gpiod::PD6<AF7<Otype>> {}
 
-        unsafe impl<OTYPE> TxPin<USART3> for gpiod::PD8<AF7<OTYPE>> {}
-        unsafe impl<OTYPE> RxPin<USART3> for gpiod::PD9<AF7<OTYPE>> {}
-        unsafe impl<OTYPE> RxPin<USART3> for gpioe::PE15<AF7<OTYPE>> {}
+        unsafe impl<Otype> TxPin<USART3> for gpiod::PD8<AF7<Otype>> {}
+        unsafe impl<Otype> RxPin<USART3> for gpiod::PD9<AF7<Otype>> {}
+        unsafe impl<Otype> RxPin<USART3> for gpioe::PE15<AF7<Otype>> {}
     }
 }
 
 cfg_if! {
     if #[cfg(not(feature = "gpio-f373"))] {
-        unsafe impl<OTYPE> TxPin<USART2> for gpioa::PA14<AF7<OTYPE>> {}
-        unsafe impl<OTYPE> RxPin<USART2> for gpioa::PA15<AF7<OTYPE>> {}
+        unsafe impl<Otype> TxPin<USART2> for gpioa::PA14<AF7<Otype>> {}
+        unsafe impl<Otype> RxPin<USART2> for gpioa::PA15<AF7<Otype>> {}
 
-        unsafe impl<OTYPE> RxPin<USART3> for gpiob::PB11<AF7<OTYPE>> {}
+        unsafe impl<Otype> RxPin<USART3> for gpiob::PB11<AF7<Otype>> {}
     }
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -3,7 +3,7 @@
 use core::{convert::Infallible, marker::PhantomData, ptr};
 
 use crate::{
-    gpio::{gpioa, gpiob, gpioc, PushPull, AF7},
+    gpio::{gpioa, gpiob, gpioc, AF7},
     hal::{blocking, serial},
     pac::{USART1, USART2, USART3},
     rcc::{Clocks, APB1, APB2},
@@ -48,42 +48,44 @@ pub unsafe trait TxPin<USART> {}
 /// RX pin - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait RxPin<USART> {}
 
-unsafe impl TxPin<USART1> for gpioa::PA9<AF7<PushPull>> {}
-unsafe impl TxPin<USART1> for gpiob::PB6<AF7<PushPull>> {}
-unsafe impl TxPin<USART1> for gpioc::PC4<AF7<PushPull>> {}
-unsafe impl RxPin<USART1> for gpioa::PA10<AF7<PushPull>> {}
-unsafe impl RxPin<USART1> for gpiob::PB7<AF7<PushPull>> {}
-unsafe impl RxPin<USART1> for gpioc::PC5<AF7<PushPull>> {}
+unsafe impl<OTYPE> TxPin<USART1> for gpioa::PA9<AF7<OTYPE>> {}
+unsafe impl<OTYPE> TxPin<USART1> for gpiob::PB6<AF7<OTYPE>> {}
+unsafe impl<OTYPE> TxPin<USART1> for gpioc::PC4<AF7<OTYPE>> {}
+unsafe impl<OTYPE> RxPin<USART1> for gpioa::PA10<AF7<OTYPE>> {}
+unsafe impl<OTYPE> RxPin<USART1> for gpiob::PB7<AF7<OTYPE>> {}
+unsafe impl<OTYPE> RxPin<USART1> for gpioc::PC5<AF7<OTYPE>> {}
 
-unsafe impl TxPin<USART2> for gpioa::PA2<AF7<PushPull>> {}
-unsafe impl TxPin<USART2> for gpiob::PB3<AF7<PushPull>> {}
-unsafe impl RxPin<USART2> for gpioa::PA3<AF7<PushPull>> {}
-unsafe impl RxPin<USART2> for gpiob::PB4<AF7<PushPull>> {}
+unsafe impl<OTYPE> TxPin<USART2> for gpioa::PA2<AF7<OTYPE>> {}
+unsafe impl<OTYPE> TxPin<USART2> for gpiob::PB3<AF7<OTYPE>> {}
+unsafe impl<OTYPE> RxPin<USART2> for gpioa::PA3<AF7<OTYPE>> {}
+unsafe impl<OTYPE> RxPin<USART2> for gpiob::PB4<AF7<OTYPE>> {}
 
-unsafe impl TxPin<USART3> for gpiob::PB10<AF7<PushPull>> {}
-unsafe impl TxPin<USART3> for gpioc::PC10<AF7<PushPull>> {}
-unsafe impl RxPin<USART3> for gpioc::PC11<AF7<PushPull>> {}
+unsafe impl<OTYPE> TxPin<USART3> for gpiob::PB10<AF7<OTYPE>> {}
+unsafe impl<OTYPE> TxPin<USART3> for gpioc::PC10<AF7<OTYPE>> {}
+unsafe impl<OTYPE> RxPin<USART3> for gpioc::PC11<AF7<OTYPE>> {}
 
 cfg_if! {
     if #[cfg(any(feature = "gpio-f303", feature = "gpio-f303e", feature = "gpio-f373"))] {
         use crate::gpio::{gpiod, gpioe};
 
-        unsafe impl TxPin<USART1> for gpioe::PE0<AF7<PushPull>> {}
-        unsafe impl RxPin<USART1> for gpioe::PE1<AF7<PushPull>> {}
+        unsafe impl<OTYPE> TxPin<USART1> for gpioe::PE0<AF7<OTYPE>> {}
+        unsafe impl<OTYPE> RxPin<USART1> for gpioe::PE1<AF7<OTYPE>> {}
 
-        unsafe impl TxPin<USART2> for gpiod::PD5<AF7<PushPull>> {}
-        unsafe impl RxPin<USART2> for gpiod::PD6<AF7<PushPull>> {}
+        unsafe impl<OTYPE> TxPin<USART2> for gpiod::PD5<AF7<OTYPE>> {}
+        unsafe impl<OTYPE> RxPin<USART2> for gpiod::PD6<AF7<OTYPE>> {}
 
-        unsafe impl TxPin<USART3> for gpiod::PD8<AF7<PushPull>> {}
-        unsafe impl RxPin<USART3> for gpiod::PD9<AF7<PushPull>> {}
-        unsafe impl RxPin<USART3> for gpioe::PE15<AF7<PushPull>> {}
+        unsafe impl<OTYPE> TxPin<USART3> for gpiod::PD8<AF7<OTYPE>> {}
+        unsafe impl<OTYPE> RxPin<USART3> for gpiod::PD9<AF7<OTYPE>> {}
+        unsafe impl<OTYPE> RxPin<USART3> for gpioe::PE15<AF7<OTYPE>> {}
     }
 }
+
 cfg_if! {
     if #[cfg(not(feature = "gpio-f373"))] {
-        unsafe impl TxPin<USART2> for gpioa::PA14<AF7<PushPull>> {}
-        unsafe impl RxPin<USART2> for gpioa::PA15<AF7<PushPull>> {}
-        unsafe impl RxPin<USART3> for gpiob::PB11<AF7<PushPull>> {}
+        unsafe impl<OTYPE> TxPin<USART2> for gpioa::PA14<AF7<OTYPE>> {}
+        unsafe impl<OTYPE> RxPin<USART2> for gpioa::PA15<AF7<OTYPE>> {}
+
+        unsafe impl<OTYPE> RxPin<USART3> for gpiob::PB11<AF7<OTYPE>> {}
     }
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -101,7 +101,7 @@ use crate::gpio::gpiof::PF6;
     feature = "stm32f398",
 ))]
 use crate::gpio::gpiof::{PF10, PF9};
-use crate::gpio::{AF5, AF6};
+use crate::gpio::{PushPull, AF5, AF6};
 use crate::rcc::Clocks;
 #[cfg(any(
     feature = "stm32f301",
@@ -156,9 +156,9 @@ pub unsafe trait MisoPin<SPI> {}
 /// MOSI pin -- DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait MosiPin<SPI> {}
 
-unsafe impl SckPin<SPI1> for PA5<AF5> {}
+unsafe impl SckPin<SPI1> for PA5<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI1> for PA12<AF6> {}
+unsafe impl SckPin<SPI1> for PA12<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -172,16 +172,16 @@ unsafe impl SckPin<SPI1> for PA12<AF6> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI1> for PB3<AF5> {}
+unsafe impl SckPin<SPI1> for PB3<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI1> for PC7<AF5> {}
+unsafe impl SckPin<SPI1> for PC7<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PA8<AF5> {}
+unsafe impl SckPin<SPI2> for PA8<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PB8<AF5> {}
+unsafe impl SckPin<SPI2> for PB8<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PB10<AF5> {}
+unsafe impl SckPin<SPI2> for PB10<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f301",
     feature = "stm32f302",
@@ -191,11 +191,11 @@ unsafe impl SckPin<SPI2> for PB10<AF5> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl SckPin<SPI2> for PB13<AF5> {}
+unsafe impl SckPin<SPI2> for PB13<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PD7<AF5> {}
+unsafe impl SckPin<SPI2> for PD7<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PD8<AF5> {}
+unsafe impl SckPin<SPI2> for PD8<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -206,7 +206,7 @@ unsafe impl SckPin<SPI2> for PD8<AF5> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF1<AF5> {}
+unsafe impl SckPin<SPI2> for PF1<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -219,7 +219,7 @@ unsafe impl SckPin<SPI2> for PF1<AF5> {}
     feature = "stm32f358",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF9<AF5> {}
+unsafe impl SckPin<SPI2> for PF9<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -232,10 +232,10 @@ unsafe impl SckPin<SPI2> for PF9<AF5> {}
     feature = "stm32f358",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF10<AF5> {}
+unsafe impl SckPin<SPI2> for PF10<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI3> for PA1<AF6> {}
+unsafe impl SckPin<SPI3> for PA1<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xd",
@@ -245,8 +245,8 @@ unsafe impl SckPin<SPI3> for PA1<AF6> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI3> for PB3<AF6> {}
-unsafe impl SckPin<SPI3> for PC10<AF6> {}
+unsafe impl SckPin<SPI3> for PB3<AF6<PushPull>> {}
+unsafe impl SckPin<SPI3> for PC10<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -255,7 +255,7 @@ unsafe impl SckPin<SPI3> for PC10<AF6> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI4> for PE2<AF5> {}
+unsafe impl SckPin<SPI4> for PE2<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -263,11 +263,11 @@ unsafe impl SckPin<SPI4> for PE2<AF5> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI4> for PE12<AF5> {}
+unsafe impl SckPin<SPI4> for PE12<AF5<PushPull>> {}
 
-unsafe impl MisoPin<SPI1> for PA6<AF5> {}
+unsafe impl MisoPin<SPI1> for PA6<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI1> for PA13<AF6> {}
+unsafe impl MisoPin<SPI1> for PA13<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -281,12 +281,12 @@ unsafe impl MisoPin<SPI1> for PA13<AF6> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI1> for PB4<AF5> {}
+unsafe impl MisoPin<SPI1> for PB4<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI1> for PC8<AF5> {}
+unsafe impl MisoPin<SPI1> for PC8<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PA9<AF5> {}
+unsafe impl MisoPin<SPI2> for PA9<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -297,15 +297,15 @@ unsafe impl MisoPin<SPI2> for PA9<AF5> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI2> for PA10<AF5> {}
-unsafe impl MisoPin<SPI2> for PB14<AF5> {}
+unsafe impl MisoPin<SPI2> for PA10<AF5<PushPull>> {}
+unsafe impl MisoPin<SPI2> for PB14<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PC2<AF5> {}
+unsafe impl MisoPin<SPI2> for PC2<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PD3<AF5> {}
+unsafe impl MisoPin<SPI2> for PD3<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI3> for PA2<AF6> {}
+unsafe impl MisoPin<SPI3> for PA2<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xd",
@@ -315,8 +315,8 @@ unsafe impl MisoPin<SPI3> for PA2<AF6> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI3> for PB4<AF6> {}
-unsafe impl MisoPin<SPI3> for PC11<AF6> {}
+unsafe impl MisoPin<SPI3> for PB4<AF6<PushPull>> {}
+unsafe impl MisoPin<SPI3> for PC11<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -325,7 +325,7 @@ unsafe impl MisoPin<SPI3> for PC11<AF6> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI4> for PE5<AF5> {}
+unsafe impl MisoPin<SPI4> for PE5<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -333,19 +333,19 @@ unsafe impl MisoPin<SPI4> for PE5<AF5> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI4> for PE13<AF5> {}
+unsafe impl MisoPin<SPI4> for PE13<AF5<PushPull>> {}
 
-unsafe impl MosiPin<SPI1> for PA7<AF5> {}
+unsafe impl MosiPin<SPI1> for PA7<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PB0<AF5> {}
-unsafe impl MosiPin<SPI1> for PB5<AF5> {}
+unsafe impl MosiPin<SPI1> for PB0<AF5<PushPull>> {}
+unsafe impl MosiPin<SPI1> for PB5<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PC9<AF5> {}
+unsafe impl MosiPin<SPI1> for PC9<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PF6<AF5> {}
+unsafe impl MosiPin<SPI1> for PF6<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI2> for PA10<AF5> {}
+unsafe impl MosiPin<SPI2> for PA10<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -356,17 +356,17 @@ unsafe impl MosiPin<SPI2> for PA10<AF5> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI2> for PA11<AF5> {}
-unsafe impl MosiPin<SPI2> for PB15<AF5> {}
+unsafe impl MosiPin<SPI2> for PA11<AF5<PushPull>> {}
+unsafe impl MosiPin<SPI2> for PB15<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PC3<AF5> {}
+unsafe impl MisoPin<SPI2> for PC3<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PD4<AF5> {}
+unsafe impl MisoPin<SPI2> for PD4<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI3> for PA3<AF6> {}
-unsafe impl MosiPin<SPI3> for PB5<AF6> {}
-unsafe impl MosiPin<SPI3> for PC12<AF6> {}
+unsafe impl MisoPin<SPI3> for PA3<AF6<PushPull>> {}
+unsafe impl MosiPin<SPI3> for PB5<AF6<PushPull>> {}
+unsafe impl MosiPin<SPI3> for PC12<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -375,7 +375,7 @@ unsafe impl MosiPin<SPI3> for PC12<AF6> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI4> for PE6<AF5> {}
+unsafe impl MosiPin<SPI4> for PE6<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -383,7 +383,7 @@ unsafe impl MosiPin<SPI4> for PE6<AF5> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI4> for PE14<AF5> {}
+unsafe impl MosiPin<SPI4> for PE14<AF5<PushPull>> {}
 
 /// Configuration trait for the Word Size
 /// used by the SPI peripheral

--- a/src/syscfg.rs
+++ b/src/syscfg.rs
@@ -26,7 +26,8 @@ impl SysCfgExt for SYSCFG {
 ///
 /// ```
 /// let dp = pac::Peripherals::take().unwrap();
-/// let syscfg = dp.SYSCFG.constrain();
+/// let mut rcc = dp.RCC.constrain();
+/// let syscfg = dp.SYSCFG.constrain(&mut rcc.apb2);
 /// ```
 pub struct SysCfg(SYSCFG);
 

--- a/src/syscfg.rs
+++ b/src/syscfg.rs
@@ -1,0 +1,40 @@
+//! System configuration controller
+
+use core::ops::Deref;
+
+use crate::{pac::SYSCFG, rcc::APB2};
+
+/// Extension trait that constrains the `SYSCFG` peripheral
+pub trait SysCfgExt {
+    /// Constrains the `SYSCFG` peripheral so it plays nicely with the other abstractions
+    fn constrain(self, apb2: &mut APB2) -> SysCfg;
+}
+
+impl SysCfgExt for SYSCFG {
+    fn constrain(self, apb2: &mut APB2) -> SysCfg {
+        apb2.enr().modify(|_, w| w.syscfgen().enabled());
+
+        SysCfg(self)
+    }
+}
+
+/// Constrained SYSCFG peripheral
+///
+/// An instance of this struct is acquired by calling the
+/// [`constrain`](SysCfgExt::constrain) function on the
+/// [`SYSCFG`](crate::pac::SYSCFG) struct.
+///
+/// ```
+/// let dp = pac::Peripherals::take().unwrap();
+/// let syscfg = dp.SYSCFG.constrain();
+/// ```
+pub struct SysCfg(SYSCFG);
+
+impl Deref for SysCfg {
+    type Target = SYSCFG;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -10,7 +10,7 @@ use crate::pac::{RCC, USB};
 use stm32_usbd::UsbPeripheral;
 
 use crate::gpio::gpioa::{PA11, PA12};
-use crate::gpio::AF14;
+use crate::gpio::{PushPull, AF14};
 pub use stm32_usbd::UsbBus;
 
 /// USB Peripheral
@@ -21,9 +21,9 @@ pub struct Peripheral {
     /// USB Register Block
     pub usb: USB,
     /// Data Negativ Pin
-    pub pin_dm: PA11<AF14>,
+    pub pin_dm: PA11<AF14<PushPull>>,
     /// Data Positiv Pin
-    pub pin_dp: PA12<AF14>,
+    pub pin_dp: PA12<AF14<PushPull>>,
 }
 
 unsafe impl Sync for Peripheral {}


### PR DESCRIPTION
* Simplify macro
  `gpio.rs` uses more generics than macro now
* Collapse Input type arguments
  An attempt to address #125
* Support interrupt
  Close #83 and #112