### PR TITLE
Add time extension trait to prelude

### DIFF
--- a/examples/can.rs
+++ b/examples/can.rs
@@ -11,7 +11,6 @@ use cortex_m_rt::entry;
 
 use hal::prelude::*;
 use hal::stm32;
-use hal::time::{duration::*, rate::*};
 use hal::watchdog::IndependentWatchDog;
 
 use hal::can::{Can, CanFilter, CanFrame, CanId, Filter, Frame, Receiver, Transmitter};

--- a/examples/i2c_scanner.rs
+++ b/examples/i2c_scanner.rs
@@ -14,7 +14,6 @@ use cortex_m::asm;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{hprint, hprintln};
 
-use hal::time::rate::*;
 use stm32f3xx_hal::{self as hal, pac, prelude::*};
 
 const VALID_ADDR_RANGE: Range<u8> = 0x08..0x78;

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -16,9 +16,9 @@ use hal::hal::PwmPin;
 use hal::flash::FlashExt;
 use hal::gpio::GpioExt;
 use hal::pac;
+use hal::prelude::*;
 use hal::pwm::{tim16, tim2, tim3, tim8};
 use hal::rcc::RccExt;
-use hal::time::rate::*;
 
 #[entry]
 fn main() -> ! {

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -9,7 +9,7 @@ use panic_semihosting as _;
 
 use cortex_m::{asm, singleton};
 use cortex_m_rt::entry;
-use stm32f3xx_hal::{pac, prelude::*, serial::Serial, time::rate::*};
+use stm32f3xx_hal::{pac, prelude::*, serial::Serial};
 
 #[entry]
 fn main() -> ! {

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -15,7 +15,6 @@ use cortex_m_rt::entry;
 use hal::pac;
 use hal::prelude::*;
 use hal::spi::{Mode, Phase, Polarity, Spi};
-use hal::time::rate::*;
 
 #[entry]
 fn main() -> ! {

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -12,7 +12,6 @@ use cortex_m_rt::entry;
 
 use hal::pac;
 use hal::prelude::*;
-use hal::time::rate::*;
 use hal::usb::{Peripheral, UsbBus};
 
 use usb_device::prelude::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,8 @@ pub use crate::flash::FlashExt as _stm32f3xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32f3xx_hal_gpio_GpioExt;
 pub use crate::hal::prelude::*;
 pub use crate::rcc::RccExt as _stm32f3xx_hal_rcc_RccExt;
+pub use crate::time::duration::Extensions as _stm32f3xx_hal_time_time_Extensions;
+pub use crate::time::rate::Extensions as _stm32f3xx_hal_time_rate_Extensions;
 #[cfg(feature = "unproven")]
 pub use crate::{
     hal::digital::v2::InputPin as _embedded_hal_digital_InputPin,

--- a/tests/rcc.rs
+++ b/tests/rcc.rs
@@ -6,7 +6,7 @@ use panic_probe as _;
 
 #[defmt_test::tests]
 mod tests {
-    use stm32f3xx_hal::{pac, prelude::*, time::rate::*};
+    use stm32f3xx_hal::{pac, prelude::*};
 
     // Test the defaults with no configuration
     #[test]


### PR DESCRIPTION
This is a slight ergonomic improvement and keeps
the old behavior.
The user does not have to remember to import
`time::duration::*` just to configure any peripheral.