### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ let clocks = rcc
     .pclk2(12u32.MHz())
 ```
 
+- Bump dependencies: ([#211])
+  - `stm32f3` dependency to 0.13.0
+  - `nb` to 1.0
+  - `cortex-m` to 0.7
+  - `stm32-usbd` to 0.6
+  - `defmt` to 0.2
+
 [embedded-time]: https://github.com/FluenTech/embedded-time/
 ### Changed
 
@@ -298,6 +305,7 @@ let clocks = rcc
 
 - Support `stm32f303` device
 
+[#211]: https://github.com/stm32-rs/stm32f3xx-hal/pull/211
 [#210]: https://github.com/stm32-rs/stm32f3xx-hal/pull/210
 [#208]: https://github.com/stm32-rs/stm32f3xx-hal/pull/208
 [#203]: https://github.com/stm32-rs/stm32f3xx-hal/issues/203

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
 cfg-if = "1.0"
-cortex-m = "0.6"
+cortex-m = "0.7"
 cortex-m-rt = "0.6"
 embedded-dma = "0.1"
 embedded-hal = "0.2"
-nb = "0.1"
+nb = "1.0"
 paste = "1"
 rtcc = "0.2"
-stm32f3 = "0.12"
+stm32f3 = "0.13"
 embedded-time = "0.10"
 
 [dependencies.embedded-hal-can]
@@ -40,11 +40,10 @@ version = "0.1.0"
 optional = true
 
 [dependencies.bare-metal]
-version = "0.2"
-features = ["const-fn"]
+version = "1.0"
 
 [dependencies.stm32-usbd]
-version = "0.5"
+version = "0.6"
 optional = true
 
 [dependencies.void]
@@ -52,7 +51,7 @@ version = "1"
 default-features = false
 
 [dependencies.defmt]
-version = "0.1.2"
+version = "0.2"
 optional = true
 
 [dev-dependencies]
@@ -60,9 +59,9 @@ panic-semihosting = "0.5"
 usb-device = "0.2"
 usbd-serial = "0.1"
 cortex-m-semihosting = "0.3"
-panic-probe = "0.1.0"
-defmt-rtt = "0.1.0"
-defmt-test = "0.1.0"
+panic-probe = "0.2"
+defmt-rtt = "0.2"
+defmt-test = "0.2"
 
 [features]
 default = ["unproven"]
@@ -92,16 +91,16 @@ stm32f302xe = ["stm32f302", "gpio-f303e", "device-selected"]
 stm32f303 = ["stm32f3/stm32f303", "direct-call-deprecated"]
 stm32f303x6 = ["stm32f303", "gpio-f333", "device-selected"]
 stm32f303x8 = ["stm32f303", "gpio-f333", "device-selected"]
-stm32f303xb = ["stm32f303", "gpio-f303", "stm32-usbd/ram_access_1x16", "device-selected"]
-stm32f303xc = ["stm32f303", "gpio-f303", "stm32-usbd/ram_access_1x16", "device-selected"]
-stm32f303xd = ["stm32f303", "gpio-f303e", "stm32-usbd/ram_access_2x16", "device-selected"]
-stm32f303xe = ["stm32f303", "gpio-f303e", "stm32-usbd/ram_access_2x16", "device-selected"]
+stm32f303xb = ["stm32f303", "gpio-f303", "device-selected"]
+stm32f303xc = ["stm32f303", "gpio-f303", "device-selected"]
+stm32f303xd = ["stm32f303", "gpio-f303e", "device-selected"]
+stm32f303xe = ["stm32f303", "gpio-f303e", "device-selected"]
 stm32f373 = ["gpio-f373", "stm32f3/stm32f373", "device-selected"]
 stm32f378 = ["gpio-f373", "stm32f3/stm32f373", "device-selected"]
 stm32f334 = ["gpio-f333", "stm32f3/stm32f3x4", "device-selected"]
-stm32f328 = ["gpio-f333", "stm32f3/stm32f3x8", "device-selected"]
-stm32f358 = ["gpio-f303", "stm32f3/stm32f3x8", "device-selected"]
-stm32f398 = ["gpio-f303e", "stm32f3/stm32f3x8", "device-selected"]
+stm32f328 = ["gpio-f333", "stm32f3/stm32f303", "device-selected"]
+stm32f358 = ["gpio-f303", "stm32f3/stm32f303", "device-selected"]
+stm32f398 = ["gpio-f303e", "stm32f3/stm32f303", "device-selected"]
 
 defmt-default = ["defmt"]
 defmt-trace = ["defmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,12 @@ pub use stm32f3::stm32f301 as pac;
 /// Peripheral access
 pub use stm32f3::stm32f302 as pac;
 
-#[cfg(feature = "stm32f303")]
+#[cfg(any(
+    feature = "stm32f303",
+    feature = "stm32f328",
+    feature = "stm32f358",
+    feature = "stm32f398"
+))]
 /// Peripheral access
 pub use stm32f3::stm32f303 as pac;
 
@@ -164,10 +169,6 @@ pub use stm32f3::stm32f373 as pac;
 #[cfg(feature = "stm32f334")]
 /// Peripheral access
 pub use stm32f3::stm32f3x4 as pac;
-
-#[cfg(any(feature = "stm32f328", feature = "stm32f358", feature = "stm32f398"))]
-/// Peripheral access
-pub use stm32f3::stm32f3x8 as pac;
 
 #[cfg(feature = "device-selected")]
 #[deprecated(since = "0.5.0", note = "please use `pac` instead")]

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1531,7 +1531,7 @@ macro_rules! tim20 {
 
         // Channels
         // TODO: stm32f3 doesn't suppport registers for all 4 channels
-        pwm_pin_for_pwm_n_channel!(TIM20, TIM20_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
+        pwm_pin_for_pwm_n_channel!(TIM20, TIM20_CH1, u16, cc1e, cc1ne, ccr1, ccr);
 
         //Pins
         pwm_channel1_pin!(TIM20, TIM20_CH1, output_to_pe2, gpioe::PE2<gpio::AF6>);

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -36,6 +36,10 @@ unsafe impl UsbPeripheral for Peripheral {
     const EP_MEMORY_SIZE: usize = 512;
     #[cfg(any(feature = "stm32f303xd", feature = "stm32f303xe"))]
     const EP_MEMORY_SIZE: usize = 1024;
+    #[cfg(any(feature = "stm32f303xb", feature = "stm32f303xc"))]
+    const EP_MEMORY_ACCESS_2X16: bool = false;
+    #[cfg(any(feature = "stm32f303xd", feature = "stm32f303xe"))]
+    const EP_MEMORY_ACCESS_2X16: bool = true;
 
     fn enable() {
         let rcc = unsafe { &*RCC::ptr() };


### PR DESCRIPTION
- stm32f3 upgrade removes `stm32f3x8` feature in place of `stm32f303`
- stm32-usbd update removes ram_access_1x16 feature