### PR TITLE
Fix long delay during ADC initialization

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -399,8 +399,15 @@ macro_rules! adc_hal {
                 }
 
                 fn wait_adc_clk_cycles(&self, cycles: u32) {
-                    let adc_clk_cycle = self.clocks.hclk().0 / (self.ckmode as u32);
-                    asm::delay(adc_clk_cycle * cycles);
+                    // using a match statement here so compilation will fail once asynchronous clk
+                    // mode is implemented (CKMODE[1:0] = 00b).  This will force whoever is working
+                    // on it to rethink what needs to be done here :)
+                    let adc_per_cpu_cycles = match self.ckmode {
+                        CkMode::SYNCDIV1 => 1,
+                        CkMode::SYNCDIV2 => 2,
+                        CkMode::SYNCDIV4 => 4,
+                    };
+                    asm::delay(adc_per_cpu_cycles * cycles);
                 }
 
                 fn advregen_enable(&mut self){


### PR DESCRIPTION
As explained in issue #206, the code here is doing the calculation completely wrong.  This leads to a multi-second startup delay instead of just a few clock cycles.

Fix this by using the correct calculation; currently only ADC clock configurations synchronous to the AHB are supported which makes this quite easy: We just need to delay the given number of cycles * the selected ADC clock prescaler (1, 2, or 4).

To make this code future proof against an implementation of asynchronous ADC clock configurations, use a `match` statement here which will fail to compile once the `ASYNCHRONOUS` variant is added to the `CkMode` struct - thus forcing the implementor to take another look at this.

Fixes: #206