### PR TITLE
Show feature gate on docsrs 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ exclude = [
 [package.metadata.docs.rs]
 features = ["stm32f303xc", "rt", "stm32-usbd", "can"]
 targets = ["thumbv7em-none-eabihf"]
+rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 cfg-if = "1"

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,4 +1,4 @@
-//! Analog to Digital Converter. (Requires feature `stm32f303x[bcde]`)
+//! Analog to Digital Converter.
 //!
 //! # Examples
 //!

--- a/src/can.rs
+++ b/src/can.rs
@@ -1,4 +1,4 @@
-//! Controller Area Network (Requires feature `can`)
+//! Controller Area Network.
 //!
 //! CAN is currently not enabled by default, and
 //! can be enabled by the `can` feature.

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -1,4 +1,4 @@
-//! Direct memory access (DMA) controller. (Requires feature `stm32f303*` or `stm32f302*`)
+//! Direct memory access (DMA) controller.
 //!
 //! Currently DMA is only supported for STM32F303 or STM32F302 MCUs.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,11 +125,14 @@ pub use stm32f3::stm32f3x4 as pac;
 pub use crate::pac::interrupt;
 
 #[cfg(feature = "stm32f303")]
+#[cfg_attr(docsrs, doc(cfg(feature = "stm32f303")))]
 pub mod adc;
 #[cfg(feature = "can")]
+#[cfg_attr(docsrs, doc(cfg(feature = "can")))]
 pub mod can;
 pub mod delay;
 #[cfg(any(feature = "stm32f302", feature = "stm32f303"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "stm32f302", feature = "stm32f303"))))]
 pub mod dma;
 pub mod flash;
 pub mod gpio;
@@ -151,6 +154,7 @@ pub mod timer;
         feature = "stm32f303xe",
     ),
 ))]
+#[cfg_attr(docsrs, doc(cfg(feature = "stm32-usbd")))]
 pub mod usb;
 pub mod watchdog;
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -425,7 +425,7 @@ impl CFGR {
     /// - Maximal supported frequency with `HSE`: 72 Mhz
     /// - Maximal supported frequency without `HSE`: 64 Mhz
     ///
-    /// If [`CFGR::hse`] is not used, therefor `HSI / 2` is used.
+    /// If [`CFGR::use_hse`] is not set, `HSI / 2` will be used.
     /// Only multiples of (HSI / 2) (4 Mhz) are allowed.
     ///
     /// This is true for devices **except** the following devices,
@@ -818,7 +818,7 @@ impl Clocks {
     /// Returns whether the USBCLK clock frequency is valid for the USB peripheral
     ///
     /// If the microcontroller does support USB, 48 Mhz or 72 Mhz have to be used
-    /// and the [`CFGR::hse`] must be used.
+    /// and the [`CFGR::use_hse`] must be set.
     ///
     /// The APB1 / [`CFGR::pclk1`] clock must have a minimum frequency of 10 MHz to avoid data
     /// overrun/underrun problems. [RM0316 32.5.2][RM0316]

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -1,4 +1,4 @@
-//! USB peripheral. (Requires feature `stm32-usbd`)
+//! USB peripheral.
 //!
 //! See [examples/usb_serial.rs] for a usage example.
 //!


### PR DESCRIPTION
Use the unstable [`#[doc(cfg(...))]`](https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html) feature. 

It is feature gated by the [`docsrs`](https://docs.rs/about/builds#cross-compiling) feature, so locally no unstable feature is required.

It will look like this: 

![image](https://user-images.githubusercontent.com/29653149/117770818-ad927700-b235-11eb-8ce0-52654e1f31b6.png)
