### PR TITLE
MVP: Make use of const generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
     "codegen",
     ".markdownlint.yml"
 ]
+resolver = "2"
 
 [package.metadata.docs.rs]
 features = ["stm32f303xc", "rt", "stm32-usbd", "can"]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -49,31 +49,31 @@ pub struct Adc<ADC> {
 ///
 /// Each channel can be sampled with a different sample time.
 /// There is always an overhead of 13 ADC clock cycles.
-/// E.g. For Sampletime T_19 the total conversion time (in ADC clock cycles) is
+/// E.g. For Sampletime T19 the total conversion time (in ADC clock cycles) is
 /// 13 + 19 = 32 ADC Clock Cycles
 pub enum SampleTime {
     /// 1.5 ADC clock cycles
-    T_1,
+    T1,
     /// 2.5 ADC clock cycles
-    T_2,
+    T2,
     /// 4.5 ADC clock cycles
-    T_4,
+    T4,
     /// 7.5 ADC clock cycles
-    T_7,
+    T7,
     /// 19.5 ADC clock cycles
-    T_19,
+    T19,
     /// 61.5 ADC clock cycles
-    T_61,
+    T61,
     /// 181.5 ADC clock cycles
-    T_181,
+    T181,
     /// 601.5 ADC clock cycles
-    T_601,
+    T601,
 }
 
 impl Default for SampleTime {
-    /// T_1 is also the reset value.
+    /// T1 is also the reset value.
     fn default() -> Self {
-        SampleTime::T_1
+        SampleTime::T1
     }
 }
 
@@ -81,14 +81,14 @@ impl SampleTime {
     /// Conversion to bits for SMP
     fn bitcode(&self) -> u8 {
         match self {
-            SampleTime::T_1 => 0b000,
-            SampleTime::T_2 => 0b001,
-            SampleTime::T_4 => 0b010,
-            SampleTime::T_7 => 0b011,
-            SampleTime::T_19 => 0b100,
-            SampleTime::T_61 => 0b101,
-            SampleTime::T_181 => 0b110,
-            SampleTime::T_601 => 0b111,
+            SampleTime::T1 => 0b000,
+            SampleTime::T2 => 0b001,
+            SampleTime::T4 => 0b010,
+            SampleTime::T7 => 0b011,
+            SampleTime::T19 => 0b100,
+            SampleTime::T61 => 0b101,
+            SampleTime::T181 => 0b110,
+            SampleTime::T601 => 0b111,
         }
     }
 }
@@ -101,23 +101,23 @@ pub enum OperationMode {
     OneShot,
 }
 
-#[derive(Clone, Copy, PartialEq)]
 /// ADC CkMode
 // TODO: Add ASYNCHRONOUS mode
+#[derive(Clone, Copy, PartialEq)]
 pub enum CkMode {
     // /// Use Kernel Clock adc_ker_ck_input divided by PRESC. Asynchronous to AHB clock
     // ASYNCHRONOUS = 0,
     /// Use AHB clock rcc_hclk3. In this case rcc_hclk must equal sys_d1cpre_ck
-    SYNCDIV1 = 1,
+    SyncDiv1 = 1,
     /// Use AHB clock rcc_hclk3 divided by 2
-    SYNCDIV2 = 2,
+    SyncDiv2 = 2,
     /// Use AHB clock rcc_hclk3 divided by 4
-    SYNCDIV4 = 4,
+    SyncDiv4 = 4,
 }
 
 impl Default for CkMode {
     fn default() -> Self {
-        CkMode::SYNCDIV2
+        CkMode::SyncDiv2
     }
 }
 
@@ -126,9 +126,9 @@ impl From<CkMode> for CKMODE_A {
     fn from(ckmode: CkMode) -> Self {
         match ckmode {
             //CkMode::ASYNCHRONOUS => CKMODE_A::ASYNCHRONOUS,
-            CkMode::SYNCDIV1 => CKMODE_A::SYNCDIV1,
-            CkMode::SYNCDIV2 => CKMODE_A::SYNCDIV2,
-            CkMode::SYNCDIV4 => CKMODE_A::SYNCDIV4,
+            CkMode::SyncDiv1 => CKMODE_A::SyncDiv1,
+            CkMode::SyncDiv2 => CKMODE_A::SyncDiv2,
+            CkMode::SyncDiv4 => CKMODE_A::SyncDiv4,
         }
     }
 }
@@ -339,10 +339,10 @@ macro_rules! adc_hal {
                     this_adc
                 }
 
-                /// Software can use CkMode::SYNCDIV1 only if
+                /// Software can use CkMode::SyncDiv1 only if
                 /// hclk and sysclk are the same. (see reference manual 15.3.3)
                 fn clocks_welldefined(&self, clocks: Clocks) -> bool {
-                    if (self.ckmode == CkMode::SYNCDIV1) {
+                    if (self.ckmode == CkMode::SyncDiv1) {
                         clocks.hclk().0 == clocks.sysclk().0
                     } else {
                         true
@@ -403,9 +403,9 @@ macro_rules! adc_hal {
                     // mode is implemented (CKMODE[1:0] = 00b).  This will force whoever is working
                     // on it to rethink what needs to be done here :)
                     let adc_per_cpu_cycles = match self.ckmode {
-                        CkMode::SYNCDIV1 => 1,
-                        CkMode::SYNCDIV2 => 2,
-                        CkMode::SYNCDIV4 => 4,
+                        CkMode::SyncDiv1 => 1,
+                        CkMode::SyncDiv2 => 2,
+                        CkMode::SyncDiv4 => 4,
                     };
                     asm::delay(adc_per_cpu_cycles * cycles);
                 }
@@ -477,15 +477,15 @@ macro_rules! adc_hal {
 
             }
 
-            impl<WORD, PIN> OneShot<$ADC, WORD, PIN> for Adc<$ADC>
+            impl<Word, Pin> OneShot<$ADC, Word, Pin> for Adc<$ADC>
             where
-                WORD: From<u16>,
-                PIN: Channel<$ADC, ID = u8>,
+                Word: From<u16>,
+                Pin: Channel<$ADC, ID = u8>,
                 {
                     type Error = ();
 
-                    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
-                        let res = self.convert_one(PIN::channel());
+                    fn read(&mut self, _pin: &mut Pin) -> nb::Result<Word, Self::Error> {
+                        let res = self.convert_one(Pin::channel());
                         return Ok(res.into());
                     }
                 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -927,7 +927,7 @@ macro_rules! gpio {
 
                 $(
                     #[doc = "Pin " $PXi]
-                    pub type $PXi<Mode> = Pin<$Gpiox, $Ui, Mode>;
+                    pub type $PXi<Mode> = Pin<$Gpiox, Mode, $Ui>;
 
                     $(
                         impl<Mode> marker::$IntoAfi for $PXi<Mode> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -223,7 +223,7 @@ pub struct Input;
 /// Output mode (type state)
 pub struct Output<Otype>(PhantomData<Otype>);
 /// Alternate function (type state)
-pub struct Alternate<Otype, const Af: u8>(u8, PhantomData<Otype>);
+pub struct Alternate<Otype, const AF: u8>(u8, PhantomData<Otype>);
 /// Analog mode (type state)
 pub struct Analog;
 
@@ -235,10 +235,10 @@ pub struct OpenDrain;
 impl marker::Readable for Input {}
 impl marker::Readable for Output<OpenDrain> {}
 impl<Otype> marker::OutputSpeed for Output<Otype> {}
-impl<Otype, const Af: u8> marker::OutputSpeed for Alternate<Otype, { Af }> {}
+impl<Otype, const AF: u8> marker::OutputSpeed for Alternate<Otype, { AF }> {}
 impl marker::Active for Input {}
 impl<Otype> marker::Active for Output<Otype> {}
-impl<Otype, const Af: u8> marker::Active for Alternate<Otype, { Af }> {}
+impl<Otype, const AF: u8> marker::Active for Alternate<Otype, { AF }> {}
 
 /// Slew rate configuration
 pub enum Speed {
@@ -271,7 +271,7 @@ pub enum Edge {
 }
 
 /// Generic pin
-pub struct Pin<Gpio, Mode, const Index: u8> {
+pub struct Pin<Gpio, Mode, const INDEX: u8> {
     gpio: Gpio,
     index: u8,
     _mode: PhantomData<Mode>,
@@ -299,16 +299,16 @@ macro_rules! modify_at {
     };
 }
 
-impl<Gpio, Mode, const Index: u8> Pin<Gpio, Mode, { Index } >
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, { INDEX } >
 {
     /// Erases the pin number from the type
     ///
     /// This is useful when you want to collect the pins into an array where you
     /// need all the elements to have the same type
-    pub fn downgrade(self) -> Pin<Gpio, Mode, { Index } > {
+    pub fn downgrade(self) -> Pin<Gpio, Mode, { INDEX } > {
         Pin {
             gpio: self.gpio,
-            index: Index,
+            index: INDEX,
             _mode: self._mode,
         }
     }
@@ -335,8 +335,8 @@ impl<Gpio, Mode, const Index: u8> Pin<Gpio, Mode, { Index } >
 //    }
 //}
 
-impl<Gpio, Mode, const Index: u8> Pin<Gpio, Mode, { Index }> {
-    fn into_mode<NewMode>(self) -> Pin<Gpio, NewMode, { Index }> {
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, { INDEX }> {
+    fn into_mode<NewMode>(self) -> Pin<Gpio, NewMode, { INDEX }> {
         Pin {
             gpio: self.gpio,
             index: self.index,
@@ -345,12 +345,12 @@ impl<Gpio, Mode, const Index: u8> Pin<Gpio, Mode, { Index }> {
     }
 }
 
-impl<Gpio, Mode, const Index: u8> Pin<Gpio, Mode, Index>
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, INDEX>
 where
     Gpio: marker::GpioStatic,
 {
     /// Configures the pin to operate as an input pin
-    pub fn into_input(self, moder: &mut Gpio::MODER) -> Pin<Gpio, Input, { Index }> {
+    pub fn into_input(self, moder: &mut Gpio::MODER) -> Pin<Gpio, Input, { INDEX }> {
         moder.input(self.index);
         self.into_mode()
     }
@@ -361,7 +361,7 @@ where
         self,
         moder: &mut Gpio::MODER,
         pupdr: &mut Gpio::PUPDR,
-    ) -> Pin<Gpio, Input, { Index } > {
+    ) -> Pin<Gpio, Input, { INDEX } > {
         moder.input(self.index);
         pupdr.floating(self.index);
         self.into_mode()
@@ -373,7 +373,7 @@ where
         self,
         moder: &mut Gpio::MODER,
         pupdr: &mut Gpio::PUPDR,
-    ) -> Pin<Gpio, Input, { Index } > {
+    ) -> Pin<Gpio, Input, { INDEX } > {
         moder.input(self.index);
         pupdr.pull_up(self.index);
         self.into_mode()
@@ -385,7 +385,7 @@ where
         self,
         moder: &mut Gpio::MODER,
         pupdr: &mut Gpio::PUPDR,
-    ) -> Pin<Gpio, Input, {Index}> {
+    ) -> Pin<Gpio, Input, {INDEX}> {
         moder.input(self.index);
         pupdr.pull_down(self.index);
         self.into_mode()
@@ -396,7 +396,7 @@ where
         self,
         moder: &mut Gpio::MODER,
         otyper: &mut Gpio::OTYPER,
-    ) -> Pin<Gpio, Output<PushPull>, Index> {
+    ) -> Pin<Gpio, Output<PushPull>, INDEX> {
         moder.output(self.index);
         otyper.push_pull(self.index);
         self.into_mode()
@@ -407,7 +407,7 @@ where
         self,
         moder: &mut Gpio::MODER,
         otyper: &mut Gpio::OTYPER,
-    ) -> Pin<Gpio, Output<OpenDrain>, Index> {
+    ) -> Pin<Gpio, Output<OpenDrain>, INDEX> {
         moder.output(self.index);
         otyper.open_drain(self.index);
         self.into_mode()
@@ -418,14 +418,14 @@ where
         self,
         moder: &mut Gpio::MODER,
         pupdr: &mut Gpio::PUPDR,
-    ) -> Pin<Gpio, Analog, Index> {
+    ) -> Pin<Gpio, Analog, INDEX> {
         moder.analog(self.index);
         pupdr.floating(self.index);
         self.into_mode()
     }
 }
 
-impl<Gpio, Mode, const Index: u8> Pin<Gpio, Mode, { Index }>
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, { INDEX }>
 where
     Gpio: marker::GpioStatic,
     Mode: marker::OutputSpeed,
@@ -440,7 +440,7 @@ where
     }
 }
 
-impl<Gpio, Mode, const Index: u8> Pin<Gpio, Mode, {Index}>
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, {INDEX}>
 where
     Gpio: marker::GpioStatic,
     Mode: marker::Active,
@@ -467,7 +467,7 @@ where
     }
 }
 
-impl<Gpio, Otype, const Index: u8> OutputPin for Pin<Gpio, Output<Otype>, {Index}>
+impl<Gpio, Otype, const INDEX: u8> OutputPin for Pin<Gpio, Output<Otype>, {INDEX}>
 where
     Gpio: marker::Gpio,
 {
@@ -487,7 +487,7 @@ where
 }
 
 #[cfg(feature = "unproven")]
-impl<Gpio, Mode, const Index: u8> InputPin for Pin<Gpio, Mode, {Index}>
+impl<Gpio, Mode, const INDEX: u8> InputPin for Pin<Gpio, Mode, {INDEX}>
 where
     Gpio: marker::Gpio,
     Mode: marker::Readable,
@@ -505,7 +505,7 @@ where
 }
 
 #[cfg(feature = "unproven")]
-impl<Gpio, Otype, const Index: u8> StatefulOutputPin for Pin<Gpio, Output<Otype>, { Index }>
+impl<Gpio, Otype, const INDEX: u8> StatefulOutputPin for Pin<Gpio, Output<Otype>, { INDEX }>
 where
     Gpio: marker::Gpio,
 {
@@ -520,7 +520,7 @@ where
 }
 
 #[cfg(feature = "unproven")]
-impl<Gpio, Otype, const Index: u8 > toggleable::Default for Pin<Gpio, Output<Otype>, { Index }>
+impl<Gpio, Otype, const INDEX: u8 > toggleable::Default for Pin<Gpio, Output<Otype>, { INDEX }>
 where
     Gpio: marker::Gpio,
 {
@@ -544,7 +544,7 @@ macro_rules! reg_for_cpu {
     };
 }
 
-impl<Gpio, Mode, const Index: u8> Pin<Gpio, Mode, {Index}>
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, {INDEX}>
 where
     Gpio: marker::Gpio,
     Mode: marker::Active,
@@ -632,7 +632,7 @@ macro_rules! af {
             pub type $AFi<Otype> = Alternate<Otype, { $i }>;
         }
 
-        impl<Gpio, Mode, const Index: u8 > Pin<Gpio, Mode, {Index} >
+        impl<Gpio, Mode, const INDEX: u8 > Pin<Gpio, Mode, {INDEX} >
         where
             Self: marker::$IntoAfi,
             Gpio: marker::GpioStatic,
@@ -643,7 +643,7 @@ macro_rules! af {
                 moder: &mut Gpio::MODER,
                 otyper: &mut Gpio::OTYPER,
                 afr: &mut <Self as marker::$IntoAfi>::AFR,
-            ) -> Pin<Gpio, $AFi<PushPull>, { Index }> {
+            ) -> Pin<Gpio, $AFi<PushPull>, { INDEX }> {
                 moder.alternate(self.index);
                 otyper.push_pull(self.index);
                 afr.afx(self.index, $i);
@@ -656,7 +656,7 @@ macro_rules! af {
                 moder: &mut Gpio::MODER,
                 otyper: &mut Gpio::OTYPER,
                 afr: &mut <Self as marker::$IntoAfi>::AFR,
-            ) -> Pin<Gpio, $AFi<OpenDrain>, { Index }> {
+            ) -> Pin<Gpio, $AFi<OpenDrain>, { INDEX }> {
                 moder.alternate(self.index);
                 otyper.open_drain(self.index);
                 afr.afx(self.index, $i);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -72,7 +72,7 @@ use crate::{
 #[cfg(feature = "unproven")]
 use crate::hal::digital::v2::{toggleable, InputPin, StatefulOutputPin};
 
-use typenum::{Unsigned, U0, U1, U10, U11, U12, U13, U14, U15, U2, U3, U4, U5, U6, U7, U8, U9};
+use typenum::{Unsigned};
 
 /// Extension trait to split a GPIO peripheral in independent pins and registers
 pub trait GpioExt {
@@ -299,13 +299,12 @@ macro_rules! modify_at {
     };
 }
 
-impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, { INDEX } >
-{
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, { INDEX }> {
     /// Erases the pin number from the type
     ///
     /// This is useful when you want to collect the pins into an array where you
     /// need all the elements to have the same type
-    pub fn downgrade(self) -> Pin<Gpio, Mode, { INDEX } > {
+    pub fn downgrade(self) -> Pin<Gpio, Mode, { INDEX }> {
         Pin {
             gpio: self.gpio,
             index: INDEX,
@@ -361,7 +360,7 @@ where
         self,
         moder: &mut Gpio::MODER,
         pupdr: &mut Gpio::PUPDR,
-    ) -> Pin<Gpio, Input, { INDEX } > {
+    ) -> Pin<Gpio, Input, { INDEX }> {
         moder.input(self.index);
         pupdr.floating(self.index);
         self.into_mode()
@@ -373,7 +372,7 @@ where
         self,
         moder: &mut Gpio::MODER,
         pupdr: &mut Gpio::PUPDR,
-    ) -> Pin<Gpio, Input, { INDEX } > {
+    ) -> Pin<Gpio, Input, { INDEX }> {
         moder.input(self.index);
         pupdr.pull_up(self.index);
         self.into_mode()
@@ -385,7 +384,7 @@ where
         self,
         moder: &mut Gpio::MODER,
         pupdr: &mut Gpio::PUPDR,
-    ) -> Pin<Gpio, Input, {INDEX}> {
+    ) -> Pin<Gpio, Input, { INDEX }> {
         moder.input(self.index);
         pupdr.pull_down(self.index);
         self.into_mode()
@@ -440,7 +439,7 @@ where
     }
 }
 
-impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, {INDEX}>
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, { INDEX }>
 where
     Gpio: marker::GpioStatic,
     Mode: marker::Active,
@@ -467,7 +466,7 @@ where
     }
 }
 
-impl<Gpio, Otype, const INDEX: u8> OutputPin for Pin<Gpio, Output<Otype>, {INDEX}>
+impl<Gpio, Otype, const INDEX: u8> OutputPin for Pin<Gpio, Output<Otype>, { INDEX }>
 where
     Gpio: marker::Gpio,
 {
@@ -487,7 +486,7 @@ where
 }
 
 #[cfg(feature = "unproven")]
-impl<Gpio, Mode, const INDEX: u8> InputPin for Pin<Gpio, Mode, {INDEX}>
+impl<Gpio, Mode, const INDEX: u8> InputPin for Pin<Gpio, Mode, { INDEX }>
 where
     Gpio: marker::Gpio,
     Mode: marker::Readable,
@@ -520,9 +519,8 @@ where
 }
 
 #[cfg(feature = "unproven")]
-impl<Gpio, Otype, const INDEX: u8 > toggleable::Default for Pin<Gpio, Output<Otype>, { INDEX }>
-where
-    Gpio: marker::Gpio,
+impl<Gpio, Otype, const INDEX: u8> toggleable::Default for Pin<Gpio, Output<Otype>, { INDEX }> where
+    Gpio: marker::Gpio
 {
 }
 
@@ -544,7 +542,7 @@ macro_rules! reg_for_cpu {
     };
 }
 
-impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, {INDEX}>
+impl<Gpio, Mode, const INDEX: u8> Pin<Gpio, Mode, { INDEX }>
 where
     Gpio: marker::Gpio,
     Mode: marker::Active,
@@ -788,11 +786,6 @@ macro_rules! gpio {
                 use super::{
                     Input, Output, Analog, PushPull, OpenDrain,
                     AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10, AF11, AF12, AF13, AF14, AF15,
-                };
-
-                #[allow(unused_imports)]
-                use typenum::{
-                    U0, U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15
                 };
 
                 /// GPIO parts

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -147,12 +147,6 @@ pub mod marker {
         type PUPDR: super::Pupdr;
     }
 
-    /// Marker trait for pin number
-    pub trait Index {
-        #[doc(hidden)]
-        fn index(&self) -> u8;
-    }
-
     /// Marker trait for readable pin modes
     pub trait Readable {}
 
@@ -201,22 +195,6 @@ impl marker::Gpio for Gpiox {}
 
 /// Runtime defined pin number (type state)
 pub struct Ux(u8);
-
-impl marker::Index for Ux {
-    fn index(&self) -> u8 {
-        self.0
-    }
-}
-
-impl<U> marker::Index for U
-where
-    U: Unsigned,
-{
-    #[inline(always)]
-    fn index(&self) -> u8 {
-        Self::U8
-    }
-}
 
 /// Input mode (type state)
 pub struct Input;

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -255,6 +255,12 @@ pub struct Pin<Gpio, Mode, const INDEX: u8> {
     _mode: PhantomData<Mode>,
 }
 
+pub struct PXx<Mode> {
+    gpio: Gpiox,
+    index: u8,
+    _mode: PhantomData<Mode>,
+}
+
 ///// Fully erased pin
 /////
 ///// This moves the pin type information to be known
@@ -883,7 +889,7 @@ macro_rules! gpio {
                 }
 
                 // /// Partially erased pin
-                // pub type $PXx<Mode> = Pin<$Gpiox, Mode, Ux>;
+                // pub type $PXx<Mode> = Pin<$Gpiox, Mode,{ Ux }>;
 
                 $(
                     #[doc = "Pin " $PXi]


### PR DESCRIPTION
This is a MVP of using const generics, based on the refactoring of the GPIO module in https://github.com/stm32-rs/stm32f3xx-hal/pull/189

The current implementation leaves out the `downgrade()` method to get a generic pin type, which is a major loss. 
This is because we can not be generic over `Unsigned` via min const generics. 
 min const generic does not allow any const generics in `where` clauses, and I'm not really sure, if this would be the right approach even if we had full const generics available. 
 
 Maybe there are some improvements to be made, which would allow not having to remove this method.