### PR TITLE
Add read and write impl for Serial, Irq flags functions and RTIC example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ panic-probe = "0.2.0"
 panic-semihosting = "0.5.6"
 usbd-serial = "0.1.1"
 usb-device = "0.2.8"
+cortex-m-rtic = "0.6.0-alpha.4"
+dwt-systick-monotonic = "0.1.0-alpha.2"     
+panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
+rtt-target = { version = "0.3.0", features = ["cortex-m"] }
 
 [build-dependencies]
 cargo_metadata = "0.13.1"
@@ -162,6 +166,10 @@ required-features = ["ld", "can", "stm32f303"]
 [[example]]
 name = "serial_dma"
 required-features = ["ld", "stm32f303"]
+
+[[example]]
+name = "serial_echo_rtic"
+required-features = ["ld", "rt", "stm32f303xc"]
 
 [[example]]
 name = "adc"

--- a/examples/serial_echo_rtic.rs
+++ b/examples/serial_echo_rtic.rs
@@ -1,0 +1,106 @@
+#![no_main]
+#![no_std]
+
+use panic_rtt_target as _;
+
+#[rtic::app(device = stm32f3xx_hal::pac, dispatchers = [TIM20_BRK, TIM20_UP, TIM20_TRG_COM])]
+mod app {
+    use dwt_systick_monotonic::DwtSystick;
+    use rtt_target::{rprintln, rtt_init_print};
+    use stm32f3xx_hal::{prelude::*, serial::{Event, Serial}};
+    use stm32f3xx_hal::gpio::{self, Output, PushPull, Alternate, U};
+
+    #[monotonic(binds = SysTick, default = true)]
+    type DwtMono = DwtSystick<48_000_000>;
+
+    type SerialType = Serial<stm32f3xx_hal::pac::USART1, (gpio::Pin<gpio::Gpioa, U<9_u8>, Alternate<PushPull, 7_u8>>, gpio::Pin<gpio::Gpioa, U<10_u8>, Alternate<PushPull, 7_u8>>)>;
+    type DirType = stm32f3xx_hal::gpio::Pin<gpio::Gpioe, U<13_u8>, Output<PushPull>>;
+    #[resources]
+    struct Resources {
+        serial: SerialType,
+        dir: DirType,
+    }
+
+    #[init]
+    fn init(cx: init::Context) -> (init::LateResources, init::Monotonics) {
+        let mut flash = cx.device.FLASH.constrain();
+        let mut rcc = cx.device.RCC.constrain();
+        let mut dcb = cx.core.DCB;
+        let dwt = cx.core.DWT;
+        let systick = cx.core.SYST;
+
+        rtt_init_print!(NoBlockSkip, 4096);
+        rprintln!("pre init");
+
+        // Initialize the clocks
+        let clocks = rcc.cfgr.sysclk(48.MHz()).freeze(&mut flash.acr);
+        let mono = DwtSystick::new(&mut dcb, dwt, systick, clocks.sysclk().0);
+
+        // Initialize the peripherals
+        // DIR
+        let mut gpioe = cx.device.GPIOE.split(&mut rcc.ahb);
+        let mut dir : DirType = gpioe.pe13.into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper);
+        dir.set_low().unwrap();
+
+        // SERIAL
+        let mut gpioa = cx.device.GPIOA.split(&mut rcc.ahb);
+        let mut pins = (
+            gpioa
+                .pa9
+                .into_af7_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh),
+            gpioa
+                .pa10
+                .into_af7_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh),
+        );
+        pins.1.internal_pull_up(&mut gpioa.pupdr, true);
+        let mut serial: SerialType = Serial::usart1(cx.device.USART1, pins, 19200_u32.Bd(), clocks, &mut rcc.apb2);
+        serial.listen(Event::Rxne);
+
+        rprintln!("post init");
+
+        task1::spawn().unwrap();
+
+        (init::LateResources {serial, dir}, init::Monotonics(mono))
+    }
+
+    #[task(binds = USART1_EXTI25, resources = [serial, dir])]
+    fn protocol_serial_task(cx: protocol_serial_task::Context) {
+        let mut serial = cx.resources.serial;
+        let mut dir = cx.resources.dir;
+
+        serial.lock(|serial| {
+            dir.lock(|dir| {
+                if serial.is_rxne() {
+                    dir.set_high().unwrap();
+                    serial.unlisten(Event::Rxne);
+                    match serial.read() {
+                        Ok(byte) => {
+                            serial.write(byte).unwrap();
+                            serial.listen(Event::Tc);
+                        },
+                        Err(_error) => rprintln!("irq error"),
+                    };
+                }
+
+                if serial.is_tc() {
+                    dir.set_low().unwrap();
+                    serial.unlisten(Event::Tc);
+                    serial.listen(Event::Rxne);
+                }                
+            })
+        });
+    }
+    
+    #[task]
+    fn task1(_cx: task1::Context) {
+        rprintln!("task1");
+    }
+
+    #[idle]
+    fn idle(_: idle::Context) -> ! {
+        rprintln!("idle");
+        loop {
+            cortex_m::asm::nop();
+        }
+    }
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -25,6 +25,8 @@ pub enum Event {
     Rxne,
     /// New data can be sent
     Txe,
+    /// Transmission complete
+    Tc,
 }
 
 /// Serial error
@@ -151,6 +153,9 @@ macro_rules! hal {
                         Event::Txe => {
                             self.usart.cr1.modify(|_, w| w.txeie().set_bit())
                         },
+                        Event::Tc => {
+                            self.usart.cr1.modify(|_, w| w.tcie().set_bit())
+                        },
                     }
                 }
 
@@ -163,9 +168,31 @@ macro_rules! hal {
                         Event::Txe => {
                             self.usart.cr1.modify(|_, w| w.txeie().clear_bit())
                         },
+                        Event::Tc => {
+                            self.usart.cr1.modify(|_, w| w.tcie().clear_bit())
+                        },
                     }
                 }
 
+                /// Return true if the line idle status is set
+                pub fn is_tc(&self) -> bool {
+                    let isr = unsafe { (*$USARTX::ptr()).isr.read() };
+                    isr.tc().bit_is_set()
+                }
+
+                /// Return true if the tx register is empty (and can accept data)
+                pub fn is_txe(&self) -> bool {
+                    let isr = unsafe { (*$USARTX::ptr()).isr.read() };
+                    isr.txe().bit_is_set()
+                }
+
+                /// Return true if the rx register is not empty (and can be read)
+                pub fn is_rxne(&self) -> bool {
+                    let isr = unsafe { (*$USARTX::ptr()).isr.read() };
+                    isr.rxne().bit_is_set()
+                }
+
+                
                 /// Splits the `Serial` abstraction into a transmitter and a receiver half
                 pub fn split(self) -> (Tx<$USARTX>, Rx<$USARTX>) {
                     (
@@ -181,6 +208,35 @@ macro_rules! hal {
                 /// Releases the USART peripheral and associated pins
                 pub fn free(self) -> ($USARTX, (TX, RX)) {
                     (self.usart, self.pins)
+                }
+            }
+            
+            impl<TX, RX> serial::Read<u8> for Serial<$USARTX, (TX, RX)> {
+                type Error = Error;
+            
+                fn read(&mut self) -> nb::Result<u8, Error> {
+                    let mut rx: Rx<$USARTX> = Rx {
+                        _usart: PhantomData,
+                    };
+                    rx.read()
+                }
+            }
+
+            impl<TX, RX> serial::Write<u8> for Serial<$USARTX, (TX, RX)> {
+                type Error = Infallible;
+
+                fn flush(&mut self) -> nb::Result<(), Infallible> {
+                    let mut tx: Tx<$USARTX> = Tx {
+                        _usart: PhantomData,
+                    };
+                    tx.flush()
+                }
+
+                fn write(&mut self, byte: u8) -> nb::Result<(), Infallible> {
+                    let mut tx: Tx<$USARTX> = Tx {
+                        _usart: PhantomData,
+                    };
+                    tx.write(byte)
                 }
             }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -192,7 +192,7 @@ macro_rules! hal {
                     isr.rxne().bit_is_set()
                 }
 
-                
+
                 /// Splits the `Serial` abstraction into a transmitter and a receiver half
                 pub fn split(self) -> (Tx<$USARTX>, Rx<$USARTX>) {
                     (
@@ -210,10 +210,10 @@ macro_rules! hal {
                     (self.usart, self.pins)
                 }
             }
-            
+
             impl<TX, RX> serial::Read<u8> for Serial<$USARTX, (TX, RX)> {
                 type Error = Error;
-            
+
                 fn read(&mut self) -> nb::Result<u8, Error> {
                     let mut rx: Rx<$USARTX> = Rx {
                         _usart: PhantomData,


### PR DESCRIPTION
Hi,
This pull request adds Read and Write implementations to Serial and few functions to work with Irq flags.
This needed to add more control under communicaiton flow and timing.

Also I added an example how to use this with RTIC. The example uses DIR pin when transmiting (like RS485).

PS: This is my first pull request ever :)