### PR TITLE
Allow Serial::new instead of Serial::usartX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `ld` feature, which enables the memory.x generation ([#216])
 - Implement `DelayMs` for `Milliseconds` and `DelayUs` for `Microseconds` ([#234])
 - ADC can now be `free()`'d ([#212])
+- Serial does now implement `embedded_hal::serial::{Read, Write}`.
+  No `split()` necessary. ([#232])
+- Serial can now listen for the "Transmission Complete" `Tc` interrupt event ([#232])
+- Serial can now listen for the `Idle` interrupt event ([#238])
 
 ### Changed
 
@@ -70,6 +74,7 @@ let clocks = rcc
 - Remove `stm32` module. Use `use stm32f3xx_hal::pac` instead.
   This module was a deprecated in [v0.5.0][] and is now subject for
   removal. ([#220])
+- `Serial::uart1` ... functions are renamed to `Serial::new`. ([#212])
 
 ## [v0.6.1] - 2020-12-10
 
@@ -325,6 +330,7 @@ let clocks = rcc
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
 [#234]: https://github.com/stm32-rs/stm32f3xx-hal/pull/234
+[#232]: https://github.com/stm32-rs/stm32f3xx-hal/pull/232
 [#229]: https://github.com/stm32-rs/stm32f3xx-hal/pull/229
 [#227]: https://github.com/stm32-rs/stm32f3xx-hal/pull/227
 [#220]: https://github.com/stm32-rs/stm32f3xx-hal/pull/220

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
             .pa10
             .into_af7_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh),
     );
-    let serial = Serial::usart1(dp.USART1, pins, 9600.Bd(), clocks, &mut rcc.apb2);
+    let serial = Serial::new(dp.USART1, pins, 9600.Bd(), clocks, &mut rcc.apb2);
     let (tx, rx) = serial.split();
 
     let dma1 = dp.DMA1.split(&mut rcc.ahb);

--- a/examples/serial_echo_rtic.rs
+++ b/examples/serial_echo_rtic.rs
@@ -64,13 +64,8 @@ mod app {
                 .into_af7_push_pull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh),
         );
         pins.1.internal_pull_up(&mut gpioa.pupdr, true);
-        let mut serial: SerialType = Serial::usart1(
-            cx.device.USART1,
-            pins,
-            19200_u32.Bd(),
-            clocks,
-            &mut rcc.apb2,
-        );
+        let mut serial: SerialType =
+            Serial::new(cx.device.USART1, pins, 19200.Bd(), clocks, &mut rcc.apb2);
         serial.listen(Event::Rxne);
 
         rprintln!("post init");

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -333,7 +333,10 @@ pub trait Channel: private::Channel {
             1 => BITS8,
             2 => BITS16,
             4 => BITS32,
-            s => crate::panic!("unsupported word size: {:?}", s),
+            #[cfg(not(feature = "defmt"))]
+            s => core::panic!("unsupported word size: {:?}", s),
+            #[cfg(feature = "defmt")]
+            _ => defmt::panic!("unsupported word size"),
         };
 
         self.ch().cr.modify(|_, w| {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -275,6 +275,9 @@ pub struct Pin<Gpio, Index, Mode> {
     _mode: PhantomData<Mode>,
 }
 
+// Make all GPIO peripheral trait extensions sealable.
+impl<Gpio, Index, Mode> crate::private::Sealed for Pin<Gpio, Index, Mode> {}
+
 /// Fully erased pin
 ///
 /// This moves the pin type information to be known

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -132,7 +132,7 @@ impl<I2C, SCL, SDA> I2c<I2C, (SCL, SDA)> {
         // t_SCL ~= t_SYNC1 + t_SYNC2 + t_SCLL + t_SCLH
         let i2cclk = I2C::clock(&clocks).0;
         let ratio = i2cclk / freq.integer() - 4;
-        let (presc, scll, sclh, sdadel, scldel) = if freq.integer() >= 100_000 {
+        let (presc, scll, sclh, sdadel, scldel) = if freq >= 100.kHz() {
             // fast-mode or fast-mode plus
             // here we pick SCLL + 1 = 2 * (SCLH + 1)
             let presc = ratio / 387;
@@ -140,7 +140,7 @@ impl<I2C, SCL, SDA> I2c<I2C, (SCL, SDA)> {
             let sclh = ((ratio / (presc + 1)) - 3) / 3;
             let scll = 2 * (sclh + 1) - 1;
 
-            let (sdadel, scldel) = if freq.integer() > 400_000 {
+            let (sdadel, scldel) = if freq > 400.kHz() {
                 // fast-mode plus
                 let sdadel = 0;
                 let scldel = i2cclk / 4_000_000 / (presc + 1) - 1;
@@ -449,7 +449,7 @@ macro_rules! i2c {
                 fn clock(clocks: &Clocks) -> Hertz {
                     // NOTE(unsafe) atomic read with no side effects
                     match unsafe { (*RCC::ptr()).cfgr3.read().$i2cXsw().variant() } {
-                        I2C1SW_A::HSI => Hertz(8_000_000),
+                        I2C1SW_A::HSI => crate::rcc::HSI,
                         I2C1SW_A::SYSCLK => clocks.sysclk(),
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,3 +203,9 @@ cfg_if! {
         }
     }
 }
+
+mod private {
+    /// Private sealed trait to seal all GPIO implementations
+    /// which do implement peripheral functionalities.
+    pub trait Sealed {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,9 @@ pub mod watchdog;
 
 cfg_if! {
     if #[cfg(feature = "defmt")] {
+        #[allow(unused_imports)]
         pub(crate) use defmt::{assert, panic, unreachable, unwrap};
+        #[allow(unused_imports)]
         pub(crate) use macros::expect;
 
         mod macros {
@@ -177,7 +179,9 @@ cfg_if! {
             pub(crate) use expect_wrapper as expect;
         }
     } else {
+        #[allow(unused_imports)]
         pub(crate) use core::{assert, panic, unreachable};
+        #[allow(unused_imports)]
         pub(crate) use macros::{unwrap, expect};
 
         mod macros {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -340,7 +340,7 @@ where
 
     fn write(&mut self, byte: u8) -> nb::Result<(), Infallible> {
         if self.usart.isr.read().txe().bit_is_set() {
-            self.usart.tdr.write(|w| unsafe { w.tdr().bits(u16::from(byte)) });
+            self.usart.tdr.write(|w| w.tdr().bits(u16::from(byte)));
             Ok(())
         } else {
             Err(nb::Error::WouldBlock)

--- a/testsuite/tests/uart.rs
+++ b/testsuite/tests/uart.rs
@@ -73,21 +73,21 @@ mod tests {
         };
 
         super::State {
-            serial1: Some(Serial::usart1(
+            serial1: Some(Serial::new(
                 dp.USART1,
                 (serial_pair.0, serial_pair.1),
                 9600.Bd(),
                 clocks,
                 &mut rcc.apb2,
             )),
-            serial_slow: Some(Serial::usart2(
+            serial_slow: Some(Serial::new(
                 dp.USART2,
                 (cs_pair_1.0, cs_pair_2.1),
                 57600.Bd(),
                 clocks,
                 &mut rcc.apb1,
             )),
-            serial_fast: Some(Serial::usart3(
+            serial_fast: Some(Serial::new(
                 dp.USART3,
                 (cs_pair_2.0, cs_pair_1.1),
                 115200.Bd(),
@@ -113,7 +113,7 @@ mod tests {
             Baud(460800),
         ] {
             let (usart, pins) = unwrap!(state.serial1.take()).free();
-            let mut serial = Serial::usart1(usart, pins, *baudrate, state.clocks, &mut state.apb2);
+            let mut serial = Serial::new(usart, pins, *baudrate, state.clocks, &mut state.apb2);
             for i in &TEST_MSG {
                 unwrap!(nb::block!(serial.write(*i)));
                 let c = unwrap!(nb::block!(serial.read()));


### PR DESCRIPTION
This requires changing I2C to a more generic implementation,
where the specific UART peripheral implementation get's dispatch
upon it's Instance trait.

The specific UART is longer hard coded into, but instead is referenced
via pointer (trait).

This also allows to reduce the usart macro implementation, so that
the code is easier to follow.

But this leads to code duplication, as code for the Write and Read
trait of embedded-hal can no longer be shared between Serial and Tx |
Rx.

Also, the underlying UART peripheral of Tx and Rx after split has to be
tracked at runtime, instead of being decoded at compile time (via macro).

In addition to all of this the Idle interrupt event was also added.