### PR TITLE
Add config struct for Serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Breaking Changes
 
 - Refactor CAN to use the [`bxCan`](https://github.com/stm32-rs/bxcan) crate. ([#207])
+- Add support for configuring parity and stop bits in addition to baud rate for `Serial` with
+  `serial::config::Config`. ([#239])
 
 ## [v0.7.0] - 2021-06-18
 
@@ -346,6 +348,7 @@ let clocks = rcc
 [#252]: https://github.com/stm32-rs/stm32f3xx-hal/pull/252
 [#247]: https://github.com/stm32-rs/stm32f3xx-hal/pull/247
 [#246]: https://github.com/stm32-rs/stm32f3xx-hal/pull/246
+[#239]: https://github.com/stm32-rs/stm32f3xx-hal/pull/239
 [#238]: https://github.com/stm32-rs/stm32f3xx-hal/pull/238
 [#234]: https://github.com/stm32-rs/stm32f3xx-hal/pull/234
 [#232]: https://github.com/stm32-rs/stm32f3xx-hal/pull/232

--- a/testsuite/tests/adc.rs
+++ b/testsuite/tests/adc.rs
@@ -69,12 +69,12 @@ mod tests {
         for _ in 0..10 {
             defmt::unwrap!(state.output.set_high());
             let adc_level: u16 = defmt::unwrap!(adc.read(&mut state.analog).ok());
-            defmt::info!("{}", adc_level);
+            defmt::debug!("{}", adc_level);
             defmt::unwrap!(state.output.set_low());
             // Vref is 3V so output should reach the maximum.
             assert!(adc_level >= 3900 && adc_level <= 4100);
             let adc_level: u16 = defmt::unwrap!(adc.read(&mut state.analog).ok());
-            defmt::info!("{}", adc_level);
+            defmt::debug!("{}", adc_level);
             // nearly zero (always zero can not be guaranteed)
             assert!(adc_level <= 100);
         }

--- a/testsuite/tests/uart.rs
+++ b/testsuite/tests/uart.rs
@@ -269,9 +269,9 @@ mod tests {
         let (mut tx_fast, mut rx_fast) = unwrap!(state.serial_fast.take()).split();
 
         // provoke an error (framing)
-        defmt::unwrap!(nb::block!(tx_slow.write(b'a')));
+        unwrap!(nb::block!(tx_slow.write(b'a')));
         let c = nb::block!(rx_fast.read());
-        defmt::info!("{}", c);
+        defmt::debug!("{}", c);
         assert!(matches!(c, Err(Error::Framing)));
 
         // provoke an error (this does not seem to be absolutely deterministic

--- a/testsuite/tests/uart.rs
+++ b/testsuite/tests/uart.rs
@@ -110,7 +110,7 @@ mod tests {
 
         // now provoke an overrun
         // send 5 u8 bytes, which do not fit in the 32 bit buffer
-        for i in &TEST_MSG[..4] {
+        for i in &TEST_MSG[..5] {
             defmt::unwrap!(nb::block!(tx.write(*i)));
         }
         let c = nb::block!(rx.read());

--- a/testsuite/tests/watchdog.rs
+++ b/testsuite/tests/watchdog.rs
@@ -72,7 +72,7 @@ mod tests {
                 ),
         )
         .unwrap();
-        defmt::info!("Delay = {}", delay);
+        defmt::debug!("Delay = {}", delay);
         for _ in 0..5 {
             state.iwdg.feed();
 


### PR DESCRIPTION
This is about to add more configuration options like data bits and parity to `Serial`. Baudrate and the new parameters are provided in a struct `Config` which replaces the baud rate parameter of `Serial::new` and could be converted from a baud rate so that it would not break existing code. 

I've created this draft PR to surface this WIP and provide a place for discussion. There is likely more to come and I will rebase my changes once UART refactoring has landed.

Closes #231 
