### PR TITLE
Fix uart clock initialization

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -514,6 +514,7 @@ macro_rules! usart {
                 fn enable_clock(apb: &mut Self::APB) {
                     apb.enr().modify(|_, w| w.$usartXen().enabled());
                     apb.rstr().modify(|_, w| w.$usartXrst().reset());
+                    apb.rstr().modify(|_, w| w.$usartXrst().clear_bit());
                 }
 
                 fn clock(clocks: &Clocks) -> Hertz {


### PR DESCRIPTION
The clear_bit in at the end of the clock enable was
deleted accidentally. This commit re-adds this call.