### PR TITLE
Mark Gpiox as Send and Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implement `Serial::join` which allows to re-create the serial peripheral,
   when `Serial::split` was previously called. ([#252])
 
-## Breaking Changes
+### Changed
+
+- `PXx` struct (representing a generic GPIO pin) implements `Send` and `Sync` [#251]
+
+### Breaking Changes
 
 - Refactor CAN to use the [`bxCan`](https://github.com/stm32-rs/bxcan) crate. ([#207])
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -183,6 +183,18 @@ pub struct Gpiox {
     index: u8,
 }
 
+// # SAFETY
+// As Gpiox uses `dyn GpioRegExt` pointer internally, `Send` is not auto-implemented.
+// But since GpioExt does only do atomic operations without side-effects we can assume
+// that it safe to `Send` this type.
+unsafe impl Send for Gpiox {}
+
+// # SAFETY
+// As Gpiox uses `dyn GpioRegExt` pointer internally, `Sync` is not auto-implemented.
+// But since GpioExt does only do atomic operations without side-effects we can assume
+// that it safe to `Send` this type.
+unsafe impl Sync for Gpiox {}
+
 impl private::Gpio for Gpiox {
     type Reg = dyn GpioRegExt;
 


### PR DESCRIPTION
This is appropriate because we only ever perform atomic operations on
these registers.  This allows `PXx` to be Send + Sync.

Closes #249 