### PR TITLE
Mark Serial::join as a breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Readd MonoTimer. This was accidentally removed before. ([#247])
 - Basic serial implementation also available for UART4 and UART5 ([#246])
 - Implement serial DMA also for Serial ([#246])
-- Implement `Serial::join` which allows to re-create the serial peripheral,
-  when `Serial::split` was previously called. ([#252])
 
 ### Changed
 
@@ -22,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 
 - Refactor CAN to use the [`bxCan`](https://github.com/stm32-rs/bxcan) crate. ([#207])
+- Implement `Serial::join` which allows to re-create the serial peripheral,
+  when `Serial::split` was previously called. ([#252])
 
 ## [v0.7.0] - 2021-06-18
 


### PR DESCRIPTION
Because to implement Serial::join the generic
parameters of Tx and Rx had to be changed from
Tx<Usart> -> Tx<Usart, Pin>