### PR TITLE
Support USB on the stm32f303xd/xe devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `serial::config::Config`. ([#239])
 - Implement `Serial::join` which allows to re-create the serial peripheral,
   when `Serial::split` was previously called. ([#252])
+- Parameterized `usb::Peripheral` and `usb::UsbType` on the pin configuration
+  used ([#254])
 
 ## [v0.7.0] - 2021-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 
 - Refactor CAN to use the [`bxCan`](https://github.com/stm32-rs/bxcan) crate. ([#207])
-- Add support for configuring parity and stop bits in addition to baud rate for `Serial` with
-  `serial::config::Config`. ([#239])
+- Add support for configuring parity and stop bits in addition to baud rate for
+ `Serial` with `serial::config::Config`. ([#239])
 - Implement `Serial::join` which allows to re-create the serial peripheral,
   when `Serial::split` was previously called. ([#252])
 - Parameterized `usb::Peripheral` and `usb::UsbType` on the pin configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implement `Serial::join` which allows to re-create the serial peripheral,
   when `Serial::split` was previously called. ([#252])
 - Parameterized `usb::Peripheral` and `usb::UsbType` on the pin configuration
-  used ([#254])
+  used ([#255])
 
 ## [v0.7.0] - 2021-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,7 @@ let clocks = rcc
 [defmt]: https://github.com/knurling-rs/defmt
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
+[#255]: https://github.com/stm32-rs/stm32f3xx-hal/pull/255
 [#252]: https://github.com/stm32-rs/stm32f3xx-hal/pull/252
 [#247]: https://github.com/stm32-rs/stm32f3xx-hal/pull/247
 [#246]: https://github.com/stm32-rs/stm32f3xx-hal/pull/246

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -89,7 +89,4 @@ pub type UsbBusType<Dm = PA11<gpio::AF14<gpio::PushPull>>, Dp = PA12<gpio::AF14<
 
 /// Type of the UsbBus
 #[cfg(any(feature = "stm32f303xd", feature = "stm32f303xe"))]
-pub type UsbBusType<
-    Dm = PA11<gpio::Output<gpio::PushPull>>,
-    Dp = PA12<gpio::Output<gpio::PushPull>>,
-> = UsbBus<Peripheral<Dm, Dp>>;
+pub type UsbBusType<Dm = PA11<gpio::Input>, Dp = PA12<gpio::Input>> = UsbBus<Peripheral<Dm, Dp>>;

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -11,44 +11,44 @@
 use crate::pac::{RCC, USB};
 use stm32_usbd::UsbPeripheral;
 
+use crate::gpio;
 use crate::gpio::gpioa::{PA11, PA12};
-use crate::gpio::{PushPull, AF14};
 pub use stm32_usbd::UsbBus;
 
 /// Trait implemented by all pins that can be the "D-" pin for the USB peripheral
-pub trait DMPin: crate::private::Sealed {}
+pub trait DmPin: crate::private::Sealed {}
 
 /// Trait implemented by all pins that can be the "D+" pin for the USB peripheral
-pub trait DPPin: crate::private::Sealed {}
+pub trait DpPin: crate::private::Sealed {}
 
 #[cfg(any(feature = "stm32f303xb", feature = "stm32f303xc"))]
-impl DMPin for PA11<AF14<PushPull>> {}
+impl DmPin for PA11<gpio::AF14<gpio::PushPull>> {}
 
 #[cfg(any(feature = "stm32f303xb", feature = "stm32f303xc"))]
-impl DPPin for PA12<AF14<PushPull>> {}
+impl DpPin for PA12<gpio::AF14<gpio::PushPull>> {}
 
 #[cfg(any(feature = "stm32f303xd", feature = "stm32f303xe"))]
-impl<Mode> DMPin for PA11<Mode> {}
+impl<Mode> DmPin for PA11<Mode> {}
 
 #[cfg(any(feature = "stm32f303xd", feature = "stm32f303xe"))]
-impl<Mode> DPPin for PA12<Mode> {}
+impl<Mode> DpPin for PA12<Mode> {}
 
 /// USB Peripheral
 ///
 /// Constructs the peripheral, which
 /// than gets passed to the [`UsbBus`].
-pub struct Peripheral<DM: DMPin, DP: DPPin> {
+pub struct Peripheral<Dm: DmPin, Dp: DpPin> {
     /// USB Register Block
     pub usb: USB,
     /// Data Negativ Pin
-    pub pin_dm: DM,
+    pub pin_dm: Dm,
     /// Data Positiv Pin
-    pub pin_dp: DP,
+    pub pin_dp: Dp,
 }
 
-unsafe impl<DM: DMPin, DP: DPPin> Sync for Peripheral<DM, DP> {}
+unsafe impl<Dm: DmPin, Dp: DpPin> Sync for Peripheral<Dm, Dp> {}
 
-unsafe impl<DM: DMPin + Send, DP: DPPin + Send> UsbPeripheral for Peripheral<DM, DP> {
+unsafe impl<Dm: DmPin + Send, Dp: DpPin + Send> UsbPeripheral for Peripheral<Dm, Dp> {
     const REGISTERS: *const () = USB::ptr() as *const ();
     const DP_PULL_UP_FEATURE: bool = false;
     const EP_MEMORY: *const () = 0x4000_6000 as _;
@@ -83,8 +83,13 @@ unsafe impl<DM: DMPin + Send, DP: DPPin + Send> UsbPeripheral for Peripheral<DM,
 }
 
 /// Type of the UsbBus
-///
-/// As this MCU family has only USB peripheral,
-/// this is the only possible concrete type construction.
-pub type UsbBusType<DP = PA11<AF14<PushPull>>, DM = PA12<AF14<PushPull>>> =
-    UsbBus<Peripheral<DM, DP>>;
+#[cfg(any(feature = "stm32f303xb", feature = "stm32f303xc"))]
+pub type UsbBusType<Dm = PA11<gpio::AF14<gpio::PushPull>>, Dp = PA12<gpio::AF14<gpio::PushPull>>> =
+    UsbBus<Peripheral<Dm, Dp>>;
+
+/// Type of the UsbBus
+#[cfg(any(feature = "stm32f303xd", feature = "stm32f303xe"))]
+pub type UsbBusType<
+    Dm = PA11<gpio::Output<gpio::PushPull>>,
+    Dp = PA12<gpio::Output<gpio::PushPull>>,
+> = UsbBus<Peripheral<Dm, Dp>>;

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -15,22 +15,40 @@ use crate::gpio::gpioa::{PA11, PA12};
 use crate::gpio::{PushPull, AF14};
 pub use stm32_usbd::UsbBus;
 
+/// Trait implemented by all pins that can be the "D-" pin for the USB peripheral
+pub trait DMPin: crate::private::Sealed {}
+
+/// Trait implemented by all pins that can be the "D+" pin for the USB peripheral
+pub trait DPPin: crate::private::Sealed {}
+
+#[cfg(any(feature = "stm32f303xb", feature = "stm32f303xc"))]
+impl DMPin for PA11<AF14<PushPull>> {}
+
+#[cfg(any(feature = "stm32f303xb", feature = "stm32f303xc"))]
+impl DPPin for PA12<AF14<PushPull>> {}
+
+#[cfg(any(feature = "stm32f303xd", feature = "stm32f303xe"))]
+impl<Mode> DMPin for PA11<Mode> {}
+
+#[cfg(any(feature = "stm32f303xd", feature = "stm32f303xe"))]
+impl<Mode> DPPin for PA12<Mode> {}
+
 /// USB Peripheral
 ///
 /// Constructs the peripheral, which
 /// than gets passed to the [`UsbBus`].
-pub struct Peripheral {
+pub struct Peripheral<DM: DMPin, DP: DPPin> {
     /// USB Register Block
     pub usb: USB,
     /// Data Negativ Pin
-    pub pin_dm: PA11<AF14<PushPull>>,
+    pub pin_dm: DM,
     /// Data Positiv Pin
-    pub pin_dp: PA12<AF14<PushPull>>,
+    pub pin_dp: DP,
 }
 
-unsafe impl Sync for Peripheral {}
+unsafe impl<DM: DMPin, DP: DPPin> Sync for Peripheral<DM, DP> {}
 
-unsafe impl UsbPeripheral for Peripheral {
+unsafe impl<DM: DMPin + Send, DP: DPPin + Send> UsbPeripheral for Peripheral<DM, DP> {
     const REGISTERS: *const () = USB::ptr() as *const ();
     const DP_PULL_UP_FEATURE: bool = false;
     const EP_MEMORY: *const () = 0x4000_6000 as _;
@@ -68,4 +86,5 @@ unsafe impl UsbPeripheral for Peripheral {
 ///
 /// As this MCU family has only USB peripheral,
 /// this is the only possible concrete type construction.
-pub type UsbBusType = UsbBus<Peripheral>;
+pub type UsbBusType<DP = PA11<AF14<PushPull>>, DM = PA12<AF14<PushPull>>> =
+    UsbBus<Peripheral<DM, DP>>;


### PR DESCRIPTION
The 303xd and 303xe series devices do not have AF14 for pins PA11 and
PA12, so the existing implementation will not work for those devices.

According to an ST document [1], stm32f303xd and xe do not require any
particular mode for the PA11 and PA12 pin, so I've parameterized the
`usb::Peripheral` type using traits so that any mode will be
supported.  I've tried to follow a familiar pattern reminescent of the
gpio alternate function configurations.

This is of course a breaking change so I'm open to other approaches if
anyone has opinions.  This seemed to me to be the most elegant and
accurate way to handle this.

[1]: https://www.st.com/resource/en/application_note/dm00260340-migrating-between-stm32f303-and-stm32f302-line-products-stmicroelectronics.pdf