### PR TITLE
Enable `feature(doc_cfg)` if `cfg(docsrs)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@
 #![warn(missing_docs)]
 #![deny(macro_use_extern_crate)]
 #![cfg_attr(nightly, deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use cfg_if::cfg_if;
 


### PR DESCRIPTION
This allows for `#[cfg_attr(docsrs, doc(cfg(...)))]` to properly work.