### PR TITLE
USART1 connects to PCLK1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   features, can no longer be disabled. ([#259])
   1. The "unproven" features are no longer unproven and used anywhere anyways.
   2. This crate was not building successfully without the unproven feature.
+- Set the correct baud rate for chips where `USART1SW_A::PCLK` leads to a baud rate 
+  derived from PCLK1, rather than the ports own bus clock, PCLK2. ([#260])
 
 ### Breaking Changes
 
@@ -367,6 +369,7 @@ let clocks = rcc
 [defmt]: https://github.com/knurling-rs/defmt
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
+[#260]: https://github.com/stm32-rs/stm32f3xx-hal/pull/260
 [#259]: https://github.com/stm32-rs/stm32f3xx-hal/pull/259
 [#257]: https://github.com/stm32-rs/stm32f3xx-hal/pull/257
 [#255]: https://github.com/stm32-rs/stm32f3xx-hal/pull/255

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   features, can no longer be disabled. ([#259])
   1. The "unproven" features are no longer unproven and used anywhere anyways.
   2. This crate was not building successfully without the unproven feature.
-- Set the correct baud rate for chips where `USART1SW_A::PCLK` leads to a baud rate 
-  derived from PCLK1, rather than the ports own bus clock, PCLK2. ([#260])
+- Set the correct baud rate for chips where `USART1SW_A::PCLK` leads to a
+  baud rate derived from PCLK1, rather than the ports own bus clock, PCLK2.
+  ([#260])
 
 ### Breaking Changes
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -869,13 +869,18 @@ macro_rules! usart_var_clock {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(all(
-        any(
-            feature = "mem-4",
-            feature = "mem-6",
-            feature = "mem-8",
-        ),
-        not(feature = "svd-f373")
+    if #[cfg(any(
+        feature = "stm32f301x6",
+        feature = "stm32f301x8",
+        feature = "stm32f318x8",
+        feature = "stm32f302x6",
+        feature = "stm32f302x8",
+        feature = "stm32f303x6",
+        feature = "stm32f303x8",
+        feature = "stm32f328x8",
+        feature = "stm32f334x4",
+        feature = "stm32f334x6",
+        feature = "stm32f334x8",
     ))] {
         // USART1 is accessed through APB2,
         // but USART1SW_A::PCLK will connect its phy to PCLK1.

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -869,8 +869,17 @@ macro_rules! usart_var_clock {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(any(feature = "svd-f301", feature = "svd-f3x4"))] {
-        usart_var_clock!([(1,2)]);
+    if #[cfg(all(
+        any(
+            feature = "mem-4",
+            feature = "mem-6",
+            feature = "mem-8",
+        ),
+        not(feature = "svd-f373")
+    ))] {
+        // USART1 is accessed through APB2,
+        // but USART1SW_A::PCLK will connect its phy to PCLK1.
+        usart_var_clock!([(1,1)]);
         // These are uart peripherals, where the only clock source
         // is the PCLK (peripheral clock).
         usart_static_clock!([(2,1), (3,1)]);


### PR DESCRIPTION
The clock tree figures of RM0366, RM0365, RM0364, RM0316, and RM0313 show that the default setting of RCC::CFGR3::USART1SW will, for some variants, make the port use PCLK1 for reference, and not PCLK2 where port is resident.

The affected variants are stm32f3xxx4/6/8, except stm32f37xxx.

This is consistent with my observations on stm32f344r8, which fails to produce the correct baud rate:
- If sysclk is configured above 32 MHz and both pclk are untouched (pclk1 is then divided, but pclk2 is not), or
- If the pclk's are specifically configured differently.

This might be related to #109, although I don't see why the discussed code snippet should cause different pclk's.