### PR TITLE
Breaking Changes for non-complete modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Make timer Events `#[non_exhaustive]`. ([#264])
 - Renames timers `release()` function to `free()` to be more in line with the
   rest of this crate. ([#264])
+- rtc's `Error` type and `OperationMode` and `CkMode` of adc are now `#[non_exhaustive]`.
+  ([#266])
 
 ## [v0.7.0] - 2021-06-18
 
@@ -428,6 +430,7 @@ let clocks = rcc
 [defmt]: https://github.com/knurling-rs/defmt
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
+[#266]: https://github.com/stm32-rs/stm32f3xx-hal/pull/266
 [#265]: https://github.com/stm32-rs/stm32f3xx-hal/pull/265
 [#264]: https://github.com/stm32-rs/stm32f3xx-hal/pull/264
 [#263]: https://github.com/stm32-rs/stm32f3xx-hal/pull/263

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - All non-camel-case types are chaged to be consistently camel-case types.
   Types which do not follow these rules are re-exported types by `stm32f3` for
   example. ([#266])
+- Adc's `SampleTime` type has been reworked and is now a consistent wrapper around
+  the underlying types for `stm32f3`'s `SMP9_A` and `SMP18_A` type. ([#266])
 
 ## [v0.7.0] - 2021-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   This should make it easier to generically use the `Serial` peripheral. ([#253])
 - Greatly increase coverage of `Debug` and `defmt::Format` implementations.
   Almost all important types should now be supported. ([#265])
+- Add a `free()` function to the RTC implementation to retrieve the passed-in
+  peripheral. ([#266])
 
 [`enumset`]: https://crates.io/crates/enumset
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   rest of this crate. ([#264])
 - rtc's `Error` type and `OperationMode` and `CkMode` of adc are now `#[non_exhaustive]`.
   ([#266])
+- All non-camel-case types are chaged to be consistently camel-case types.
+  Types which do not follow these rules are re-exported types by `stm32f3` for
+  example. ([#266])
 
 ## [v0.7.0] - 2021-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   example. ([#266])
 - Adc's `SampleTime` type has been reworked and is now a consistent wrapper around
   the underlying types for `stm32f3`'s `SMP9_A` and `SMP18_A` type. ([#266])
+- Rename `CkMode` to `ClockMode` ([#266])
 
 ## [v0.7.0] - 2021-06-18
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ chosen.
 #### Background
 
 For some of the stm32f3xx chips there are sub-variants that differ in
-functionality, peripheral use and hence 'under the hood' implementation.  To
-allow the full use of all peripherals on certain subvariants without
-allowing for code that just doesn't run on other sub-vairants, they are
+functionality, peripheral use and hence 'under the hood' implementation.
+To allow the full use of all peripherals on certain sub-variants without
+allowing for code that just doesn't run on other sub-variants, they are
 distinct features that need to be specified.
 
 [user manual]: https://www.st.com/content/ccc/resource/technical/document/user_manual/8a/56/97/63/8d/56/41/73/DM00063382.pdf/files/DM00063382.pdf/jcr:content/translations/en.DM00063382.pdf
@@ -141,10 +141,8 @@ compile with older versions but that may change in any new patch release.
 
 <!-- Don't forget to also adjust the MSVR version in `.github/workflows/ci.yml` -->
 
+## [Contributing](CONTRIBUTING.md)
+
 ## License
 
 [0-clause BSD license](LICENSE-0BSD.txt).
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -26,7 +26,7 @@ fn main() -> ! {
         // correctly.
         &mut dp.ADC1_2,
         &mut rcc.ahb,
-        adc::CkMode::default(),
+        adc::ClockMode::default(),
         clocks,
     );
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -191,7 +191,7 @@ macro_rules! adc_pins {
 // # ADC1 Pin/Channel mapping
 // ## f303
 
-#[cfg(feature = "stm32f303")]
+#[cfg(feature = "svd-f303")]
 adc_pins!(ADC1,
     gpio::PA0<Analog> => 1,
     gpio::PA1<Analog> => 2,
@@ -203,19 +203,14 @@ adc_pins!(ADC1,
     gpio::PC3<Analog> => 9,
 );
 
-#[cfg(any(feature = "stm32f303x6", feature = "stm32f303x8"))]
+#[cfg(feature = "gpio-f333")]
 adc_pins!(ADC1,
     gpio::PB0<Analog> => 11,
     gpio::PB1<Analog> => 12,
     gpio::PB13<Analog> => 13,
 );
 
-#[cfg(any(
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e"))]
 adc_pins!(ADC1,
     gpio::PF4<Analog> => 5,
     gpio::PF2<Analog> => 10,
@@ -224,7 +219,7 @@ adc_pins!(ADC1,
 // # ADC2 Pin/Channel mapping
 // ## f303
 
-#[cfg(feature = "stm32f303")]
+#[cfg(feature = "svd-f303")]
 adc_pins!(ADC2,
     gpio::PA4<Analog> => 1,
     gpio::PA5<Analog> => 2,
@@ -239,19 +234,14 @@ adc_pins!(ADC2,
     gpio::PB2<Analog> => 12,
 );
 
-#[cfg(any(feature = "stm32f303x6", feature = "stm32f303x8"))]
+#[cfg(feature = "gpio-f333")]
 adc_pins!(ADC2,
     gpio::PB12<Analog> => 13,
     gpio::PB14<Analog> => 14,
     gpio::PB15<Analog> => 15,
 );
 
-#[cfg(any(
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e",))]
 adc_pins!(ADC2,
     gpio::PF2<Analog> => 10,
 );
@@ -259,12 +249,7 @@ adc_pins!(ADC2,
 // # ADC3 Pin/Channel mapping
 // ## f303
 
-#[cfg(any(
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e",))]
 adc_pins!(ADC3,
     gpio::PB1<Analog> => 1,
     gpio::PE9<Analog> => 2,
@@ -287,12 +272,7 @@ adc_pins!(ADC3,
 // # ADC4 Pin/Channel mapping
 // ## f303
 
-#[cfg(any(
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e",))]
 adc_pins!(ADC4,
     gpio::PE14<Analog> => 1,
     gpio::PE15<Analog> => 2,
@@ -577,12 +557,7 @@ macro_rules! adc12_hal {
 
 // Macro to implement ADC functionallity for ADC3 and ADC4
 // TODO: Extend/differentiate beyond f303.
-#[cfg(any(
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e",))]
 macro_rules! adc34_hal {
     ($(
             $ADC:ident: ($adcx:ident),
@@ -610,17 +585,12 @@ macro_rules! adc34_hal {
     }
 }
 
-#[cfg(feature = "stm32f303")]
+#[cfg(feature = "svd-f303")]
 adc12_hal! {
     ADC1: (adc1),
     ADC2: (adc2),
 }
-#[cfg(any(
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e",))]
 adc34_hal! {
     ADC3: (adc3),
     ADC4: (adc4),

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -14,7 +14,11 @@ use embedded_hal::adc::{Channel, OneShot};
 
 use crate::{
     gpio::{self, Analog},
-    pac::{adc1::cfgr::ALIGN_A, adc1_2::ccr::CKMODE_A, ADC1, ADC1_2, ADC2},
+    pac::{
+        adc1::{cfgr::ALIGN_A, smpr1::SMP9_A, smpr2::SMP18_A},
+        adc1_2::ccr::CKMODE_A,
+        ADC1, ADC1_2, ADC2,
+    },
     rcc::{Clocks, AHB},
 };
 
@@ -73,18 +77,32 @@ impl Default for SampleTime {
     }
 }
 
-impl SampleTime {
-    /// Conversion to bits for SMP
-    fn bitcode(&self) -> u8 {
-        match self {
-            SampleTime::T_1 => 0b000,
-            SampleTime::T_2 => 0b001,
-            SampleTime::T_4 => 0b010,
-            SampleTime::T_7 => 0b011,
-            SampleTime::T_19 => 0b100,
-            SampleTime::T_61 => 0b101,
-            SampleTime::T_181 => 0b110,
-            SampleTime::T_601 => 0b111,
+impl From<SampleTime> for SMP9_A {
+    fn from(t: SampleTime) -> Self {
+        match t {
+            SampleTime::T_1 => Self::CYCLES1_5,
+            SampleTime::T_2 => Self::CYCLES2_5,
+            SampleTime::T_4 => Self::CYCLES4_5,
+            SampleTime::T_7 => Self::CYCLES7_5,
+            SampleTime::T_19 => Self::CYCLES19_5,
+            SampleTime::T_61 => Self::CYCLES61_5,
+            SampleTime::T_181 => Self::CYCLES181_5,
+            SampleTime::T_601 => Self::CYCLES601_5,
+        }
+    }
+}
+
+impl From<SampleTime> for SMP18_A {
+    fn from(t: SampleTime) -> Self {
+        match t {
+            SampleTime::T_1 => Self::CYCLES1_5,
+            SampleTime::T_2 => Self::CYCLES2_5,
+            SampleTime::T_4 => Self::CYCLES4_5,
+            SampleTime::T_7 => Self::CYCLES7_5,
+            SampleTime::T_19 => Self::CYCLES19_5,
+            SampleTime::T_61 => Self::CYCLES61_5,
+            SampleTime::T_181 => Self::CYCLES181_5,
+            SampleTime::T_601 => Self::CYCLES601_5,
         }
     }
 }
@@ -488,23 +506,23 @@ macro_rules! adc_hal {
                 // TODO: there are boundaries on how this can be set depending on the hardware.
                 fn set_chan_smps(&self, chan: u8, smp: SampleTime) {
                     match chan {
-                        1 => self.rb.smpr1.modify(|_, w| w.smp1().bits(smp.bitcode())),
-                        2 => self.rb.smpr1.modify(|_, w| w.smp2().bits(smp.bitcode())),
-                        3 => self.rb.smpr1.modify(|_, w| w.smp3().bits(smp.bitcode())),
-                        4 => self.rb.smpr1.modify(|_, w| w.smp4().bits(smp.bitcode())),
-                        5 => self.rb.smpr1.modify(|_, w| w.smp5().bits(smp.bitcode())),
-                        6 => self.rb.smpr1.modify(|_, w| w.smp6().bits(smp.bitcode())),
-                        7 => self.rb.smpr1.modify(|_, w| w.smp7().bits(smp.bitcode())),
-                        8 => self.rb.smpr1.modify(|_, w| w.smp8().bits(smp.bitcode())),
-                        9 => self.rb.smpr1.modify(|_, w| w.smp9().bits(smp.bitcode())),
-                        11 => self.rb.smpr2.modify(|_, w| w.smp10().bits(smp.bitcode())),
-                        12 => self.rb.smpr2.modify(|_, w| w.smp12().bits(smp.bitcode())),
-                        13 => self.rb.smpr2.modify(|_, w| w.smp13().bits(smp.bitcode())),
-                        14 => self.rb.smpr2.modify(|_, w| w.smp14().bits(smp.bitcode())),
-                        15 => self.rb.smpr2.modify(|_, w| w.smp15().bits(smp.bitcode())),
-                        16 => self.rb.smpr2.modify(|_, w| w.smp16().bits(smp.bitcode())),
-                        17 => self.rb.smpr2.modify(|_, w| w.smp17().bits(smp.bitcode())),
-                        18 => self.rb.smpr2.modify(|_, w| w.smp18().bits(smp.bitcode())),
+                        1 => self.rb.smpr1.modify(|_, w| w.smp1().variant(smp.into())),
+                        2 => self.rb.smpr1.modify(|_, w| w.smp2().variant(smp.into())),
+                        3 => self.rb.smpr1.modify(|_, w| w.smp3().variant(smp.into())),
+                        4 => self.rb.smpr1.modify(|_, w| w.smp4().variant(smp.into())),
+                        5 => self.rb.smpr1.modify(|_, w| w.smp5().variant(smp.into())),
+                        6 => self.rb.smpr1.modify(|_, w| w.smp6().variant(smp.into())),
+                        7 => self.rb.smpr1.modify(|_, w| w.smp7().variant(smp.into())),
+                        8 => self.rb.smpr1.modify(|_, w| w.smp8().variant(smp.into())),
+                        9 => self.rb.smpr1.modify(|_, w| w.smp9().variant(smp.into())),
+                        11 => self.rb.smpr2.modify(|_, w| w.smp10().variant(smp.into())),
+                        12 => self.rb.smpr2.modify(|_, w| w.smp12().variant(smp.into())),
+                        13 => self.rb.smpr2.modify(|_, w| w.smp13().variant(smp.into())),
+                        14 => self.rb.smpr2.modify(|_, w| w.smp14().variant(smp.into())),
+                        15 => self.rb.smpr2.modify(|_, w| w.smp15().variant(smp.into())),
+                        16 => self.rb.smpr2.modify(|_, w| w.smp16().variant(smp.into())),
+                        17 => self.rb.smpr2.modify(|_, w| w.smp17().variant(smp.into())),
+                        18 => self.rb.smpr2.modify(|_, w| w.smp18().variant(smp.into())),
                         _ => crate::unreachable!(),
                     };
                 }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -93,6 +93,7 @@ impl SampleTime {
 // TODO: Implement other modes (DMA, Differential,…)
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum OperationMode {
     /// OneShot Mode
     OneShot,

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -35,6 +35,7 @@ const MAX_ADVREGEN_STARTUP_US: u32 = 10;
 /// Analog Digital Converter Peripheral
 // TODO: Remove `pub` from the register block once all functionalities are implemented.
 // Leave it here until then as it allows easy access to the registers.
+// TODO(Sh3Rm4n) Add configuration and other things like in the `stm32f4xx-hal` crate
 pub struct Adc<ADC> {
     /// ADC Register
     pub rb: ADC,
@@ -109,6 +110,8 @@ impl From<SampleTime> for SMP18_A {
 
 /// ADC operation mode
 // TODO: Implement other modes (DMA, Differential,…)
+// TODO(Sh3Rm4n): Maybe make operation modes to type states to better
+// integrate with embedded-hal crates?
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -102,20 +102,21 @@ pub enum OperationMode {
 #[derive(Clone, Copy, PartialEq)]
 /// ADC CkMode
 // TODO: Add ASYNCHRONOUS mode
+#[non_exhaustive]
 pub enum CkMode {
     // /// Use Kernel Clock adc_ker_ck_input divided by PRESC. Asynchronous to AHB clock
-    // ASYNCHRONOUS = 0,
+    // Asynchronous,
     /// Use AHB clock rcc_hclk3. In this case rcc_hclk must equal sys_d1cpre_ck
-    SYNCDIV1 = 1,
+    SyncDiv1,
     /// Use AHB clock rcc_hclk3 divided by 2
-    SYNCDIV2 = 2,
+    SyncDiv2,
     /// Use AHB clock rcc_hclk3 divided by 4
-    SYNCDIV4 = 4,
+    SyncDiv4,
 }
 
 impl Default for CkMode {
     fn default() -> Self {
-        CkMode::SYNCDIV2
+        CkMode::SyncDiv2
     }
 }
 
@@ -123,10 +124,10 @@ impl Default for CkMode {
 impl From<CkMode> for CKMODE_A {
     fn from(ckmode: CkMode) -> Self {
         match ckmode {
-            //CkMode::ASYNCHRONOUS => CKMODE_A::ASYNCHRONOUS,
-            CkMode::SYNCDIV1 => CKMODE_A::SYNCDIV1,
-            CkMode::SYNCDIV2 => CKMODE_A::SYNCDIV2,
-            CkMode::SYNCDIV4 => CKMODE_A::SYNCDIV4,
+            //CkMode::Asynchronous => CKMODE_A::ASYNCHRONOUS,
+            CkMode::SyncDiv1 => CKMODE_A::SYNCDIV1,
+            CkMode::SyncDiv2 => CKMODE_A::SYNCDIV2,
+            CkMode::SyncDiv4 => CKMODE_A::SYNCDIV4,
         }
     }
 }
@@ -345,10 +346,10 @@ macro_rules! adc_hal {
                     self.rb
                 }
 
-                /// Software can use CkMode::SYNCDIV1 only if
+                /// Software can use CkMode::SyncDiv1 only if
                 /// hclk and sysclk are the same. (see reference manual 15.3.3)
                 fn clocks_welldefined(&self, clocks: Clocks) -> bool {
-                    if (self.ckmode == CkMode::SYNCDIV1) {
+                    if (self.ckmode == CkMode::SyncDiv1) {
                         clocks.hclk().0 == clocks.sysclk().0
                     } else {
                         true
@@ -440,9 +441,9 @@ macro_rules! adc_hal {
                     // mode is implemented (CKMODE[1:0] = 00b).  This will force whoever is working
                     // on it to rethink what needs to be done here :)
                     let adc_per_cpu_cycles = match self.ckmode {
-                        CkMode::SYNCDIV1 => 1,
-                        CkMode::SYNCDIV2 => 2,
-                        CkMode::SYNCDIV4 => 4,
+                        CkMode::SyncDiv1 => 1,
+                        CkMode::SyncDiv2 => 2,
+                        CkMode::SyncDiv4 => 4,
                     };
                     asm::delay(adc_per_cpu_cycles * cycles);
                 }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -53,41 +53,41 @@ pub struct Adc<ADC> {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SampleTime {
     /// 1.5 ADC clock cycles
-    T_1,
+    Cycles1C5,
     /// 2.5 ADC clock cycles
-    T_2,
+    Cycles2C5,
     /// 4.5 ADC clock cycles
-    T_4,
+    Cycles4C5,
     /// 7.5 ADC clock cycles
-    T_7,
+    Cycles7C5,
     /// 19.5 ADC clock cycles
-    T_19,
+    Cycles19C5,
     /// 61.5 ADC clock cycles
-    T_61,
+    Cycles61C5,
     /// 181.5 ADC clock cycles
-    T_181,
+    Cycles181C5,
     /// 601.5 ADC clock cycles
-    T_601,
+    Cycles601C5,
 }
 
 impl Default for SampleTime {
-    /// T_1 is also the reset value.
+    /// [`SampelTime::Cycles1C5`] is also the reset value.
     fn default() -> Self {
-        SampleTime::T_1
+        SampleTime::Cycles1C5
     }
 }
 
 impl From<SampleTime> for SMP9_A {
     fn from(t: SampleTime) -> Self {
         match t {
-            SampleTime::T_1 => Self::CYCLES1_5,
-            SampleTime::T_2 => Self::CYCLES2_5,
-            SampleTime::T_4 => Self::CYCLES4_5,
-            SampleTime::T_7 => Self::CYCLES7_5,
-            SampleTime::T_19 => Self::CYCLES19_5,
-            SampleTime::T_61 => Self::CYCLES61_5,
-            SampleTime::T_181 => Self::CYCLES181_5,
-            SampleTime::T_601 => Self::CYCLES601_5,
+            SampleTime::Cycles1C5 => Self::CYCLES1_5,
+            SampleTime::Cycles2C5 => Self::CYCLES2_5,
+            SampleTime::Cycles4C5 => Self::CYCLES4_5,
+            SampleTime::Cycles7C5 => Self::CYCLES7_5,
+            SampleTime::Cycles19C5 => Self::CYCLES19_5,
+            SampleTime::Cycles61C5 => Self::CYCLES61_5,
+            SampleTime::Cycles181C5 => Self::CYCLES181_5,
+            SampleTime::Cycles601C5 => Self::CYCLES601_5,
         }
     }
 }
@@ -95,14 +95,14 @@ impl From<SampleTime> for SMP9_A {
 impl From<SampleTime> for SMP18_A {
     fn from(t: SampleTime) -> Self {
         match t {
-            SampleTime::T_1 => Self::CYCLES1_5,
-            SampleTime::T_2 => Self::CYCLES2_5,
-            SampleTime::T_4 => Self::CYCLES4_5,
-            SampleTime::T_7 => Self::CYCLES7_5,
-            SampleTime::T_19 => Self::CYCLES19_5,
-            SampleTime::T_61 => Self::CYCLES61_5,
-            SampleTime::T_181 => Self::CYCLES181_5,
-            SampleTime::T_601 => Self::CYCLES601_5,
+            SampleTime::Cycles1C5 => Self::CYCLES1_5,
+            SampleTime::Cycles2C5 => Self::CYCLES2_5,
+            SampleTime::Cycles4C5 => Self::CYCLES4_5,
+            SampleTime::Cycles7C5 => Self::CYCLES7_5,
+            SampleTime::Cycles19C5 => Self::CYCLES19_5,
+            SampleTime::Cycles61C5 => Self::CYCLES61_5,
+            SampleTime::Cycles181C5 => Self::CYCLES181_5,
+            SampleTime::Cycles601C5 => Self::CYCLES601_5,
         }
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -45,38 +45,37 @@ pub enum Error {
     // Alert, // SMBUS mode only
 }
 
-// FIXME these should be "closed" traits
-/// SCL pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait SclPin<I2C> {}
+/// SCL pin
+pub trait SclPin<I2C>: crate::private::Sealed {}
 
-/// SDA pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait SdaPin<I2C> {}
+/// SDA pin
+pub trait SdaPin<I2C>: crate::private::Sealed {}
 
-unsafe impl SclPin<I2C1> for gpioa::PA15<AF4<OpenDrain>> {}
-unsafe impl SclPin<I2C1> for gpiob::PB6<AF4<OpenDrain>> {}
-unsafe impl SclPin<I2C1> for gpiob::PB8<AF4<OpenDrain>> {}
-unsafe impl SdaPin<I2C1> for gpioa::PA14<AF4<OpenDrain>> {}
-unsafe impl SdaPin<I2C1> for gpiob::PB7<AF4<OpenDrain>> {}
-unsafe impl SdaPin<I2C1> for gpiob::PB9<AF4<OpenDrain>> {}
+impl SclPin<I2C1> for gpioa::PA15<AF4<OpenDrain>> {}
+impl SclPin<I2C1> for gpiob::PB6<AF4<OpenDrain>> {}
+impl SclPin<I2C1> for gpiob::PB8<AF4<OpenDrain>> {}
+impl SdaPin<I2C1> for gpioa::PA14<AF4<OpenDrain>> {}
+impl SdaPin<I2C1> for gpiob::PB7<AF4<OpenDrain>> {}
+impl SdaPin<I2C1> for gpiob::PB9<AF4<OpenDrain>> {}
 
 cfg_if! {
     if #[cfg(not(feature = "gpio-f333"))] {
-        unsafe impl SclPin<I2C2> for gpioa::PA9<AF4<OpenDrain>> {}
-        unsafe impl SclPin<I2C2> for gpiof::PF1<AF4<OpenDrain>> {}
+        impl SclPin<I2C2> for gpioa::PA9<AF4<OpenDrain>> {}
+        impl SclPin<I2C2> for gpiof::PF1<AF4<OpenDrain>> {}
         #[cfg(any(feature = "gpio-f303", feature = "gpio-f303e", feature = "gpio-f373"))]
-        unsafe impl SclPin<I2C2> for gpiof::PF6<AF4<OpenDrain>> {}
-        unsafe impl SdaPin<I2C2> for gpioa::PA10<AF4<OpenDrain>> {}
-        unsafe impl SdaPin<I2C2> for gpiof::PF0<AF4<OpenDrain>> {}
+        impl SclPin<I2C2> for gpiof::PF6<AF4<OpenDrain>> {}
+        impl SdaPin<I2C2> for gpioa::PA10<AF4<OpenDrain>> {}
+        impl SdaPin<I2C2> for gpiof::PF0<AF4<OpenDrain>> {}
         #[cfg(feature = "gpio-f373")]
-        unsafe impl SdaPin<I2C2> for gpiof::PF7<AF4<OpenDrain>> {}
+        impl SdaPin<I2C2> for gpiof::PF7<AF4<OpenDrain>> {}
     }
 }
 
 cfg_if! {
     if #[cfg(any(feature = "gpio-f302", feature = "gpio-f303e"))] {
-        unsafe impl SclPin<I2C3> for gpioa::PA8<AF3<OpenDrain>> {}
-        unsafe impl SdaPin<I2C3> for gpiob::PB5<AF8<OpenDrain>> {}
-        unsafe impl SdaPin<I2C3> for gpioc::PC9<AF3<OpenDrain>> {}
+        impl SclPin<I2C3> for gpioa::PA8<AF3<OpenDrain>> {}
+        impl SdaPin<I2C3> for gpiob::PB5<AF8<OpenDrain>> {}
+        impl SdaPin<I2C3> for gpioc::PC9<AF3<OpenDrain>> {}
     }
 }
 
@@ -428,8 +427,8 @@ where
     }
 }
 
-/// I2C instance -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait Instance: Deref<Target = RegisterBlock> {
+/// I2C instance
+pub trait Instance: Deref<Target = RegisterBlock> + crate::private::Sealed {
     #[doc(hidden)]
     fn enable_clock(apb1: &mut APB1);
     #[doc(hidden)]
@@ -439,7 +438,8 @@ pub unsafe trait Instance: Deref<Target = RegisterBlock> {
 macro_rules! i2c {
     ($($I2CX:ident: ($i2cXen:ident, $i2cXrst:ident, $i2cXsw:ident),)+) => {
         $(
-            unsafe impl Instance for $I2CX {
+            impl crate::private::Sealed for $I2CX {}
+            impl Instance for $I2CX {
                 fn enable_clock(apb1: &mut APB1) {
                     apb1.enr().modify(|_, w| w.$i2cXen().enabled());
                     apb1.rstr().modify(|_, w| w.$i2cXrst().reset());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,8 +159,9 @@ pub use stm32f3::stm32f373 as pac;
 #[cfg(feature = "svd-f3x4")]
 pub use stm32f3::stm32f3x4 as pac;
 
-/// Enable use of interrupt macro. (Requires feature `rt`)
+/// Enable use of interrupt macro.
 #[cfg(feature = "rt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
 pub use crate::pac::interrupt;
 
 #[cfg(feature = "stm32f303")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@
  [filter]: https://defmt.ferrous-systems.com/filtering.html
 */
 #![no_std]
-#![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 #![warn(missing_docs)]
 #![deny(macro_use_extern_crate)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,35 @@
 
  [stm]: https://www.st.com/en/microcontrollers-microprocessors/stm32f3-series.html
 
+ ## Basic Usagee
+
+ ```rust
+ #![no_std]
+ #![no_main]
+
+ use cortex_m::asm;
+ use cortex_m_rt::entry;
+ use panic_halt as _;
+ use stm32f3xx_hal::{self as hal, pac, prelude::*};
+
+ #[entry]
+ fn main() -> ! {
+       let dp = pac::Peripherals::take().unwrap();
+
+       let mut rcc = dp.RCC.constrain();
+       let mut gpioe = dp.GPIOE.split(&mut rcc.ahb);
+
+       let mut led = gpioe
+             .pe13
+             .into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper);
+
+       loop {
+             led.toggle().unwrap();
+             asm::delay(8_000_000);
+       }
+ }
+ ```
+
  ## Cargo features
 
  ### Target chip selection

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -210,38 +210,38 @@ use crate::gpio::{gpioc, gpiof};
 /// Output Compare Channel 1 of Timer 1 (type state)
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TIM2_CH1 {}
+pub struct Tim2Ch1 {}
 /// Output Compare Channel 2 of Timer 1 (type state)
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TIM2_CH2 {}
+pub struct Tim2Ch2 {}
 /// Output Compare Channel 3 of Timer 1 (type state)
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TIM2_CH3 {}
+pub struct Tim2Ch3 {}
 /// Output Compare Channel 4 of Timer 1 (type state)
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TIM2_CH4 {}
+pub struct Tim2Ch4 {}
 
 /// Output Compare Channel 1 of Timer 15 (type state)
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TIM15_CH1 {}
+pub struct Tim15Ch1 {}
 /// Output Compare Channel 2 of Timer 15 (type state)
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TIM15_CH2 {}
+pub struct Tim15Ch2 {}
 
 /// Output Compare Channel 1 of Timer 16 (type state)
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TIM16_CH1 {}
+pub struct Tim16Ch1 {}
 
 /// Output Compare Channel 1 of Timer 17 (type state)
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TIM17_CH1 {}
+pub struct Tim17Ch1 {}
 
 /// Type state used to represent a channel that has no pins yet
 #[derive(Debug)]
@@ -602,13 +602,13 @@ macro_rules! tim1_common {
         use crate::pac::TIM1;
 
         /// Output Compare Channel 1 of Timer 1 (type state)
-        pub struct TIM1_CH1 {}
+        pub struct Tim1Ch1 {}
         /// Output Compare Channel 2 of Timer 1 (type state)
-        pub struct TIM1_CH2 {}
+        pub struct Tim1Ch2 {}
         /// Output Compare Channel 3 of Timer 1 (type state)
-        pub struct TIM1_CH3 {}
+        pub struct Tim1Ch3 {}
         /// Output Compare Channel 4 of Timer 1 (type state)
-        pub struct TIM1_CH4 {}
+        pub struct Tim1Ch4 {}
 
         pwm_timer_with_break!(
             tim1,
@@ -619,50 +619,50 @@ macro_rules! tim1_common {
             pclk2,
             tim1rst,
             tim1en,
-            [TIM1_CH1, TIM1_CH2, TIM1_CH3, TIM1_CH4],
+            [Tim1Ch1, Tim1Ch2, Tim1Ch3, Tim1Ch4],
             [PwmChannel, PwmChannel, PwmChannel, PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_n_channel!(TIM1, TIM1_CH1, u16, cc1e, cc1ne, ccr1, ccr);
-        pwm_pin_for_pwm_n_channel!(TIM1, TIM1_CH2, u16, cc2e, cc2ne, ccr2, ccr);
-        pwm_pin_for_pwm_n_channel!(TIM1, TIM1_CH3, u16, cc3e, cc3ne, ccr3, ccr);
-        pwm_pin_for_pwm_channel!(TIM1, TIM1_CH4, u16, cc4e, ccr4, ccr);
+        pwm_pin_for_pwm_n_channel!(TIM1, Tim1Ch1, u16, cc1e, cc1ne, ccr1, ccr);
+        pwm_pin_for_pwm_n_channel!(TIM1, Tim1Ch2, u16, cc2e, cc2ne, ccr2, ccr);
+        pwm_pin_for_pwm_n_channel!(TIM1, Tim1Ch3, u16, cc3e, cc3ne, ccr3, ccr);
+        pwm_pin_for_pwm_channel!(TIM1, Tim1Ch4, u16, cc4e, ccr4, ccr);
 
         //Pins
-        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pa8, gpioa::PA8<AF6>);
+        pwm_channel1_pin!(TIM1, Tim1Ch1, output_to_pa8, gpioa::PA8<AF6>);
 
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pa7, gpioa::PA7<AF6>);
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pa11, gpioa::PA11<AF6>);
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pb13, gpiob::PB13<AF6>);
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pc13, gpioc::PC13<AF4>);
+        pwm_channel1n_pin!(TIM1, Tim1Ch1, output_to_pa7, gpioa::PA7<AF6>);
+        pwm_channel1n_pin!(TIM1, Tim1Ch1, output_to_pa11, gpioa::PA11<AF6>);
+        pwm_channel1n_pin!(TIM1, Tim1Ch1, output_to_pb13, gpiob::PB13<AF6>);
+        pwm_channel1n_pin!(TIM1, Tim1Ch1, output_to_pc13, gpioc::PC13<AF4>);
 
-        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pa9, gpioa::PA9<AF6>);
+        pwm_channel2_pin!(TIM1, Tim1Ch2, output_to_pa9, gpioa::PA9<AF6>);
 
-        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pa12, gpioa::PA12<AF6>);
-        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pb0, gpiob::PB0<AF6>);
-        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pb14, gpiob::PB14<AF6>);
+        pwm_channel2n_pin!(TIM1, Tim1Ch2, output_to_pa12, gpioa::PA12<AF6>);
+        pwm_channel2n_pin!(TIM1, Tim1Ch2, output_to_pb0, gpiob::PB0<AF6>);
+        pwm_channel2n_pin!(TIM1, Tim1Ch2, output_to_pb14, gpiob::PB14<AF6>);
 
-        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pa10, gpioa::PA10<AF6>);
+        pwm_channel3_pin!(TIM1, Tim1Ch3, output_to_pa10, gpioa::PA10<AF6>);
 
-        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pb1, gpiob::PB1<AF6>);
-        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pb15, gpiob::PB15<AF4>);
-        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pf0, gpiof::PF0<AF6>);
+        pwm_channel3n_pin!(TIM1, Tim1Ch3, output_to_pb1, gpiob::PB1<AF6>);
+        pwm_channel3n_pin!(TIM1, Tim1Ch3, output_to_pb15, gpiob::PB15<AF4>);
+        pwm_channel3n_pin!(TIM1, Tim1Ch3, output_to_pf0, gpiof::PF0<AF6>);
 
-        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pa11, gpioa::PA11<AF11>);
+        pwm_channel4_pin!(TIM1, Tim1Ch4, output_to_pa11, gpioa::PA11<AF11>);
     };
 }
 
 #[cfg(any(feature = "stm32f334", feature = "stm32f398"))]
 macro_rules! tim1_ext1 {
     () => {
-        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pc0, gpioc::PC0<AF2>);
+        pwm_channel1_pin!(TIM1, Tim1Ch1, output_to_pc0, gpioc::PC0<AF2>);
 
-        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pc1, gpioc::PC1<AF2>);
+        pwm_channel2_pin!(TIM1, Tim1Ch2, output_to_pc1, gpioc::PC1<AF2>);
 
-        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pc2, gpioc::PC2<AF2>);
+        pwm_channel3_pin!(TIM1, Tim1Ch3, output_to_pc2, gpioc::PC2<AF2>);
 
-        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pc3, gpioc::PC3<AF2>);
+        pwm_channel4_pin!(TIM1, Tim1Ch4, output_to_pc3, gpioc::PC3<AF2>);
     };
 }
 
@@ -680,19 +680,19 @@ macro_rules! tim1_ext1 {
 ))]
 macro_rules! tim1_ext2 {
     () => {
-        pwm_channel1_pin!(TIM1, TIM1_CH1, output_to_pe9, gpioe::PE9<AF2>);
+        pwm_channel1_pin!(TIM1, Tim1Ch1, output_to_pe9, gpioe::PE9<AF2>);
 
-        pwm_channel1n_pin!(TIM1, TIM1_CH1, output_to_pe8, gpioe::PE8<AF2>);
+        pwm_channel1n_pin!(TIM1, Tim1Ch1, output_to_pe8, gpioe::PE8<AF2>);
 
-        pwm_channel2_pin!(TIM1, TIM1_CH2, output_to_pe11, gpioe::PE11<AF2>);
+        pwm_channel2_pin!(TIM1, Tim1Ch2, output_to_pe11, gpioe::PE11<AF2>);
 
-        pwm_channel2n_pin!(TIM1, TIM1_CH2, output_to_pe10, gpioe::PE10<AF2>);
+        pwm_channel2n_pin!(TIM1, Tim1Ch2, output_to_pe10, gpioe::PE10<AF2>);
 
-        pwm_channel3_pin!(TIM1, TIM1_CH3, output_to_pe13, gpioe::PE13<AF2>);
+        pwm_channel3_pin!(TIM1, Tim1Ch3, output_to_pe13, gpioe::PE13<AF2>);
 
-        pwm_channel3n_pin!(TIM1, TIM1_CH3, output_to_pe12, gpioe::PE12<AF2>);
+        pwm_channel3n_pin!(TIM1, Tim1Ch3, output_to_pe12, gpioe::PE12<AF2>);
 
-        pwm_channel4_pin!(TIM1, TIM1_CH4, output_to_pe14, gpioe::PE14<AF2>);
+        pwm_channel4_pin!(TIM1, Tim1Ch4, output_to_pe14, gpioe::PE14<AF2>);
     };
 }
 
@@ -735,20 +735,20 @@ pwm_timer_basic!(
     pclk1,
     tim2rst,
     tim2en,
-    [TIM2_CH1, TIM2_CH2, TIM2_CH3, TIM2_CH4],
+    [Tim2Ch1, Tim2Ch2, Tim2Ch3, Tim2Ch4],
     [PwmChannel, PwmChannel, PwmChannel, PwmChannel]
 );
 
 // Channels
-pwm_pin_for_pwm_channel!(TIM2, TIM2_CH1, u32, cc1e, ccr1, ccr);
-pwm_pin_for_pwm_channel!(TIM2, TIM2_CH2, u32, cc2e, ccr2, ccr);
-pwm_pin_for_pwm_channel!(TIM2, TIM2_CH3, u32, cc3e, ccr3, ccr);
-pwm_pin_for_pwm_channel!(TIM2, TIM2_CH4, u32, cc4e, ccr4, ccr);
+pwm_pin_for_pwm_channel!(TIM2, Tim2Ch1, u32, cc1e, ccr1, ccr);
+pwm_pin_for_pwm_channel!(TIM2, Tim2Ch2, u32, cc2e, ccr2, ccr);
+pwm_pin_for_pwm_channel!(TIM2, Tim2Ch3, u32, cc3e, ccr3, ccr);
+pwm_pin_for_pwm_channel!(TIM2, Tim2Ch4, u32, cc4e, ccr4, ccr);
 
 // Pins
-pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa0, gpioa::PA0<AF1>);
-pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa5, gpioa::PA5<AF1>);
-pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa15, gpioa::PA15<AF1>);
+pwm_channel1_pin!(TIM2, Tim2Ch1, output_to_pa0, gpioa::PA0<AF1>);
+pwm_channel1_pin!(TIM2, Tim2Ch1, output_to_pa5, gpioa::PA5<AF1>);
+pwm_channel1_pin!(TIM2, Tim2Ch1, output_to_pa15, gpioa::PA15<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -761,10 +761,10 @@ pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pa15, gpioa::PA15<AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(TIM2, TIM2_CH1, output_to_pd3, gpiod::PD3<AF2>);
+pwm_channel1_pin!(TIM2, Tim2Ch1, output_to_pd3, gpiod::PD3<AF2>);
 
-pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pa1, gpioa::PA1<AF1>);
-pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pb3, gpiob::PB3<AF1>);
+pwm_channel2_pin!(TIM2, Tim2Ch2, output_to_pa1, gpioa::PA1<AF1>);
+pwm_channel2_pin!(TIM2, Tim2Ch2, output_to_pb3, gpiob::PB3<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -777,11 +777,11 @@ pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pb3, gpiob::PB3<AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel2_pin!(TIM2, TIM2_CH2, output_to_pd4, gpiod::PD4<AF2>);
+pwm_channel2_pin!(TIM2, Tim2Ch2, output_to_pd4, gpiod::PD4<AF2>);
 
-pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pa2, gpioa::PA2<AF1>);
-pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pa9, gpioa::PA9<AF10>);
-pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pb10, gpiob::PB10<AF1>);
+pwm_channel3_pin!(TIM2, Tim2Ch3, output_to_pa2, gpioa::PA2<AF1>);
+pwm_channel3_pin!(TIM2, Tim2Ch3, output_to_pa9, gpioa::PA9<AF10>);
+pwm_channel3_pin!(TIM2, Tim2Ch3, output_to_pb10, gpiob::PB10<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -794,12 +794,12 @@ pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pb10, gpiob::PB10<AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel3_pin!(TIM2, TIM2_CH3, output_to_pd7, gpiod::PD7<AF2>);
+pwm_channel3_pin!(TIM2, Tim2Ch3, output_to_pd7, gpiod::PD7<AF2>);
 
-pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pa3, gpioa::PA3<AF1>);
-pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pa10, gpioa::PA10<AF1>);
+pwm_channel4_pin!(TIM2, Tim2Ch4, output_to_pa3, gpioa::PA3<AF1>);
+pwm_channel4_pin!(TIM2, Tim2Ch4, output_to_pa10, gpioa::PA10<AF1>);
 #[cfg(not(any(feature = "stm32f373", feature = "stm32f378")))]
-pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pb11, gpiob::PB11<AF1>);
+pwm_channel4_pin!(TIM2, Tim2Ch4, output_to_pb11, gpiob::PB11<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -812,7 +812,7 @@ pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pb11, gpiob::PB11<AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel4_pin!(TIM2, TIM2_CH4, output_to_pd6, gpiod::PD6<AF2>);
+pwm_channel4_pin!(TIM2, Tim2Ch4, output_to_pd6, gpiod::PD6<AF2>);
 
 // TIM3
 
@@ -831,13 +831,13 @@ macro_rules! tim3_common {
         use crate::pac::TIM3;
 
         /// Output Compare Channel 1 of Timer 3 (type state)
-        pub struct TIM3_CH1 {}
+        pub struct Tim3Ch1 {}
         /// Output Compare Channel 2 of Timer 3 (type state)
-        pub struct TIM3_CH2 {}
+        pub struct Tim3Ch2 {}
         /// Output Compare Channel 3 of Timer 3 (type state)
-        pub struct TIM3_CH3 {}
+        pub struct Tim3Ch3 {}
         /// Output Compare Channel 4 of Timer 3 (type state)
-        pub struct TIM3_CH4 {}
+        pub struct Tim3Ch4 {}
 
         pwm_timer_basic!(
             tim3,
@@ -848,28 +848,28 @@ macro_rules! tim3_common {
             pclk1,
             tim3rst,
             tim3en,
-            [TIM3_CH1, TIM3_CH2, TIM3_CH3, TIM3_CH4],
+            [Tim3Ch1, Tim3Ch2, Tim3Ch3, Tim3Ch4],
             [PwmChannel, PwmChannel, PwmChannel, PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_channel!(TIM3, TIM3_CH1, u16, cc1e, ccr1, ccr);
-        pwm_pin_for_pwm_channel!(TIM3, TIM3_CH2, u16, cc2e, ccr2, ccr);
-        pwm_pin_for_pwm_channel!(TIM3, TIM3_CH3, u16, cc3e, ccr3, ccr);
-        pwm_pin_for_pwm_channel!(TIM3, TIM3_CH4, u16, cc4e, ccr4, ccr);
+        pwm_pin_for_pwm_channel!(TIM3, Tim3Ch1, u16, cc1e, ccr1, ccr);
+        pwm_pin_for_pwm_channel!(TIM3, Tim3Ch2, u16, cc2e, ccr2, ccr);
+        pwm_pin_for_pwm_channel!(TIM3, Tim3Ch3, u16, cc3e, ccr3, ccr);
+        pwm_pin_for_pwm_channel!(TIM3, Tim3Ch4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pa6, gpioa::PA6<AF2>);
-        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pb4, gpiob::PB4<AF2>);
+        pwm_channel1_pin!(TIM3, Tim3Ch1, output_to_pa6, gpioa::PA6<AF2>);
+        pwm_channel1_pin!(TIM3, Tim3Ch1, output_to_pb4, gpiob::PB4<AF2>);
 
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pa4, gpioa::PA4<AF2>);
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pa7, gpioa::PA7<AF2>);
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pb5, gpiob::PB5<AF2>);
+        pwm_channel2_pin!(TIM3, Tim3Ch2, output_to_pa4, gpioa::PA4<AF2>);
+        pwm_channel2_pin!(TIM3, Tim3Ch2, output_to_pa7, gpioa::PA7<AF2>);
+        pwm_channel2_pin!(TIM3, Tim3Ch2, output_to_pb5, gpiob::PB5<AF2>);
 
-        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pb0, gpiob::PB0<AF2>);
+        pwm_channel3_pin!(TIM3, Tim3Ch3, output_to_pb0, gpiob::PB0<AF2>);
 
-        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pb1, gpiob::PB1<AF2>);
-        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pb7, gpiob::PB7<AF10>);
+        pwm_channel4_pin!(TIM3, Tim3Ch4, output_to_pb1, gpiob::PB1<AF2>);
+        pwm_channel4_pin!(TIM3, Tim3Ch4, output_to_pb7, gpiob::PB7<AF10>);
     };
 }
 
@@ -884,13 +884,13 @@ macro_rules! tim3_common {
 ))]
 macro_rules! tim3_ext1 {
     () => {
-        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pc6, gpioc::PC6<AF2>);
+        pwm_channel1_pin!(TIM3, Tim3Ch1, output_to_pc6, gpioc::PC6<AF2>);
 
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pc7, gpioc::PC7<AF2>);
+        pwm_channel2_pin!(TIM3, Tim3Ch2, output_to_pc7, gpioc::PC7<AF2>);
 
-        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pc8, gpioc::PC8<AF2>);
+        pwm_channel3_pin!(TIM3, Tim3Ch3, output_to_pc8, gpioc::PC8<AF2>);
 
-        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pc9, gpioc::PC9<AF2>);
+        pwm_channel4_pin!(TIM3, Tim3Ch4, output_to_pc9, gpioc::PC9<AF2>);
     };
 }
 
@@ -908,13 +908,13 @@ macro_rules! tim3_ext1 {
 ))]
 macro_rules! tim3_ext2 {
     () => {
-        pwm_channel1_pin!(TIM3, TIM3_CH1, output_to_pe2, gpioe::PE6<AF2>);
+        pwm_channel1_pin!(TIM3, Tim3Ch1, output_to_pe2, gpioe::PE6<AF2>);
 
-        pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pe3, gpioe::PE7<AF2>);
+        pwm_channel2_pin!(TIM3, Tim3Ch2, output_to_pe3, gpioe::PE7<AF2>);
 
-        pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pe4, gpioe::PE8<AF2>);
+        pwm_channel3_pin!(TIM3, Tim3Ch3, output_to_pe4, gpioe::PE8<AF2>);
 
-        pwm_channel4_pin!(TIM3, TIM3_CH4, output_to_pe5, gpioe::PE9<AF2>);
+        pwm_channel4_pin!(TIM3, Tim3Ch4, output_to_pe5, gpioe::PE9<AF2>);
     };
 }
 
@@ -956,10 +956,10 @@ tim3_ext1!();
 tim3_ext2!();
 
 #[cfg(feature = "stm32f373")]
-pwm_channel2_pin!(TIM3, TIM3_CH2, output_to_pb0, gpiob::PB0<AF10>);
+pwm_channel2_pin!(TIM3, Tim3Ch2, output_to_pb0, gpiob::PB0<AF10>);
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel3_pin!(TIM3, TIM3_CH3, output_to_pb6, gpiob::PB6<AF10>);
+pwm_channel3_pin!(TIM3, Tim3Ch3, output_to_pb6, gpiob::PB6<AF10>);
 
 // TIM4
 
@@ -976,13 +976,13 @@ macro_rules! tim4_common {
         use crate::pac::TIM4;
 
         /// Output Compare Channel 1 of Timer 4 (type state)
-        pub struct TIM4_CH1 {}
+        pub struct Tim4Ch1 {}
         /// Output Compare Channel 2 of Timer 4 (type state)
-        pub struct TIM4_CH2 {}
+        pub struct Tim4Ch2 {}
         /// Output Compare Channel 3 of Timer 4 (type state)
-        pub struct TIM4_CH3 {}
+        pub struct Tim4Ch3 {}
         /// Output Compare Channel 4 of Timer 4 (type state)
-        pub struct TIM4_CH4 {}
+        pub struct Tim4Ch4 {}
 
         pwm_timer_basic!(
             tim4,
@@ -993,27 +993,27 @@ macro_rules! tim4_common {
             pclk1,
             tim4rst,
             tim4en,
-            [TIM4_CH1, TIM4_CH2, TIM4_CH3, TIM4_CH4],
+            [Tim4Ch1, Tim4Ch2, Tim4Ch3, Tim4Ch4],
             [PwmChannel, PwmChannel, PwmChannel, PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_channel!(TIM4, TIM4_CH1, u16, cc1e, ccr1, ccr);
-        pwm_pin_for_pwm_channel!(TIM4, TIM4_CH2, u16, cc2e, ccr2, ccr);
-        pwm_pin_for_pwm_channel!(TIM4, TIM4_CH3, u16, cc3e, ccr3, ccr);
-        pwm_pin_for_pwm_channel!(TIM4, TIM4_CH4, u16, cc4e, ccr4, ccr);
+        pwm_pin_for_pwm_channel!(TIM4, Tim4Ch1, u16, cc1e, ccr1, ccr);
+        pwm_pin_for_pwm_channel!(TIM4, Tim4Ch2, u16, cc2e, ccr2, ccr);
+        pwm_pin_for_pwm_channel!(TIM4, Tim4Ch3, u16, cc3e, ccr3, ccr);
+        pwm_pin_for_pwm_channel!(TIM4, Tim4Ch4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pa11, gpioa::PA11<AF10>);
-        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pb6, gpiob::PB6<AF2>);
+        pwm_channel1_pin!(TIM4, Tim4Ch1, output_to_pa11, gpioa::PA11<AF10>);
+        pwm_channel1_pin!(TIM4, Tim4Ch1, output_to_pb6, gpiob::PB6<AF2>);
 
-        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pa12, gpioa::PA12<AF10>);
-        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pb7, gpiob::PB7<AF2>);
+        pwm_channel2_pin!(TIM4, Tim4Ch2, output_to_pa12, gpioa::PA12<AF10>);
+        pwm_channel2_pin!(TIM4, Tim4Ch2, output_to_pb7, gpiob::PB7<AF2>);
 
-        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pa13, gpioa::PA13<AF10>);
-        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pb8, gpiob::PB8<AF2>);
+        pwm_channel3_pin!(TIM4, Tim4Ch3, output_to_pa13, gpioa::PA13<AF10>);
+        pwm_channel3_pin!(TIM4, Tim4Ch3, output_to_pb8, gpiob::PB8<AF2>);
 
-        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pb9, gpiob::PB9<AF2>);
+        pwm_channel4_pin!(TIM4, Tim4Ch4, output_to_pb9, gpiob::PB9<AF2>);
     };
 }
 
@@ -1033,14 +1033,14 @@ macro_rules! tim4_common {
 ))]
 macro_rules! tim4_ext {
     () => {
-        pwm_channel1_pin!(TIM4, TIM4_CH1, output_to_pd12, gpiod::PD12<AF2>);
+        pwm_channel1_pin!(TIM4, Tim4Ch1, output_to_pd12, gpiod::PD12<AF2>);
 
-        pwm_channel2_pin!(TIM4, TIM4_CH2, output_to_pd13, gpiod::PD13<AF2>);
+        pwm_channel2_pin!(TIM4, Tim4Ch2, output_to_pd13, gpiod::PD13<AF2>);
 
-        pwm_channel3_pin!(TIM4, TIM4_CH3, output_to_pd14, gpiod::PD14<AF2>);
+        pwm_channel3_pin!(TIM4, Tim4Ch3, output_to_pd14, gpiod::PD14<AF2>);
 
-        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pd15, gpiod::PD15<AF2>);
-        pwm_channel4_pin!(TIM4, TIM4_CH4, output_to_pf6, gpiof::PF6<AF2>);
+        pwm_channel4_pin!(TIM4, Tim4Ch4, output_to_pd15, gpiod::PD15<AF2>);
+        pwm_channel4_pin!(TIM4, Tim4Ch4, output_to_pf6, gpiof::PF6<AF2>);
     };
 }
 
@@ -1078,13 +1078,13 @@ macro_rules! tim5 {
         use crate::pac::TIM5;
 
         /// Output Compare Channel 1 of Timer 5 (type state)
-        pub struct TIM5_CH1 {}
+        pub struct Tim5Ch1 {}
         /// Output Compare Channel 2 of Timer 5 (type state)
-        pub struct TIM5_CH2 {}
+        pub struct Tim5Ch2 {}
         /// Output Compare Channel 3 of Timer 5 (type state)
-        pub struct TIM5_CH3 {}
+        pub struct Tim5Ch3 {}
         /// Output Compare Channel 4 of Timer 5 (type state)
-        pub struct TIM5_CH4 {}
+        pub struct Tim5Ch4 {}
 
         pwm_timer_basic!(
             tim5,
@@ -1095,32 +1095,32 @@ macro_rules! tim5 {
             pclk1,
             tim5rst,
             tim5en,
-            [TIM5_CH1, TIM5_CH2, TIM5_CH3, TIM5_CH4],
+            [Tim5Ch1, Tim5Ch2, Tim5Ch3, Tim5Ch4],
             [PwmChannel, PwmChannel, PwmChannel, PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_channel!(TIM5, TIM5_CH1, u32, cc1e, ccr1, ccr);
-        pwm_pin_for_pwm_channel!(TIM5, TIM5_CH2, u32, cc2e, ccr2, ccr);
-        pwm_pin_for_pwm_channel!(TIM5, TIM5_CH3, u32, cc3e, ccr3, ccr);
-        pwm_pin_for_pwm_channel!(TIM5, TIM5_CH4, u32, cc4e, ccr4, ccr);
+        pwm_pin_for_pwm_channel!(TIM5, Tim5Ch1, u32, cc1e, ccr1, ccr);
+        pwm_pin_for_pwm_channel!(TIM5, Tim5Ch2, u32, cc2e, ccr2, ccr);
+        pwm_pin_for_pwm_channel!(TIM5, Tim5Ch3, u32, cc3e, ccr3, ccr);
+        pwm_pin_for_pwm_channel!(TIM5, Tim5Ch4, u32, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pa0, gpioa::PA0<AF2>);
-        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pa8, gpioa::PA8<AF2>);
-        pwm_channel1_pin!(TIM5, TIM5_CH1, output_to_pc0, gpioc::PC0<AF2>);
+        pwm_channel1_pin!(TIM5, Tim5Ch1, output_to_pa0, gpioa::PA0<AF2>);
+        pwm_channel1_pin!(TIM5, Tim5Ch1, output_to_pa8, gpioa::PA8<AF2>);
+        pwm_channel1_pin!(TIM5, Tim5Ch1, output_to_pc0, gpioc::PC0<AF2>);
 
-        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pa1, gpioa::PA1<AF2>);
-        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pa11, gpioa::PA11<AF2>);
-        pwm_channel2_pin!(TIM5, TIM5_CH2, output_to_pc1, gpioc::PC1<AF2>);
+        pwm_channel2_pin!(TIM5, Tim5Ch2, output_to_pa1, gpioa::PA1<AF2>);
+        pwm_channel2_pin!(TIM5, Tim5Ch2, output_to_pa11, gpioa::PA11<AF2>);
+        pwm_channel2_pin!(TIM5, Tim5Ch2, output_to_pc1, gpioc::PC1<AF2>);
 
-        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pa2, gpioa::PA2<AF2>);
-        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pa12, gpioa::PA12<AF2>);
-        pwm_channel3_pin!(TIM5, TIM5_CH3, output_to_pc2, gpioc::PC2<AF2>);
+        pwm_channel3_pin!(TIM5, Tim5Ch3, output_to_pa2, gpioa::PA2<AF2>);
+        pwm_channel3_pin!(TIM5, Tim5Ch3, output_to_pa12, gpioa::PA12<AF2>);
+        pwm_channel3_pin!(TIM5, Tim5Ch3, output_to_pc2, gpioc::PC2<AF2>);
 
-        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pa3, gpioa::PA3<AF2>);
-        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pa13, gpioa::PA13<AF2>);
-        pwm_channel4_pin!(TIM5, TIM5_CH4, output_to_pc3, gpioc::PC3<AF2>);
+        pwm_channel4_pin!(TIM5, Tim5Ch4, output_to_pa3, gpioa::PA3<AF2>);
+        pwm_channel4_pin!(TIM5, Tim5Ch4, output_to_pa13, gpioa::PA13<AF2>);
+        pwm_channel4_pin!(TIM5, Tim5Ch4, output_to_pc3, gpioc::PC3<AF2>);
     };
 }
 
@@ -1136,13 +1136,13 @@ macro_rules! tim8 {
         use crate::pac::TIM8;
 
         /// Output Compare Channel 1 of Timer 8 (type state)
-        pub struct TIM8_CH1 {}
+        pub struct Tim8Ch1 {}
         /// Output Compare Channel 2 of Timer 8 (type state)
-        pub struct TIM8_CH2 {}
+        pub struct Tim8Ch2 {}
         /// Output Compare Channel 3 of Timer 8 (type state)
-        pub struct TIM8_CH3 {}
+        pub struct Tim8Ch3 {}
         /// Output Compare Channel 4 of Timer 8 (type state)
-        pub struct TIM8_CH4 {}
+        pub struct Tim8Ch4 {}
 
         pwm_timer_with_break!(
             tim8,
@@ -1153,41 +1153,41 @@ macro_rules! tim8 {
             pclk2,
             tim8rst,
             tim8en,
-            [TIM8_CH1, TIM8_CH2, TIM8_CH3, TIM8_CH4],
+            [Tim8Ch1, Tim8Ch2, Tim8Ch3, Tim8Ch4],
             [PwmChannel, PwmChannel, PwmChannel, PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_n_channel!(TIM8, TIM8_CH1, u16, cc1e, cc1ne, ccr1, ccr);
-        pwm_pin_for_pwm_n_channel!(TIM8, TIM8_CH2, u16, cc2e, cc2ne, ccr2, ccr);
-        pwm_pin_for_pwm_n_channel!(TIM8, TIM8_CH3, u16, cc3e, cc3ne, ccr3, ccr);
-        pwm_pin_for_pwm_channel!(TIM8, TIM8_CH4, u16, cc4e, ccr4, ccr);
+        pwm_pin_for_pwm_n_channel!(TIM8, Tim8Ch1, u16, cc1e, cc1ne, ccr1, ccr);
+        pwm_pin_for_pwm_n_channel!(TIM8, Tim8Ch2, u16, cc2e, cc2ne, ccr2, ccr);
+        pwm_pin_for_pwm_n_channel!(TIM8, Tim8Ch3, u16, cc3e, cc3ne, ccr3, ccr);
+        pwm_pin_for_pwm_channel!(TIM8, Tim8Ch4, u16, cc4e, ccr4, ccr);
 
         //Pins
-        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pa15, gpioa::PA15<AF2>);
-        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pb6, gpiob::PB6<AF2>);
-        pwm_channel1_pin!(TIM8, TIM8_CH1, output_to_pc6, gpioc::PC6<AF4>);
+        pwm_channel1_pin!(TIM8, Tim8Ch1, output_to_pa15, gpioa::PA15<AF2>);
+        pwm_channel1_pin!(TIM8, Tim8Ch1, output_to_pb6, gpiob::PB6<AF2>);
+        pwm_channel1_pin!(TIM8, Tim8Ch1, output_to_pc6, gpioc::PC6<AF4>);
 
-        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pa7, gpioa::PA7<AF4>);
-        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pb3, gpiob::PB3<AF4>);
-        pwm_channel1n_pin!(TIM8, TIM8_CH1, output_to_pc10, gpioc::PC10<AF4>);
+        pwm_channel1n_pin!(TIM8, Tim8Ch1, output_to_pa7, gpioa::PA7<AF4>);
+        pwm_channel1n_pin!(TIM8, Tim8Ch1, output_to_pb3, gpiob::PB3<AF4>);
+        pwm_channel1n_pin!(TIM8, Tim8Ch1, output_to_pc10, gpioc::PC10<AF4>);
 
-        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pa14, gpioa::PA14<AF5>);
-        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pb8, gpiob::PB8<AF10>);
-        pwm_channel2_pin!(TIM8, TIM8_CH2, output_to_pc7, gpioc::PC7<AF4>);
+        pwm_channel2_pin!(TIM8, Tim8Ch2, output_to_pa14, gpioa::PA14<AF5>);
+        pwm_channel2_pin!(TIM8, Tim8Ch2, output_to_pb8, gpiob::PB8<AF10>);
+        pwm_channel2_pin!(TIM8, Tim8Ch2, output_to_pc7, gpioc::PC7<AF4>);
 
-        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pb0, gpiob::PB0<AF4>);
-        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pb4, gpiob::PB4<AF4>);
-        pwm_channel2n_pin!(TIM8, TIM8_CH2, output_to_pc11, gpioc::PC11<AF4>);
+        pwm_channel2n_pin!(TIM8, Tim8Ch2, output_to_pb0, gpiob::PB0<AF4>);
+        pwm_channel2n_pin!(TIM8, Tim8Ch2, output_to_pb4, gpiob::PB4<AF4>);
+        pwm_channel2n_pin!(TIM8, Tim8Ch2, output_to_pc11, gpioc::PC11<AF4>);
 
-        pwm_channel3_pin!(TIM8, TIM8_CH3, output_to_pb9, gpiob::PB9<AF10>);
-        pwm_channel3_pin!(TIM8, TIM8_CH3, output_to_pc8, gpioc::PC8<AF4>);
+        pwm_channel3_pin!(TIM8, Tim8Ch3, output_to_pb9, gpiob::PB9<AF10>);
+        pwm_channel3_pin!(TIM8, Tim8Ch3, output_to_pc8, gpioc::PC8<AF4>);
 
-        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pb1, gpiob::PB1<AF4>);
-        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pb5, gpiob::PB5<AF3>);
-        pwm_channel3n_pin!(TIM8, TIM8_CH3, output_to_pc12, gpioc::PC12<AF4>);
+        pwm_channel3n_pin!(TIM8, Tim8Ch3, output_to_pb1, gpiob::PB1<AF4>);
+        pwm_channel3n_pin!(TIM8, Tim8Ch3, output_to_pb5, gpiob::PB5<AF3>);
+        pwm_channel3n_pin!(TIM8, Tim8Ch3, output_to_pc12, gpioc::PC12<AF4>);
 
-        pwm_channel4_pin!(TIM8, TIM8_CH4, output_to_pc9, gpioc::PC9<AF4>);
+        pwm_channel4_pin!(TIM8, Tim8Ch4, output_to_pc9, gpioc::PC9<AF4>);
     };
 }
 
@@ -1202,7 +1202,7 @@ tim8!();
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel4_pin!(TIM8, TIM8_CH4, output_to_pd1, gpiod::PD1<AF4>);
+pwm_channel4_pin!(TIM8, Tim8Ch4, output_to_pd1, gpiod::PD1<AF4>);
 
 // TIM12
 
@@ -1212,13 +1212,13 @@ macro_rules! tim12 {
         use crate::pac::TIM12;
 
         /// Output Compare Channel 1 of Timer 12 (type state)
-        pub struct TIM12_CH1 {}
+        pub struct Tim12Ch1 {}
         /// Output Compare Channel 2 of Timer 12 (type state)
-        pub struct TIM12_CH2 {}
+        pub struct Tim12Ch2 {}
         /// Output Compare Channel 3 of Timer 12 (type state)
-        pub struct TIM12_CH3 {}
+        pub struct Tim12Ch3 {}
         /// Output Compare Channel 4 of Timer 12 (type state)
-        pub struct TIM12_CH4 {}
+        pub struct Tim12Ch4 {}
 
         pwm_timer_basic!(
             tim12,
@@ -1229,22 +1229,22 @@ macro_rules! tim12 {
             pclk1,
             tim12rst,
             tim12en,
-            [TIM12_CH1, TIM12_CH2],
+            [Tim12Ch1, Tim12Ch2],
             [PwmChannel, PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_channel!(TIM12, TIM12_CH1, u16, cc1e, ccr1, ccr);
-        pwm_pin_for_pwm_channel!(TIM12, TIM12_CH2, u16, cc2e, ccr2, ccr);
+        pwm_pin_for_pwm_channel!(TIM12, Tim12Ch1, u16, cc1e, ccr1, ccr);
+        pwm_pin_for_pwm_channel!(TIM12, Tim12Ch2, u16, cc2e, ccr2, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pa4, gpioa::PA4<AF10>);
-        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pa14, gpioa::PA14<AF10>);
-        pwm_channel1_pin!(TIM12, TIM12_CH1, output_to_pb14, gpiob::PB14<AF10>);
+        pwm_channel1_pin!(TIM12, Tim12Ch1, output_to_pa4, gpioa::PA4<AF10>);
+        pwm_channel1_pin!(TIM12, Tim12Ch1, output_to_pa14, gpioa::PA14<AF10>);
+        pwm_channel1_pin!(TIM12, Tim12Ch1, output_to_pb14, gpiob::PB14<AF10>);
 
-        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pa5, gpioa::PA5<AF10>);
-        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pa15, gpioa::PA15<AF10>);
-        pwm_channel2_pin!(TIM12, TIM12_CH2, output_to_pb15, gpiob::PB15<AF10>);
+        pwm_channel2_pin!(TIM12, Tim12Ch2, output_to_pa5, gpioa::PA5<AF10>);
+        pwm_channel2_pin!(TIM12, Tim12Ch2, output_to_pa15, gpioa::PA15<AF10>);
+        pwm_channel2_pin!(TIM12, Tim12Ch2, output_to_pb15, gpiob::PB15<AF10>);
     };
 }
 
@@ -1260,13 +1260,13 @@ macro_rules! tim13 {
         use crate::pac::TIM13;
 
         /// Output Compare Channel 1 of Timer 13 (type state)
-        pub struct TIM13_CH1 {}
+        pub struct Tim13Ch1 {}
         /// Output Compare Channel 2 of Timer 13 (type state)
-        pub struct TIM13_CH2 {}
+        pub struct Tim13Ch2 {}
         /// Output Compare Channel 3 of Timer 13 (type state)
-        pub struct TIM13_CH3 {}
+        pub struct Tim13Ch3 {}
         /// Output Compare Channel 4 of Timer 13 (type state)
-        pub struct TIM13_CH4 {}
+        pub struct Tim13Ch4 {}
 
         pwm_timer_basic!(
             tim13,
@@ -1277,18 +1277,18 @@ macro_rules! tim13 {
             pclk1,
             tim13rst,
             tim13en,
-            [TIM13_CH1],
+            [Tim13Ch1],
             [PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_channel!(TIM13, TIM13_CH1, u16, cc1e, ccr1, ccr);
+        pwm_pin_for_pwm_channel!(TIM13, Tim13Ch1, u16, cc1e, ccr1, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pa6, gpioa::PA6<AF9>);
-        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pa9, gpioa::PA9<AF2>);
-        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pb3, gpiob::PB3<AF9>);
-        pwm_channel1_pin!(TIM13, TIM13_CH1, output_to_pc4, gpioc::PC4<AF2>);
+        pwm_channel1_pin!(TIM13, Tim13Ch1, output_to_pa6, gpioa::PA6<AF9>);
+        pwm_channel1_pin!(TIM13, Tim13Ch1, output_to_pa9, gpioa::PA9<AF2>);
+        pwm_channel1_pin!(TIM13, Tim13Ch1, output_to_pb3, gpiob::PB3<AF9>);
+        pwm_channel1_pin!(TIM13, Tim13Ch1, output_to_pc4, gpioc::PC4<AF2>);
     };
 }
 
@@ -1303,13 +1303,13 @@ macro_rules! tim14 {
         use crate::pac::TIM14;
 
         /// Output Compare Channel 1 of Timer 14 (type state)
-        pub struct TIM14_CH1 {}
+        pub struct Tim14Ch1 {}
         /// Output Compare Channel 2 of Timer 14 (type state)
-        pub struct TIM14_CH2 {}
+        pub struct Tim14Ch2 {}
         /// Output Compare Channel 3 of Timer 14 (type state)
-        pub struct TIM14_CH3 {}
+        pub struct Tim14Ch3 {}
         /// Output Compare Channel 4 of Timer 14 (type state)
-        pub struct TIM14_CH4 {}
+        pub struct Tim14Ch4 {}
 
         pwm_timer_basic!(
             tim14,
@@ -1320,18 +1320,18 @@ macro_rules! tim14 {
             pclk1,
             tim14rst,
             tim14en,
-            [TIM14_CH1],
+            [Tim14Ch1],
             [PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_channel!(TIM14, TIM14_CH1, u16, cc1e, ccr1, ccr);
+        pwm_pin_for_pwm_channel!(TIM14, Tim14Ch1, u16, cc1e, ccr1, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa5, gpioa::PA5<AF9>);
-        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa7, gpioa::PA7<AF9>);
-        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pa10, gpioa::PA10<AF9>);
-        pwm_channel1_pin!(TIM14, TIM14_CH1, output_to_pf9, gpiof::PF9<AF2>);
+        pwm_channel1_pin!(TIM14, Tim14Ch1, output_to_pa5, gpioa::PA5<AF9>);
+        pwm_channel1_pin!(TIM14, Tim14Ch1, output_to_pa7, gpioa::PA7<AF9>);
+        pwm_channel1_pin!(TIM14, Tim14Ch1, output_to_pa10, gpioa::PA10<AF9>);
+        pwm_channel1_pin!(TIM14, Tim14Ch1, output_to_pf9, gpiof::PF9<AF2>);
     };
 }
 
@@ -1350,19 +1350,19 @@ pwm_timer_with_break!(
     pclk2,
     tim15rst,
     tim15en,
-    [TIM15_CH1, TIM15_CH2],
+    [Tim15Ch1, Tim15Ch2],
     [PwmChannel, PwmChannel]
 );
 
 // Channels
-pwm_pin_for_pwm_n_channel!(TIM15, TIM15_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
-pwm_pin_for_pwm_channel!(TIM15, TIM15_CH2, u16, cc2e, ccr2, ccr2);
+pwm_pin_for_pwm_n_channel!(TIM15, Tim15Ch1, u16, cc1e, cc1ne, ccr1, ccr1);
+pwm_pin_for_pwm_channel!(TIM15, Tim15Ch2, u16, cc2e, ccr2, ccr2);
 
 // Pins
-pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pa2, gpioa::PA2<AF9>);
+pwm_channel1_pin!(TIM15, Tim15Ch1, output_to_pa2, gpioa::PA2<AF9>);
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pb6, gpiob::PB6<AF9>);
-pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pb14, gpiob::PB14<AF1>);
+pwm_channel1_pin!(TIM15, Tim15Ch1, output_to_pb6, gpiob::PB6<AF9>);
+pwm_channel1_pin!(TIM15, Tim15Ch1, output_to_pb14, gpiob::PB14<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1375,14 +1375,14 @@ pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pb14, gpiob::PB14<AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(TIM15, TIM15_CH1, output_to_pf9, gpiof::PF9<AF3>);
+pwm_channel1_pin!(TIM15, Tim15Ch1, output_to_pf9, gpiof::PF9<AF3>);
 
-pwm_channel1n_pin!(TIM15, TIM15_CH1, output_to_pa1, gpioa::PA1<AF9>);
-pwm_channel1n_pin!(TIM15, TIM15_CH1, output_to_pb15, gpiob::PB15<AF2>);
-pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pa3, gpioa::PA3<AF9>);
+pwm_channel1n_pin!(TIM15, Tim15Ch1, output_to_pa1, gpioa::PA1<AF9>);
+pwm_channel1n_pin!(TIM15, Tim15Ch1, output_to_pb15, gpiob::PB15<AF2>);
+pwm_channel2_pin!(TIM15, Tim15Ch2, output_to_pa3, gpioa::PA3<AF9>);
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pb7, gpiob::PB7<AF9>);
-pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pb15, gpiob::PB15<AF2>);
+pwm_channel2_pin!(TIM15, Tim15Ch2, output_to_pb7, gpiob::PB7<AF9>);
+pwm_channel2_pin!(TIM15, Tim15Ch2, output_to_pb15, gpiob::PB15<AF2>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1395,7 +1395,7 @@ pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pb15, gpiob::PB15<AF2>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel2_pin!(TIM15, TIM15_CH2, output_to_pf10, gpiof::PF10<AF3>);
+pwm_channel2_pin!(TIM15, Tim15Ch2, output_to_pf10, gpiof::PF10<AF3>);
 
 // TIM16
 
@@ -1408,18 +1408,18 @@ pwm_timer_with_break!(
     pclk2,
     tim16rst,
     tim16en,
-    [TIM16_CH1],
+    [Tim16Ch1],
     [PwmChannel]
 );
 
 // Channels
-pwm_pin_for_pwm_n_channel!(TIM16, TIM16_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
+pwm_pin_for_pwm_n_channel!(TIM16, Tim16Ch1, u16, cc1e, cc1ne, ccr1, ccr1);
 
 // Pins
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pa9, gpioa::PA6<AF1>);
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pa12, gpioa::PA12<AF1>);
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pb4, gpiob::PB4<AF1>);
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pb8, gpiob::PB8<AF1>);
+pwm_channel1_pin!(TIM16, Tim16Ch1, output_to_pa9, gpioa::PA6<AF1>);
+pwm_channel1_pin!(TIM16, Tim16Ch1, output_to_pa12, gpioa::PA12<AF1>);
+pwm_channel1_pin!(TIM16, Tim16Ch1, output_to_pb4, gpiob::PB4<AF1>);
+pwm_channel1_pin!(TIM16, Tim16Ch1, output_to_pb8, gpiob::PB8<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1432,10 +1432,10 @@ pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pb8, gpiob::PB8<AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(TIM16, TIM16_CH1, output_to_pe0, gpioe::PE0<AF4>);
+pwm_channel1_pin!(TIM16, Tim16Ch1, output_to_pe0, gpioe::PE0<AF4>);
 
-pwm_channel1n_pin!(TIM16, TIM16_CH1, output_to_pa13, gpioa::PA13<AF1>);
-pwm_channel1n_pin!(TIM16, TIM16_CH1, output_to_pb6, gpiob::PB6<AF1>);
+pwm_channel1n_pin!(TIM16, Tim16Ch1, output_to_pa13, gpioa::PA13<AF1>);
+pwm_channel1n_pin!(TIM16, Tim16Ch1, output_to_pb6, gpiob::PB6<AF1>);
 
 // TIM17
 
@@ -1448,17 +1448,17 @@ pwm_timer_with_break!(
     pclk2,
     tim17rst,
     tim17en,
-    [TIM17_CH1],
+    [Tim17Ch1],
     [PwmChannel]
 );
 
 // Channels
-pwm_pin_for_pwm_n_channel!(TIM17, TIM17_CH1, u16, cc1e, cc1ne, ccr1, ccr1);
+pwm_pin_for_pwm_n_channel!(TIM17, Tim17Ch1, u16, cc1e, cc1ne, ccr1, ccr1);
 
 // Pins
-pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pa7, gpioa::PA7<AF1>);
-pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pb5, gpiob::PB5<AF10>);
-pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pb9, gpiob::PB9<AF1>);
+pwm_channel1_pin!(TIM17, Tim17Ch1, output_to_pa7, gpioa::PA7<AF1>);
+pwm_channel1_pin!(TIM17, Tim17Ch1, output_to_pb5, gpiob::PB5<AF10>);
+pwm_channel1_pin!(TIM17, Tim17Ch1, output_to_pb9, gpiob::PB9<AF1>);
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -1471,9 +1471,9 @@ pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pb9, gpiob::PB9<AF1>);
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-pwm_channel1_pin!(TIM17, TIM17_CH1, output_to_pe1, gpioe::PE1<AF4>);
+pwm_channel1_pin!(TIM17, Tim17Ch1, output_to_pe1, gpioe::PE1<AF4>);
 
-pwm_channel1n_pin!(TIM17, TIM17_CH1, output_to_pa13, gpioa::PA13<AF1>);
+pwm_channel1n_pin!(TIM17, Tim17Ch1, output_to_pa13, gpioa::PA13<AF1>);
 
 // TIM19
 
@@ -1483,13 +1483,13 @@ macro_rules! tim19 {
         use crate::pac::TIM19;
 
         /// Output Compare Channel 1 of Timer 19 (type state)
-        pub struct TIM19_CH1 {}
+        pub struct Tim19Ch1 {}
         /// Output Compare Channel 2 of Timer 19 (type state)
-        pub struct TIM19_CH2 {}
+        pub struct Tim19Ch2 {}
         /// Output Compare Channel 3 of Timer 19 (type state)
-        pub struct TIM19_CH3 {}
+        pub struct Tim19Ch3 {}
         /// Output Compare Channel 4 of Timer 19 (type state)
-        pub struct TIM19_CH4 {}
+        pub struct Tim19Ch4 {}
 
         pwm_timer_basic!(
             tim19,
@@ -1500,32 +1500,32 @@ macro_rules! tim19 {
             pclk2,
             tim19rst,
             tim19en,
-            [TIM19_CH1, TIM19_CH2, TIM19_CH3, TIM19_CH4],
+            [Tim19Ch1, Tim19Ch2, Tim19Ch3, Tim19Ch4],
             [PwmChannel, PwmChannel, PwmChannel, PwmChannel]
         );
 
         // Channels
-        pwm_pin_for_pwm_channel!(TIM19, TIM19_CH1, u16, cc1e, ccr1, ccr);
-        pwm_pin_for_pwm_channel!(TIM19, TIM19_CH2, u16, cc2e, ccr2, ccr);
-        pwm_pin_for_pwm_channel!(TIM19, TIM19_CH3, u16, cc3e, ccr3, ccr);
-        pwm_pin_for_pwm_channel!(TIM19, TIM19_CH4, u16, cc4e, ccr4, ccr);
+        pwm_pin_for_pwm_channel!(TIM19, Tim19Ch1, u16, cc1e, ccr1, ccr);
+        pwm_pin_for_pwm_channel!(TIM19, Tim19Ch2, u16, cc2e, ccr2, ccr);
+        pwm_pin_for_pwm_channel!(TIM19, Tim19Ch3, u16, cc3e, ccr3, ccr);
+        pwm_pin_for_pwm_channel!(TIM19, Tim19Ch4, u16, cc4e, ccr4, ccr);
 
         // Pins
-        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pa0, gpioa::PA0<AF11>);
-        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pb6, gpiob::PB6<AF11>);
-        pwm_channel1_pin!(TIM19, TIM19_CH1, output_to_pc10, gpioc::PC10<AF2>);
+        pwm_channel1_pin!(TIM19, Tim19Ch1, output_to_pa0, gpioa::PA0<AF11>);
+        pwm_channel1_pin!(TIM19, Tim19Ch1, output_to_pb6, gpiob::PB6<AF11>);
+        pwm_channel1_pin!(TIM19, Tim19Ch1, output_to_pc10, gpioc::PC10<AF2>);
 
-        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pa1, gpioa::PA1<AF11>);
-        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pb7, gpiob::PB7<AF11>);
-        pwm_channel2_pin!(TIM19, TIM19_CH2, output_to_pc11, gpioc::PC11<AF2>);
+        pwm_channel2_pin!(TIM19, Tim19Ch2, output_to_pa1, gpioa::PA1<AF11>);
+        pwm_channel2_pin!(TIM19, Tim19Ch2, output_to_pb7, gpiob::PB7<AF11>);
+        pwm_channel2_pin!(TIM19, Tim19Ch2, output_to_pc11, gpioc::PC11<AF2>);
 
-        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pa2, gpioa::PA2<AF11>);
-        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pb8, gpiob::PB8<AF11>);
-        pwm_channel3_pin!(TIM19, TIM19_CH3, output_to_pc12, gpioc::PC12<AF2>);
+        pwm_channel3_pin!(TIM19, Tim19Ch3, output_to_pa2, gpioa::PA2<AF11>);
+        pwm_channel3_pin!(TIM19, Tim19Ch3, output_to_pb8, gpiob::PB8<AF11>);
+        pwm_channel3_pin!(TIM19, Tim19Ch3, output_to_pc12, gpioc::PC12<AF2>);
 
-        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pa3, gpioa::PA3<AF11>);
-        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pb9, gpiob::PB9<AF11>);
-        pwm_channel4_pin!(TIM19, TIM19_CH4, output_to_pd0, gpiod::PD0<AF2>);
+        pwm_channel4_pin!(TIM19, Tim19Ch4, output_to_pa3, gpioa::PA3<AF11>);
+        pwm_channel4_pin!(TIM19, Tim19Ch4, output_to_pb9, gpiob::PB9<AF11>);
+        pwm_channel4_pin!(TIM19, Tim19Ch4, output_to_pd0, gpiod::PD0<AF2>);
     };
 }
 
@@ -1541,13 +1541,13 @@ macro_rules! tim20 {
         use crate::pac::TIM20;
 
         /// Output Compare Channel 1 of Timer 20 (type state)
-        pub struct TIM20_CH1 {}
+        pub struct Tim20Ch1 {}
         /// Output Compare Channel 2 of Timer 20 (type state)
-        pub struct TIM20_CH2 {}
+        pub struct Tim20Ch2 {}
         /// Output Compare Channel 3 of Timer 20 (type state)
-        pub struct TIM20_CH3 {}
+        pub struct Tim20Ch3 {}
         /// Output Compare Channel 4 of Timer 20 (type state)
-        pub struct TIM20_CH4 {}
+        pub struct Tim20Ch4 {}
 
         pwm_timer_basic!(
             tim20,
@@ -1558,18 +1558,18 @@ macro_rules! tim20 {
             pclk2,
             tim20rst,
             tim20en,
-            [TIM20_CH1, TIM20_CH2, TIM20_CH3, TIM20_CH4],
+            [Tim20Ch1, Tim20Ch2, Tim20Ch3, Tim20Ch4],
             [PwmChannel, PwmChannel, PwmChannel, PwmChannel]
         );
 
         // Channels
         // TODO: stm32f3 doesn't suppport registers for all 4 channels
-        pwm_pin_for_pwm_n_channel!(TIM20, TIM20_CH1, u16, cc1e, cc1ne, ccr1, ccr);
+        pwm_pin_for_pwm_n_channel!(TIM20, Tim20Ch1, u16, cc1e, cc1ne, ccr1, ccr);
 
         //Pins
-        pwm_channel1_pin!(TIM20, TIM20_CH1, output_to_pe2, gpioe::PE2<AF6>);
+        pwm_channel1_pin!(TIM20, Tim20Ch1, output_to_pe2, gpioe::PE2<AF6>);
 
-        pwm_channel1n_pin!(TIM20, TIM20_CH1, output_to_pe4, gpioe::PE4<AF6>);
+        pwm_channel1n_pin!(TIM20, Tim20Ch1, output_to_pe4, gpioe::PE4<AF6>);
     };
 }
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -84,6 +84,11 @@ impl Rtc {
         self.regs.cr.read().fmt().bit()
     }
 
+    /// Release the RTC peripheral
+    pub fn free(self) -> RTC {
+        self.regs
+    }
+
     /// As described in Section 27.3.7 in RM0316,
     /// this function is used to disable write protection
     /// when modifying an RTC register

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -14,6 +14,7 @@ use rtcc::{Datelike, Hours, NaiveDate, NaiveDateTime, NaiveTime, Rtcc, Timelike}
 /// RTC error type
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Error {
     /// Invalid input error
     InvalidInputData,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -16,122 +16,45 @@ use crate::pac::{
     SPI1, SPI2, SPI3,
 };
 
-#[cfg(any(
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f398",
-))]
+#[cfg(feature = "gpio-f303e")]
 use crate::pac::SPI4;
 
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-use crate::gpio::gpioa::{PA1, PA10, PA12, PA13, PA2, PA3, PA8, PA9};
-#[cfg(any(
-    feature = "stm32f302x6",
-    feature = "stm32f302x8",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f398",
+#[cfg(not(feature = "gpio-f373"))]
+use crate::gpio::PB13;
+#[cfg(all(
+    not(feature = "stm32f301"),
+    any(feature = "gpio-f302", feature = "gpio-f303e")
 ))]
-use crate::gpio::gpioa::{PA10, PA11};
-use crate::gpio::gpioa::{PA5, PA6, PA7};
-#[cfg(any(
-    feature = "stm32f301",
-    feature = "stm32f302",
-    feature = "stm32f303",
-    feature = "stm32f318",
-    feature = "stm32f334",
-    feature = "stm32f358",
-    feature = "stm32f398"
-))]
-use crate::gpio::gpiob::PB13;
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-use crate::gpio::gpiob::{PB0, PB10, PB8};
-use crate::gpio::gpiob::{PB14, PB15, PB5};
-#[cfg(any(
-    feature = "stm32f302",
-    feature = "stm32f303",
-    feature = "stm32f318",
-    feature = "stm32f328",
-    feature = "stm32f334",
-    feature = "stm32f358",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f398",
-))]
-use crate::gpio::gpiob::{PB3, PB4};
-use crate::gpio::gpioc::{PC10, PC11, PC12};
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-use crate::gpio::gpioc::{PC2, PC3, PC7, PC8, PC9};
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-use crate::gpio::gpiod::{PD3, PD4, PD7, PD8};
-#[cfg(any(
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f398",
-))]
-use crate::gpio::gpioe::{PE12, PE13, PE14, PE2, PE5, PE6};
-#[cfg(any(
-    feature = "stm32f302x6",
-    feature = "stm32f302x8",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f398",
-))]
-use crate::gpio::gpiof::PF1;
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-use crate::gpio::gpiof::PF6;
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f358",
-    feature = "stm32f398",
-))]
-use crate::gpio::gpiof::{PF10, PF9};
+use crate::gpio::PF1;
+#[cfg(feature = "gpio-f373")]
+use crate::gpio::PF6;
 use crate::gpio::{PushPull, AF5, AF6};
+#[cfg(feature = "gpio-f373")]
+use crate::gpio::{PA1, PA10, PA12, PA13, PA2, PA3, PA8, PA9};
+#[cfg(all(
+    not(feature = "stm32f301"),
+    any(feature = "gpio-f302", feature = "gpio-f303e"),
+))]
+use crate::gpio::{PA10, PA11};
+use crate::gpio::{PA5, PA6, PA7};
+#[cfg(feature = "gpio-f373")]
+use crate::gpio::{PB0, PB10, PB8};
+use crate::gpio::{PB14, PB15, PB5};
+#[cfg(not(feature = "stm32f301"))]
+use crate::gpio::{PB3, PB4};
+use crate::gpio::{PC10, PC11, PC12};
+#[cfg(feature = "gpio-f373")]
+use crate::gpio::{PC2, PC3, PC7, PC8, PC9};
+#[cfg(feature = "gpio-f373")]
+use crate::gpio::{PD3, PD4, PD7, PD8};
+#[cfg(feature = "gpio-f303e")]
+use crate::gpio::{PE12, PE13, PE14, PE2, PE5, PE6};
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e",))]
+use crate::gpio::{PF10, PF9};
 use crate::rcc::Clocks;
-#[cfg(any(
-    feature = "stm32f301",
-    feature = "stm32f302",
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f358",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f398"
-))]
+#[cfg(not(feature = "gpio-f333"))]
 use crate::rcc::APB1;
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303",
-    feature = "stm32f328",
-    feature = "stm32f334",
-    feature = "stm32f358",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f398"
-))]
+#[cfg(not(feature = "gpio-f302"))]
 use crate::rcc::APB2;
 use crate::time::rate::*;
 use core::marker::PhantomData;
@@ -159,232 +82,115 @@ pub trait MisoPin<SPI>: crate::private::Sealed {}
 pub trait MosiPin<SPI>: crate::private::Sealed {}
 
 impl SckPin<SPI1> for PA5<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl SckPin<SPI1> for PA12<AF6<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303",
-    feature = "stm32f328",
-    feature = "stm32f334",
-    feature = "stm32f358",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f398",
-))]
+#[cfg(not(feature = "gpio-f302"))]
 impl SckPin<SPI1> for PB3<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl SckPin<SPI1> for PC7<AF5<PushPull>> {}
 
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl SckPin<SPI2> for PA8<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl SckPin<SPI2> for PB8<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl SckPin<SPI2> for PB10<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f301",
-    feature = "stm32f302",
-    feature = "stm32f303",
-    feature = "stm32f318",
-    feature = "stm32f334",
-    feature = "stm32f358",
-    feature = "stm32f398"
-))]
+#[cfg(not(feature = "gpio-f373"))]
 impl SckPin<SPI2> for PB13<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl SckPin<SPI2> for PD7<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl SckPin<SPI2> for PD8<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302x6",
-    feature = "stm32f302x8",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f398",
+#[cfg(all(
+    not(feature = "stm32f301"),
+    any(feature = "gpio-f303e", feature = "gpio-f302"),
 ))]
 impl SckPin<SPI2> for PF1<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f358",
-    feature = "stm32f398",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e",))]
 impl SckPin<SPI2> for PF9<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xb",
-    feature = "stm32f303xc",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f358",
-    feature = "stm32f398",
-))]
+#[cfg(any(feature = "gpio-f303", feature = "gpio-f303e",))]
 impl SckPin<SPI2> for PF10<AF5<PushPull>> {}
 
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl SckPin<SPI3> for PA1<AF6<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f398",
+#[cfg(all(
+    not(feature = "stm32f301"),
+    not(feature = "gpio-f333"),
+    not(feature = "gpio-f303"),
 ))]
 impl SckPin<SPI3> for PB3<AF6<PushPull>> {}
 impl SckPin<SPI3> for PC10<AF6<PushPull>> {}
 
-#[cfg(any(
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f398",
-))]
+#[cfg(feature = "gpio-f303e")]
 impl SckPin<SPI4> for PE2<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f398",
-))]
+#[cfg(feature = "gpio-f303e")]
 impl SckPin<SPI4> for PE12<AF5<PushPull>> {}
 
 impl MisoPin<SPI1> for PA6<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI1> for PA13<AF6<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302xb",
-    feature = "stm32f302xc",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303",
-    feature = "stm32f328",
-    feature = "stm32f334",
-    feature = "stm32f358",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f398",
-))]
+#[cfg(not(feature = "gpio-f302"))]
 impl MisoPin<SPI1> for PB4<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI1> for PC8<AF5<PushPull>> {}
 
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI2> for PA9<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302x6",
-    feature = "stm32f302x8",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f398",
+#[cfg(all(
+    not(feature = "stm32f301"),
+    any(feature = "gpio-f303e", feature = "gpio-f302")
 ))]
 impl MisoPin<SPI2> for PA10<AF5<PushPull>> {}
 impl MisoPin<SPI2> for PB14<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI2> for PC2<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI2> for PD3<AF5<PushPull>> {}
 
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI3> for PA2<AF6<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f373",
-    feature = "stm32f378",
-    feature = "stm32f398",
+#[cfg(all(
+    not(feature = "stm32f301"),
+    any(feature = "gpio-f302", feature = "gpio-f303e", feature = "gpio-f373"),
 ))]
 impl MisoPin<SPI3> for PB4<AF6<PushPull>> {}
 impl MisoPin<SPI3> for PC11<AF6<PushPull>> {}
 
-#[cfg(any(
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f398",
-))]
+#[cfg(feature = "gpio-f303e")]
 impl MisoPin<SPI4> for PE5<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f398",
-))]
+#[cfg(feature = "gpio-f303e")]
 impl MisoPin<SPI4> for PE13<AF5<PushPull>> {}
 
 impl MosiPin<SPI1> for PA7<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MosiPin<SPI1> for PB0<AF5<PushPull>> {}
 impl MosiPin<SPI1> for PB5<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MosiPin<SPI1> for PC9<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MosiPin<SPI1> for PF6<AF5<PushPull>> {}
 
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MosiPin<SPI2> for PA10<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302x6",
-    feature = "stm32f302x8",
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f318",
-    feature = "stm32f398",
+#[cfg(all(
+    not(feature = "stm32f301"),
+    any(feature = "gpio-f302", feature = "gpio-f303e"),
 ))]
 impl MosiPin<SPI2> for PA11<AF5<PushPull>> {}
 impl MosiPin<SPI2> for PB15<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI2> for PC3<AF5<PushPull>> {}
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI2> for PD4<AF5<PushPull>> {}
 
-#[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
+#[cfg(feature = "gpio-f373")]
 impl MisoPin<SPI3> for PA3<AF6<PushPull>> {}
 impl MosiPin<SPI3> for PB5<AF6<PushPull>> {}
 impl MosiPin<SPI3> for PC12<AF6<PushPull>> {}
 
-#[cfg(any(
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f398",
-))]
+#[cfg(feature = "gpio-f303e")]
 impl MosiPin<SPI4> for PE6<AF5<PushPull>> {}
-#[cfg(any(
-    feature = "stm32f302xd",
-    feature = "stm32f302xe",
-    feature = "stm32f303xd",
-    feature = "stm32f303xe",
-    feature = "stm32f398",
-))]
+#[cfg(feature = "gpio-f303e")]
 impl MosiPin<SPI4> for PE14<AF5<PushPull>> {}
 
 /// Configuration trait for the Word Size

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -149,19 +149,18 @@ pub enum Error {
     Crc,
 }
 
-// FIXME these should be "closed" traits
-/// SCK pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait SckPin<SPI> {}
+/// SCK pin
+pub trait SckPin<SPI>: crate::private::Sealed {}
 
-/// MISO pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait MisoPin<SPI> {}
+/// MISO pin
+pub trait MisoPin<SPI>: crate::private::Sealed {}
 
-/// MOSI pin -- DO NOT IMPLEMENT THIS TRAIT
-pub unsafe trait MosiPin<SPI> {}
+/// MOSI pin
+pub trait MosiPin<SPI>: crate::private::Sealed {}
 
-unsafe impl SckPin<SPI1> for PA5<AF5<PushPull>> {}
+impl SckPin<SPI1> for PA5<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI1> for PA12<AF6<PushPull>> {}
+impl SckPin<SPI1> for PA12<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -175,16 +174,16 @@ unsafe impl SckPin<SPI1> for PA12<AF6<PushPull>> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI1> for PB3<AF5<PushPull>> {}
+impl SckPin<SPI1> for PB3<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI1> for PC7<AF5<PushPull>> {}
+impl SckPin<SPI1> for PC7<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PA8<AF5<PushPull>> {}
+impl SckPin<SPI2> for PA8<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PB8<AF5<PushPull>> {}
+impl SckPin<SPI2> for PB8<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PB10<AF5<PushPull>> {}
+impl SckPin<SPI2> for PB10<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f301",
     feature = "stm32f302",
@@ -194,11 +193,11 @@ unsafe impl SckPin<SPI2> for PB10<AF5<PushPull>> {}
     feature = "stm32f358",
     feature = "stm32f398"
 ))]
-unsafe impl SckPin<SPI2> for PB13<AF5<PushPull>> {}
+impl SckPin<SPI2> for PB13<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PD7<AF5<PushPull>> {}
+impl SckPin<SPI2> for PD7<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI2> for PD8<AF5<PushPull>> {}
+impl SckPin<SPI2> for PD8<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -209,7 +208,7 @@ unsafe impl SckPin<SPI2> for PD8<AF5<PushPull>> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF1<AF5<PushPull>> {}
+impl SckPin<SPI2> for PF1<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -222,7 +221,7 @@ unsafe impl SckPin<SPI2> for PF1<AF5<PushPull>> {}
     feature = "stm32f358",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF9<AF5<PushPull>> {}
+impl SckPin<SPI2> for PF9<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -235,10 +234,10 @@ unsafe impl SckPin<SPI2> for PF9<AF5<PushPull>> {}
     feature = "stm32f358",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI2> for PF10<AF5<PushPull>> {}
+impl SckPin<SPI2> for PF10<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl SckPin<SPI3> for PA1<AF6<PushPull>> {}
+impl SckPin<SPI3> for PA1<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xd",
@@ -248,8 +247,8 @@ unsafe impl SckPin<SPI3> for PA1<AF6<PushPull>> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI3> for PB3<AF6<PushPull>> {}
-unsafe impl SckPin<SPI3> for PC10<AF6<PushPull>> {}
+impl SckPin<SPI3> for PB3<AF6<PushPull>> {}
+impl SckPin<SPI3> for PC10<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -258,7 +257,7 @@ unsafe impl SckPin<SPI3> for PC10<AF6<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI4> for PE2<AF5<PushPull>> {}
+impl SckPin<SPI4> for PE2<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -266,11 +265,11 @@ unsafe impl SckPin<SPI4> for PE2<AF5<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl SckPin<SPI4> for PE12<AF5<PushPull>> {}
+impl SckPin<SPI4> for PE12<AF5<PushPull>> {}
 
-unsafe impl MisoPin<SPI1> for PA6<AF5<PushPull>> {}
+impl MisoPin<SPI1> for PA6<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI1> for PA13<AF6<PushPull>> {}
+impl MisoPin<SPI1> for PA13<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xb",
     feature = "stm32f302xc",
@@ -284,12 +283,12 @@ unsafe impl MisoPin<SPI1> for PA13<AF6<PushPull>> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI1> for PB4<AF5<PushPull>> {}
+impl MisoPin<SPI1> for PB4<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI1> for PC8<AF5<PushPull>> {}
+impl MisoPin<SPI1> for PC8<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PA9<AF5<PushPull>> {}
+impl MisoPin<SPI2> for PA9<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -300,15 +299,15 @@ unsafe impl MisoPin<SPI2> for PA9<AF5<PushPull>> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI2> for PA10<AF5<PushPull>> {}
-unsafe impl MisoPin<SPI2> for PB14<AF5<PushPull>> {}
+impl MisoPin<SPI2> for PA10<AF5<PushPull>> {}
+impl MisoPin<SPI2> for PB14<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PC2<AF5<PushPull>> {}
+impl MisoPin<SPI2> for PC2<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PD3<AF5<PushPull>> {}
+impl MisoPin<SPI2> for PD3<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI3> for PA2<AF6<PushPull>> {}
+impl MisoPin<SPI3> for PA2<AF6<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302",
     feature = "stm32f303xd",
@@ -318,8 +317,8 @@ unsafe impl MisoPin<SPI3> for PA2<AF6<PushPull>> {}
     feature = "stm32f378",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI3> for PB4<AF6<PushPull>> {}
-unsafe impl MisoPin<SPI3> for PC11<AF6<PushPull>> {}
+impl MisoPin<SPI3> for PB4<AF6<PushPull>> {}
+impl MisoPin<SPI3> for PC11<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -328,7 +327,7 @@ unsafe impl MisoPin<SPI3> for PC11<AF6<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI4> for PE5<AF5<PushPull>> {}
+impl MisoPin<SPI4> for PE5<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -336,19 +335,19 @@ unsafe impl MisoPin<SPI4> for PE5<AF5<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MisoPin<SPI4> for PE13<AF5<PushPull>> {}
+impl MisoPin<SPI4> for PE13<AF5<PushPull>> {}
 
-unsafe impl MosiPin<SPI1> for PA7<AF5<PushPull>> {}
+impl MosiPin<SPI1> for PA7<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PB0<AF5<PushPull>> {}
-unsafe impl MosiPin<SPI1> for PB5<AF5<PushPull>> {}
+impl MosiPin<SPI1> for PB0<AF5<PushPull>> {}
+impl MosiPin<SPI1> for PB5<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PC9<AF5<PushPull>> {}
+impl MosiPin<SPI1> for PC9<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI1> for PF6<AF5<PushPull>> {}
+impl MosiPin<SPI1> for PF6<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MosiPin<SPI2> for PA10<AF5<PushPull>> {}
+impl MosiPin<SPI2> for PA10<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302x6",
     feature = "stm32f302x8",
@@ -359,17 +358,17 @@ unsafe impl MosiPin<SPI2> for PA10<AF5<PushPull>> {}
     feature = "stm32f318",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI2> for PA11<AF5<PushPull>> {}
-unsafe impl MosiPin<SPI2> for PB15<AF5<PushPull>> {}
+impl MosiPin<SPI2> for PA11<AF5<PushPull>> {}
+impl MosiPin<SPI2> for PB15<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PC3<AF5<PushPull>> {}
+impl MisoPin<SPI2> for PC3<AF5<PushPull>> {}
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI2> for PD4<AF5<PushPull>> {}
+impl MisoPin<SPI2> for PD4<AF5<PushPull>> {}
 
 #[cfg(any(feature = "stm32f373", feature = "stm32f378"))]
-unsafe impl MisoPin<SPI3> for PA3<AF6<PushPull>> {}
-unsafe impl MosiPin<SPI3> for PB5<AF6<PushPull>> {}
-unsafe impl MosiPin<SPI3> for PC12<AF6<PushPull>> {}
+impl MisoPin<SPI3> for PA3<AF6<PushPull>> {}
+impl MosiPin<SPI3> for PB5<AF6<PushPull>> {}
+impl MosiPin<SPI3> for PC12<AF6<PushPull>> {}
 
 #[cfg(any(
     feature = "stm32f302xd",
@@ -378,7 +377,7 @@ unsafe impl MosiPin<SPI3> for PC12<AF6<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI4> for PE6<AF5<PushPull>> {}
+impl MosiPin<SPI4> for PE6<AF5<PushPull>> {}
 #[cfg(any(
     feature = "stm32f302xd",
     feature = "stm32f302xe",
@@ -386,7 +385,7 @@ unsafe impl MosiPin<SPI4> for PE6<AF5<PushPull>> {}
     feature = "stm32f303xe",
     feature = "stm32f398",
 ))]
-unsafe impl MosiPin<SPI4> for PE14<AF5<PushPull>> {}
+impl MosiPin<SPI4> for PE14<AF5<PushPull>> {}
 
 /// Configuration trait for the Word Size
 /// used by the SPI peripheral

--- a/testsuite/tests/adc.rs
+++ b/testsuite/tests/adc.rs
@@ -52,7 +52,7 @@ mod tests {
                 dp.ADC1,
                 &mut dp.ADC1_2,
                 &mut rcc.ahb,
-                adc::CkMode::default(),
+                adc::ClockMode::default(),
                 clocks,
             )),
             analog: pair.0,
@@ -94,7 +94,7 @@ mod tests {
             adc1,
             &mut state.adc1_2,
             &mut state.ahb,
-            adc::CkMode::default(),
+            adc::ClockMode::default(),
             state.clocks,
         );
 


### PR DESCRIPTION
Preparations like introducing `#[non_exhaustive]` to later not having to introduce breaking changes, when improving these modules.

Closes #175 
Closes #169 