### PR TITLE
ci: Use build instead of check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           target: thumbv7em-none-eabihf
           override: true
           profile: minimal
-      - run: cargo check --features=${{ matrix.mcu }} --lib --examples
+      - run: cargo build --features=${{ matrix.mcu }} --lib --examples
 
   # This is our MSRV. However this is only for documentation
   # purposes and should be increased if newer features are used.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ required-features = ["ld", "stm32f303xc"]
 
 [[example]]
 name = "can"
-required-features = ["ld", "rt", "can", "stm32f302"]
+required-features = ["ld", "rt", "can", "stm32f302xc"]
 
 [[example]]
 name = "serial_dma"
@@ -192,7 +192,7 @@ required-features = ["ld", "rt", "stm32f303xc", "enumset"]
 
 [[example]]
 name = "adc"
-required-features = ["ld", "stm32f303"]
+required-features = ["ld", "stm32f303xc"]
 
 [[example]]
 name = "i2c_scanner"


### PR DESCRIPTION
This catches linking errors, which might not be catched otherwise