### PR TITLE
Fix minimal dependency build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ bxcan = { version = "0.6.2", optional = true }
 stm32-usbd = { version = "0.6.0", optional = true }
 void = { version = "1.0.2", default-features = false }
 enumset = { version = "1.0.6", optional = true}
+# NOTE: Workaround for build
+# $ cargo +nightly update -Z minimal-versions
+# as long cortex-m depends on bare-metal 0.2.1
+bare-metal = "0.2.5"
 
 [dev-dependencies]
 cortex-m = "0.7.2"


### PR DESCRIPTION
Workaround the cortex-m -> bare-metal 0.2.1
dependency by depending on bare-metal 0.2.5
directly, as long as

https://github.com/rust-embedded/cortex-m/pull/361

is not fixed.