### PR TITLE
Add missing spi impls for gpio-f303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `RccBus`, `Enable`, `Reset` traits and implementations for peripherals ([#299])
 - Support cortex-m-rt `v0.7.0` but still allow `v0.6.13` ([#283])
 - Add missing SPI impls for the `gpio-f303` device groups (e.g. stm32f303vc) ([#304])
+- Make timer `InterruptTypes` fields public to be useful. ([#304])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   To disable that behavior, set `default-features = false`. ([#283])
 - The MSRV was bumped to 1.52 ([#283])
 - Update `stm32f3` pac to v0.14.0 ([#282])
+- Remove the `bxcan` re-export. ([#303])
 
 ## [v0.8.1] - 2021-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `BusClock` and `BusTimerClock` traits ([#302])
 - `RccBus`, `Enable`, `Reset` traits and implementations for peripherals ([#299])
 - Support cortex-m-rt `v0.7.0` but still allow `v0.6.13` ([#283])
+- Add missing SPI impls for the `gpio-f303` device groups (e.g. stm32f303vc) ([#304])
 
 ### Fixed
 
@@ -502,6 +503,7 @@ let clocks = rcc
 [defmt]: https://github.com/knurling-rs/defmt
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
+[#303]: https://github.com/stm32-rs/stm32f3xx-hal/pull/303
 [#302]: https://github.com/stm32-rs/stm32f3xx-hal/pull/302
 [#299]: https://github.com/stm32-rs/stm32f3xx-hal/pull/299
 [#291]: https://github.com/stm32-rs/stm32f3xx-hal/pull/291

--- a/examples/can.rs
+++ b/examples/can.rs
@@ -13,8 +13,8 @@ use hal::pac;
 use hal::prelude::*;
 use hal::watchdog::IndependentWatchDog;
 
-use hal::can::bxcan::filter::Mask32;
-use hal::can::bxcan::{Frame, StandardId};
+use bxcan::filter::Mask32;
+use bxcan::{Frame, StandardId};
 use hal::can::Can;
 use nb::block;
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -17,7 +17,6 @@ use crate::pac;
 
 use crate::rcc::{Enable, Reset, APB1};
 
-pub use bxcan;
 use bxcan::RegisterBlock;
 
 use cfg_if::cfg_if;
@@ -55,12 +54,7 @@ where
     Tx: TxPin,
     Rx: RxPin,
 {
-    /// Create a new CAN instance, using the specified TX and RX pins.
-    ///
-    /// Note: this does not actually initialize the CAN bus.
-    /// You will need to first call [`bxcan::Can::new`] and  set the bus configuration and filters
-    /// before the peripheral can be enabled.
-    /// See the CAN example, for a more thorough example of the full setup process.
+    /// Create a new `bxcan::CAN` instance.
     pub fn new(can: pac::CAN, tx: Tx, rx: Rx, apb1: &mut APB1) -> bxcan::Can<Self> {
         pac::CAN::enable(apb1);
         pac::CAN::reset(apb1);

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -351,6 +351,7 @@ pub struct BDCR {
 }
 
 impl BDCR {
+    #[allow(unused)]
     pub(crate) fn bdcr(&mut self) -> &rcc::BDCR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).bdcr }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -46,6 +46,7 @@ use cortex_m::interrupt;
 #[cfg_attr(feature = "enumset", derive(EnumSetType))]
 #[cfg_attr(not(feature = "enumset"), derive(Copy, Clone, PartialEq, Eq))]
 #[non_exhaustive]
+// TODO: Split up in transmission and reception events (RM0316 29.7)
 pub enum Event {
     /// Transmit data register empty / new data can be sent.
     ///

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -143,7 +143,7 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(all(
         not(feature = "stm32f301"),
-        any(feature = "gpio-f302", feature = "gpio-f303e"),
+        any(feature = "gpio-f302", feature = "gpio-f303", feature = "gpio-f303e"),
     ))] {
         impl SckPin<SPI3> for gpio::PB3<AF6<PushPull>> {}
         impl MisoPin<SPI3> for gpio::PB4<AF6<PushPull>> {}

--- a/src/timer/interrupts.rs
+++ b/src/timer/interrupts.rs
@@ -6,13 +6,13 @@ use crate::pac::Interrupt;
 #[non_exhaustive]
 pub struct InterruptTypes {
     /// Break Interrupt
-    r#break: Interrupt,
+    pub r#break: Interrupt,
     /// Update Interrupt
-    update: Interrupt,
+    pub update: Interrupt,
     /// Trigger and communication Interrupt
-    trigger: Interrupt,
+    pub trigger: Interrupt,
     /// Capture and compare interupt
-    capture_compare: Interrupt,
+    pub capture_compare: Interrupt,
 }
 
 // FIXME: Use conditional feature compilation to make this compialble for all chip families.

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -50,25 +50,17 @@ harness = false
 [dependencies]
 cfg-if = "1.0"
 cortex-m = "0.7.0"
-cortex-m-rt = "0.7"
+cortex-m-rt = "0.7.1"
 defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 defmt-test = "0.3.0"
 enumset = { version = "1.0.6" }
 # TODO: Set stm32f303xc as default, but make it overwritable
-stm32f3xx-hal = { path = "..", features = ["defmt-trace"]}
+stm32f3xx-hal = { path = "..", features = ["defmt"]}
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 nb = "1.0.0"
 num-traits = { version = "0.2.14", default-features = false }
 
 [features]
 # enable all defmt logging levels
-default = ["stm32f3xx-hal/stm32f303xc", "defmt-default"]
-
-# do not modify these features
-defmt-default = ["defmt-trace"]
-defmt-trace = ["stm32f3xx-hal/defmt-trace"]
-defmt-debug = ["stm32f3xx-hal/defmt-trace"]
-defmt-info = ["stm32f3xx-hal/defmt-trace"]
-defmt-warn = ["stm32f3xx-hal/defmt-trace"]
-defmt-error = ["stm32f3xx-hal/defmt-trace"]
+default = ["stm32f3xx-hal/stm32f303xc"]

--- a/testsuite/tests/uart.rs
+++ b/testsuite/tests/uart.rs
@@ -394,6 +394,9 @@ mod tests {
             unwrap!(nb::block!(serial.write(b'A')).ok());
         });
 
+        // FIXME: This test is sensitive to timing and the event might already be triggered by a
+        // previous transmission. (More details about IDLE event RM0316 29.8.1)
+        #[cfg(feature = "disabled")]
         trigger_event(Event::Idle, &mut serial, |serial| {
             // Note: The IDLE bit will not be set again until the RXNE bit has been set (i.e. a new
             // idle line occurs).


### PR DESCRIPTION
- [ ] Adjust example to specify [`WORD`](https://github.com/stm32-rs/stm32f3xx-hal/issues/303#issuecomment-991955400)
- [ ] Fix testsuite build

Fixes #303
