### PR TITLE
Fix testsuite build failure

### DIFF
--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -50,7 +50,5 @@ pub struct CrossSerialPair2<T1, T2>(pub PB10<T1>, pub PA3<T2>);
 /// This is used for SPI, where SPI3(TX) is connected to SPI3(RX)
 pub struct SpiPair<T>(pub PC10<T>, pub PC11<T>, pub PC12<T>);
 
-#[export_name = "main"]
-unsafe extern "C" fn __dummy_entry() -> ! {
-    defmt_test::export::exit()
-}
+#[defmt_test::tests]
+mod tests {}


### PR DESCRIPTION
The build failure was introduced by Rust 1.56 -> 1.57 upgrade.
This is not a regression, though as it likely just revealed an existing
bug.

The build failure was probably introduced because of the custom
profile change and the interaction with LTO.

I assume the build behavior changed so that not only the built-in `test`
profile was build, but also the `dev` profile, suggested by the patch
fixing / working around the failure:

```patch
diff --git a/Cargo.toml b/Cargo.toml
index 75586959..827fe80a 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ defmt-error = ["defmt"]
 # cargo build/run
 [profile.dev]
 debug = 2
-lto = true
+lto = false

 # cargo test
 [profile.test]
diff --git a/testsuite/src/lib.rs b/testsuite/src/lib.rs
index eee27ca5..a9ea5bce 100644
--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -50,6 +50,7 @@ pub struct CrossSerialPair2<T1, T2>(pub PB10<T1>, pub PA3<T2>);
 /// This is used for SPI, where SPI3(TX) is connected to SPI3(RX)
 pub struct SpiPair<T>(pub PC10<T>, pub PC11<T>, pub PC12<T>);

+#[cfg(test)]
 #[export_name = "main"]
 unsafe extern "C" fn __dummy_entry() -> ! {
     defmt_test::export::exit()
```

Building with the `dev` profile alone, it resulted into a linker error,
because two `main` function symbols existed. The __dummy_entry function
was not excluded via `#[cfg(test)]` as the crate was conditionally
set to `#![cfg_attr(test, no_main)]`, which meant, `dev` created a
default main function.

This might not be intended behavior by rustc after all, but it does not
affect this crate anymore after the change.

The fix is a little different to the above patch though, as it applies
a similar as knurling-rs/app-template was already doing.