### PR TITLE
Fix uart busy handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Missing `MosiPin` impl for `PB5` ([#322])
+- Read valid data from data register even if reception of next character
+  has started ([#317])
 
 ## [v0.9.0] - 2022-03-06
 
@@ -562,6 +564,7 @@ let clocks = rcc
 
 [#322]: https://github.com/stm32-rs/stm32f3xx-hal/pull/322
 [#318]: https://github.com/stm32-rs/stm32f3xx-hal/pull/318
+[#317]: https://github.com/stm32-rs/stm32f3xx-hal/pull/317
 [#314]: https://github.com/stm32-rs/stm32f3xx-hal/pull/314
 [#309]: https://github.com/stm32-rs/stm32f3xx-hal/pull/309
 [#308]: https://github.com/stm32-rs/stm32f3xx-hal/pull/308

--- a/src/adc/config.rs
+++ b/src/adc/config.rs
@@ -50,7 +50,7 @@ use core::convert::TryFrom;
 /// [`Adc::set_pin_sequence_position`]: `super::Adc::set_pin_sequence_position`
 /// [`Adc::set_channel_sequence_position`]: `super::Adc::set_channel_sequence_position`
 /// [`Adc::channel_sequence`]: `super::Adc::channel_sequence`
-#[derive(Debug, PartialEq, PartialOrd, Copy, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[allow(missing_docs)]
 pub enum Sequence {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -881,9 +881,7 @@ where
 {
     let isr = usart.isr.read();
 
-    Err(if isr.busy().bit_is_set() {
-        nb::Error::WouldBlock
-    } else if isr.pe().bit_is_set() {
+    Err(if isr.pe().bit_is_set() {
         usart.icr.write(|w| w.pecf().clear());
         nb::Error::Other(Error::Parity)
     } else if isr.fe().bit_is_set() {

--- a/src/serial/config.rs
+++ b/src/serial/config.rs
@@ -6,7 +6,7 @@ use crate::time::rate::{Baud, Extensions};
 /// Stop Bit configuration parameter for serial.
 ///
 /// Wrapper around [`STOP_A`]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum StopBits {
     /// 0.5 stop bit
@@ -45,7 +45,7 @@ impl From<STOP_A> for StopBits {
 /// underlying USART will be configured to send/receive the parity bit in
 /// addtion to the data bits.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Parity {
     /// No parity bit will be added/checked.
     None,
@@ -73,7 +73,7 @@ pub enum Parity {
 /// assert!(config.parity == Parity::None);
 /// assert!(config.stopbits == StopBits::STOP1);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Config {
     /// Serial interface baud rate

--- a/src/spi/config.rs
+++ b/src/spi/config.rs
@@ -35,7 +35,7 @@ use crate::time::rate::Generic;
 /// assert!(config.parity == Parity::None);
 /// assert!(config.stopbits == StopBits::STOP1);
 /// ```
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Config {
     /// Operating frequency of the SPI peripheral.


### PR DESCRIPTION
I tried a small test program on the Discovery board and suffered from receive overflows while polling the serial interface via "uart.read()".
Data rate is 19200 baud and polling interval is about 50-60us, so this shouldn't be possible.

I could fix my problem by the change in this PR

It looks like there is a chance to poll when some data is still in shift register and in the next poll cycle rdr got updated and the start-bit of the next character is already in the shift register. 
This sets isr.busy and read() returns Error::WouldBlock although there is a valid character in rdr.

To test this I added a uart test case to the testsuite, which fails with the original implementation and passes with my fix.

Please let me know, if the PR is invalid, needs a change or if I missed something.
I can also squash the commits, if that fits better.

Thanks,
Ralf
