### PR TITLE
Add missing MosiPin for PB5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-No changes.
+### Fixed
+
+- Missing `MosiPin` impl for `PB5` ([#322])
 
 ## [v0.9.0] - 2022-03-06
 
@@ -554,6 +556,7 @@ let clocks = rcc
 [defmt]: https://github.com/knurling-rs/defmt
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
+[#322]: https://github.com/stm32-rs/stm32f3xx-hal/pull/322
 [#314]: https://github.com/stm32-rs/stm32f3xx-hal/pull/314
 [#309]: https://github.com/stm32-rs/stm32f3xx-hal/pull/309
 [#308]: https://github.com/stm32-rs/stm32f3xx-hal/pull/308

--- a/deny.toml
+++ b/deny.toml
@@ -14,5 +14,6 @@ ignore = [
 allow = [
     "MIT",
     "Apache-2.0",
-    "0BSD"
+    "0BSD",
+    "Unicode-DFS-2016",
 ]

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -53,6 +53,7 @@ pub trait MosiPin<SPI>: crate::private::Sealed {}
 impl SckPin<SPI1> for gpio::PA5<AF5<PushPull>> {}
 impl MisoPin<SPI1> for gpio::PA6<AF5<PushPull>> {}
 impl MosiPin<SPI1> for gpio::PA7<AF5<PushPull>> {}
+impl MosiPin<SPI1> for gpio::PB5<AF5<PushPull>> {}
 
 #[cfg(not(feature = "gpio-f373"))]
 impl SckPin<SPI2> for gpio::PB13<AF5<PushPull>> {}


### PR DESCRIPTION
This impl was accidentally removed after refactoring
and is a regression at least from previous versions

Fix #320