### PR TITLE
Update RTC API

### DIFF
--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -18,6 +18,8 @@ use rtcc::{DateTimeAccess, Datelike, Hours, NaiveDate, NaiveDateTime, NaiveTime,
 pub enum Error {
     /// Invalid input error
     InvalidInputData,
+    /// Invalid register data, failed to convert to rtcc Type
+    InvalidRtcData,
 }
 
 /// Real Time Clock peripheral
@@ -178,12 +180,10 @@ impl DateTimeAccess for Rtc {
         let minutes = self.minutes()?;
         let hours = hours_to_u8(self.hours()?)?;
 
-        Ok(
-            NaiveDate::from_ymd_opt(year.into(), month.into(), day.into())
-                .unwrap()
-                .and_hms_opt(hours.into(), minutes.into(), seconds.into())
-                .unwrap(),
-        )
+        NaiveDate::from_ymd_opt(year.into(), month.into(), day.into())
+            .ok_or(Error::InvalidRtcData)?
+            .and_hms_opt(hours.into(), minutes.into(), seconds.into())
+            .ok_or(Error::InvalidRtcData)
     }
 }
 
@@ -332,7 +332,8 @@ impl Rtcc for Rtc {
         let minutes = self.minutes()?;
         let hours = hours_to_u8(self.hours()?)?;
 
-        Ok(NaiveTime::from_hms_opt(hours.into(), minutes.into(), seconds.into()).unwrap())
+        NaiveTime::from_hms_opt(hours.into(), minutes.into(), seconds.into())
+            .ok_or(Error::InvalidRtcData)
     }
 
     fn weekday(&mut self) -> Result<u8, Self::Error> {
@@ -365,7 +366,7 @@ impl Rtcc for Rtc {
         let month = self.month()?;
         let year = self.year()?;
 
-        Ok(NaiveDate::from_ymd_opt(year.into(), month.into(), day.into()).unwrap())
+        NaiveDate::from_ymd_opt(year.into(), month.into(), day.into()).ok_or(Error::InvalidRtcData)
     }
 }
 
@@ -379,13 +380,13 @@ fn bcd2_encode(word: u32) -> Result<(u8, u8), Error> {
     let l = match (word / 10).try_into() {
         Ok(v) => v,
         Err(_) => {
-            return Err(Error::InvalidInputData);
+            return Err(Error::InvalidRtcData);
         }
     };
     let r = match (word % 10).try_into() {
         Ok(v) => v,
         Err(_) => {
-            return Err(Error::InvalidInputData);
+            return Err(Error::InvalidRtcData);
         }
     };
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -179,11 +179,10 @@ impl DateTimeAccess for Rtc {
         let hours = hours_to_u8(self.hours()?)?;
 
         Ok(
-            NaiveDate::from_ymd(year.into(), month.into(), day.into()).and_hms(
-                hours.into(),
-                minutes.into(),
-                seconds.into(),
-            ),
+            NaiveDate::from_ymd_opt(year.into(), month.into(), day.into())
+                .unwrap()
+                .and_hms_opt(hours.into(), minutes.into(), seconds.into())
+                .unwrap(),
         )
     }
 }
@@ -333,11 +332,7 @@ impl Rtcc for Rtc {
         let minutes = self.minutes()?;
         let hours = hours_to_u8(self.hours()?)?;
 
-        Ok(NaiveTime::from_hms(
-            hours.into(),
-            minutes.into(),
-            seconds.into(),
-        ))
+        Ok(NaiveTime::from_hms_opt(hours.into(), minutes.into(), seconds.into()).unwrap())
     }
 
     fn weekday(&mut self) -> Result<u8, Self::Error> {
@@ -370,7 +365,7 @@ impl Rtcc for Rtc {
         let month = self.month()?;
         let year = self.year()?;
 
-        Ok(NaiveDate::from_ymd(year.into(), month.into(), day.into()))
+        Ok(NaiveDate::from_ymd_opt(year.into(), month.into(), day.into()).unwrap())
     }
 }
 


### PR DESCRIPTION
The functions [`from_ymd`](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDate.html#method.from_ymd) and [`and_hms`](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDate.html#method.and_hms) were deprecated in 0.4.23 in favour of the `_opt` variants