### PR TITLE
UART DMA improvements and refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 No changes.
 
+### Changed
+
+- serial: The DMA functions `write_all` and `read_exact` now returns
+  the wrapper structs `SerialDmaTx` and `SerialDmaRx` instead of the direct
+  DMA transfer struct. These allow checking the USART ISR events
+  with `is_event_triggered` as well.
+
+### Fixed
+
+- serial: The previous DMA `write_all` implementation did use the DMA transfer completion
+  event to check for transfer completion, but MCU datasheet specifies that the TC
+  flag of the USART peripheral should be checked for transfer completion to avoid
+  corruption of the last transfer. This is now done by the new `SerialDmaTx` wrapper.
+
+## Added
+
+- serial: Public `is_event_triggered` method which allows to check for events
+  given an event and a USART reference.
+
 ## [v0.9.1] - 2022-09-07
 
 ### Added

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -153,6 +153,11 @@ impl<B, C: Channel, T: Target> Transfer<B, C, T> {
 
         self.stop()
     }
+
+    pub(crate) fn target(&self) -> &T {
+        let inner = crate::unwrap!(self.inner.as_ref());
+        &inner.target
+    }
 }
 
 impl<B, C: Channel, T: Target> Drop for Transfer<B, C, T> {


### PR DESCRIPTION
Some preparation to allow variable sized DMA transfers as specified in https://github.com/stm32-rs/stm32f3xx-hal/issues/325 . I did not have to change anything in the `serial_dma` example, but this is unfortunately a breaking change. In the process of reading a it about DMA, I also saw that the datasheet recommends checking the UART TC flag for transmission completeness. I am not sure whether this was not done on purpose or simply overlooked, but the changes ensure the TC flag is now checked as well.

Copied from CHANGELOG:

### Changed

- serial: The DMA functions `write_all` and `read_exact` now returns
  the wrapper structs `SerialDmaTx` and `SerialDmaRx` instead of the direct
  DMA transfer struct. These allow checking the USART ISR events
  with `is_event_triggered` as well.

### Fixed

- serial: The previous DMA `write_all` implementation did use the DMA transfer completion
  event to check for transfer completion, but MCU datasheet specifies that the TC
  flag of the USART peripheral should be checked for transfer completion to avoid
  corruption of the last transfer. This is now done by the new `SerialDmaTx` wrapper.

## Added

- serial: Public `is_event_triggered` method which allows to check for events
  given an event and a USART reference.

If you consider this mergeable (with adaptions/changes), I also have some other branches which build on top of these changes, for example the splitting of RX and TX events.