### PR TITLE
extend ticks calculation in timer start from u32 to u64

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -279,9 +279,9 @@ where
         let timeout: Self::Time = timeout.into();
         let clock = TIM::clock(&self.clocks);
 
-        let ticks = clock.integer().saturating_mul(timeout.integer()) * *timeout.scaling_factor();
+        let ticks = (clock.integer() as u64).saturating_mul(timeout.integer() as u64) * *timeout.scaling_factor();
 
-        let psc: u32 = (ticks.saturating_sub(1)) / (1 << 16);
+        let psc = ticks.saturating_sub(1) / (1 << 16);
         self.tim.set_psc(crate::unwrap!(u16::try_from(psc).ok()));
 
         let mut arr = ticks / psc.saturating_add(1);


### PR DESCRIPTION
Fixes #342 