### PR TITLE
Add channel impls for pins PE9 and PE10 when using stm32f303xe feature 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add missing ADC channels ([#337])
 - Add many `#[must_use]` instances ([#347])
+- Add missing ADC channels ([#345])
 
 ### Fixed
 
@@ -598,6 +599,7 @@ let clocks = rcc
 [defmt]: https://github.com/knurling-rs/defmt
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
+[#345]: https://github.com/stm32-rs/stm32f3xx-hal/pull/345
 [#346]: https://github.com/stm32-rs/stm32f3xx-hal/pull/346
 [#347]: https://github.com/stm32-rs/stm32f3xx-hal/pull/347
 [#340]: https://github.com/stm32-rs/stm32f3xx-hal/pull/340

--- a/src/adc/channel.rs
+++ b/src/adc/channel.rs
@@ -294,6 +294,8 @@ cfg_if::cfg_if! {
             (PD13, [(ADC3, Id::Ten), (ADC4, Id::Ten)]),
             (PD14, [(ADC3, Id::Eleven), (ADC4, Id::Eleven)]),
             (PD9, [(ADC4, Id::Thirteen)]),
+            (PE9, [(ADC3, Id::Two)]),
+            (PE10, [(ADC3, Id::Fourteen)]),
             (PE11, [(ADC3, Id::Fifteen)]),
             (PE12, [(ADC3, Id::Sixteen)]),
             (PE7, [(ADC3, Id::Thirteen)]),


### PR DESCRIPTION
Fixes https://github.com/stm32-rs/stm32f3xx-hal/issues/344.