### PR TITLE
Extend ticks calculation in timer start from u32 to u64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix wrong timer frequency calculation and unexpected panics ([#338])
+- Fixed integer saturation in Timer::start, see #342 ([#356])
 
 ### Changed
 
@@ -614,6 +615,7 @@ let clocks = rcc
 [defmt]: https://github.com/knurling-rs/defmt
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
+[#356]: https://github.com/stm32-rs/stm32f3xx-hal/pull/356
 [#352]: https://github.com/stm32-rs/stm32f3xx-hal/pull/352
 [#351]: https://github.com/stm32-rs/stm32f3xx-hal/pull/351
 [#350]: https://github.com/stm32-rs/stm32f3xx-hal/pull/350

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -281,9 +281,10 @@ where
         let timeout: Self::Time = timeout.into();
         let clock = TIM::clock(&self.clocks);
 
-        let ticks = clock.integer().saturating_mul(timeout.integer()) * *timeout.scaling_factor();
+        let ticks = u64::from(clock.integer()).saturating_mul(u64::from(timeout.integer()))
+            * *timeout.scaling_factor();
 
-        let psc: u32 = (ticks.saturating_sub(1)) / (1 << 16);
+        let psc = ticks.saturating_sub(1) / (1 << 16);
         self.tim.set_psc(crate::unwrap!(u16::try_from(psc).ok()));
 
         let mut arr = ticks / psc.saturating_add(1);


### PR DESCRIPTION
Supersedes #343
Fixes #342