### PR TITLE
RtcBuilder for Rtc easy initialization and access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-No changes.
+- Added RtcBuilder for rtc module
 
 ## [v0.10.0] - 2023-11-30
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -103,7 +103,7 @@ impl RtcBuilder {
     ///
     /// If your using:
     ///
-    /// - ***LSE*** - your clock will be accurate, but it is external peripheral, so might not have it.
+    /// - ***LSE*** - your clock will be accurate, but it is external peripheral, so you might not have it.
     ///
     /// - ***LSI*** - your clock might be not accurate, but if you don't need super accurate clock you can use LSI.
     /// It is build in microcontroller clock source.
@@ -598,7 +598,7 @@ fn unlock(apb1: &mut APB1, pwr: &mut PWR) {
     while pwr.cr.read().dbp().bit_is_clear() {}
 }
 
-/// Enable RTC withLow Speed Internal clock (LSI) as clock source.
+/// Enable RTC with Low Speed Internal clock (LSI) as clock source.
 fn enable_rtc_with_lsi(bdcr: &mut BDCR) {
     bdcr.bdcr().modify(|_, w| w.bdrst().enabled());
     bdcr.bdcr().modify(|_, w| {

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -582,8 +582,10 @@ fn enable_lse(bdcr: &mut BDCR, bypass: bool) {
 /// Enable the low frequency internal oscillator (LSI) - potentially unsafe
 ///
 /// # Safety
-/// Function potentially unsafe because of writing in to CSR
+/// Function potentially unsafe because of writing into CSR
 fn enable_lsi() {
+    // SAFETY:
+    // potentially unsafe because of writing into CSR
     let rcc = unsafe { &*RCC::ptr() };
     rcc.csr.modify(|_, w| w.lsion().set_bit());
     while rcc.csr.read().lsirdy().bit_is_clear() {}


### PR DESCRIPTION
Added a builder that facilitates the initialization of RTC with various clock sources (LSE or LSI, HSE in future). The intent of the update is to easy access to other clock sources without the need for detailed knowledge of this modules configuration while still offering the ability to modify default settings. The solution does not affect the existing setup so as not to force current users to update their existing code. Easy to expand. 