### PR TITLE
Rename AlreadyCancled and configure_intterupt

### DIFF
--- a/src/dma.rs
+++ b/src/dma.rs
@@ -405,7 +405,14 @@ pub trait Channel: private::Channel {
     }
 
     /// Enable or disable the interrupt for the specified [`Event`].
+    #[deprecated(note = "Please use `configure_interrupt` instead.")]
+    #[inline(always)]
     fn configure_intterupt(&mut self, event: Event, enable: bool) {
+        self.configure_interrupt(event, enable)
+    }
+
+    /// Enable or disable the interrupt for the specified [`Event`].
+    fn configure_interrupt(&mut self, event: Event, enable: bool) {
         match event {
             Event::HalfTransfer => self.ch().cr.modify(|_, w| w.htie().bit(enable)),
             Event::TransferComplete => self.ch().cr.modify(|_, w| w.tcie().bit(enable)),
@@ -420,12 +427,12 @@ pub trait Channel: private::Channel {
 
     /// Enable the interrupt for the given [`Event`].
     fn enable_interrupt(&mut self, event: Event) {
-        self.configure_intterupt(event, true);
+        self.configure_interrupt(event, true);
     }
 
     /// Disable the interrupt for the given [`Event`].
     fn disable_interrupt(&mut self, event: Event) {
-        self.configure_intterupt(event, false);
+        self.configure_interrupt(event, false);
     }
 
     /// Start a transfer

--- a/src/syscfg.rs
+++ b/src/syscfg.rs
@@ -67,10 +67,10 @@ impl SysCfg {
     ///
     /// This means, that only on of `PA1`, `PB1`, `PC1`, ... can be activated.
     ///
-    /// For example, if first [`crate::gpio::gpioa::PA1`] and than [`crate::gpio::gpiob::PB1`]
+    /// For example, if first [`crate::gpio::gpioa::PA1`] and then [`crate::gpio::gpiob::PB1`]
     /// would be configured, the former configuration would be overwritten.
     ///
-    /// But configuring `PA1` and and `PB2` works!
+    /// But configuring `PA1` and `PB2` works!
     #[doc(alias = "enable_interrupt")]
     pub fn select_exti_interrupt_source<Gpio, Index, Mode>(&mut self, pin: &Pin<Gpio, Index, Mode>)
     where

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -317,7 +317,7 @@ where
     }
 
     /// Wait until [`Event::Update`] / the timer has elapsed
-    /// and than clear the event.
+    /// and then clear the event.
     fn wait(&mut self) -> nb::Result<(), Void> {
         if self.tim.is_sr_uief_set() {
             self.clear_event(Event::Update);
@@ -328,20 +328,24 @@ where
     }
 }
 
-/// Error if a [`Cancel`]-ble [`Timer`] was cancled already or never been started.
+/// Error if a [`Cancel`]-ble [`Timer`] was canceled already or never been started.
+#[deprecated(note = "Use `AlreadyCanceled` instead of `AlreadyCancled`.")]
+pub type AlreadyCancled = AlreadyCanceled;
+
+/// Error if a [`Cancel`]-ble [`Timer`] was canceled already or never been started.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct AlreadyCancled;
+pub struct AlreadyCanceled;
 
 impl<TIM> Cancel for Timer<TIM>
 where
     TIM: Instance,
 {
-    type Error = AlreadyCancled;
+    type Error = AlreadyCanceled;
     fn cancel(&mut self) -> Result<(), Self::Error> {
         // If timer is already stopped.
         if !self.tim.is_cr1_cen_set() {
-            return Err(AlreadyCancled);
+            return Err(AlreadyCanceled);
         }
         self.stop();
         Ok(())

--- a/testsuite/tests/timer.rs
+++ b/testsuite/tests/timer.rs
@@ -15,7 +15,7 @@ use hal::hal::timer::Cancel;
 use hal::interrupts::InterruptNumber;
 use hal::rcc::{Clocks, APB1};
 use hal::time::{duration, fixed_point::FixedPoint};
-use hal::timer::{AlreadyCancled, Event, MonoTimer, Timer};
+use hal::timer::{AlreadyCanceled, Event, MonoTimer, Timer};
 use hal::{interrupt, pac, prelude::*};
 
 use pac::TIM2;
@@ -125,7 +125,7 @@ mod tests {
         state.delay.delay_ms(5u32);
 
         assert_eq!(timer.cancel(), Ok(()));
-        assert_eq!(timer.cancel(), Err(AlreadyCancled));
+        assert_eq!(timer.cancel(), Err(AlreadyCanceled));
         state.timer = Some(timer);
     }
 


### PR DESCRIPTION
This corrects some typos in documentation comments and renames the `AlreadyCancled` type to `AlreadyCanceled`. In order to not make it a breaking change, a type alias was introduced alongside a deprecation notice.

This also resolves the `configure_intterupt` typo reported in #360.