### PR TITLE
Update stm32-usbd to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ embedded-hal = { version = "0.2.7", features = ["unproven"] }
 embedded-time = "0.12.1"
 enumset = { version = "1.1.3", optional = true }
 nb = "1.1.0"
-num-traits = { version = "0.2.17", default-features = false}
+num-traits = { version = "0.2.17", default-features = false }
 paste = "1.0.14"
 rtcc = { version = "0.3.0", optional = true }
-stm32-usbd = { version = "0.6.0", optional = true }
+stm32-usbd = { version = "0.7.0", optional = true }
 stm32f3 = { version = "0.15.1", default-features = false }
 void = { version = "1.0.2", default-features = false }
 
@@ -56,8 +56,8 @@ panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
 panic-semihosting = "0.6.0"
 rtt-target = { version = "0.4.0" }
 systick-monotonic = "1.0"
-usb-device = "0.3.1"
-usbd-serial = "0.2.0"
+usb-device = "0.3.2"
+usbd-serial = "0.2.2"
 
 [build-dependencies]
 slice-group-by = "0.3.1"


### PR DESCRIPTION
`stm32-usbd` has released version [0.7.0](https://github.com/stm32-rs/stm32-usbd/pull/36), which updates its `usb-device` dependency from `0.2.9` to `0.3.3`. This unblocks other implementations that previously needed a version patch. For an example, see e.g. https://github.com/stm32-rs/stm32-usbd/issues/35.