### PR TITLE
Bump MSRV to 1.65

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.60.0
+          toolchain: 1.65.0
           target: thumbv7em-none-eabihf
       - run: cargo check --features=stm32f303xc,usb,rt,can,ld --lib
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-No changes.
+### Changed
+
+- The MSRV was bumped to 1.65 ([#367])
 
 ## [v0.10.0] - 2023-11-30
 
@@ -619,6 +621,7 @@ let clocks = rcc
 [defmt]: https://github.com/knurling-rs/defmt
 [filter]: https://defmt.ferrous-systems.com/filtering.html
 
+[#367]: https://github.com/stm32-rs/stm32f3xx-hal/pull/367
 [#356]: https://github.com/stm32-rs/stm32f3xx-hal/pull/356
 [#352]: https://github.com/stm32-rs/stm32f3xx-hal/pull/352
 [#351]: https://github.com/stm32-rs/stm32f3xx-hal/pull/351

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/stm32f3xx-hal"
 version = "0.10.0"
 exclude = ["codegen", ".markdownlint.yml"]
 resolver = "2"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 features = ["stm32f303xc", "rt", "usb", "can", "enumset"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crate](https://img.shields.io/crates/v/stm32f3xx-hal.svg)](https://crates.io/crates/stm32f3xx-hal)
 [![Docs](https://docs.rs/stm32f3xx-hal/badge.svg)](https://docs.rs/stm32f3xx-hal)
 [![Crates.io](https://img.shields.io/crates/d/stm32f3xx-hal.svg)](https://crates.io/crates/stm32f3xx-hal)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.60+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.65+-blue.svg)
 
 `stm32f3xx-hal` contains a multi device hardware abstraction on top of the
 peripheral access API for the STMicro STM32F3 series microcontrollers. The
@@ -37,7 +37,9 @@ Almost all of the implementation was shamelessly adapted from the
 [`stm32f30x-hal`][] crate by Jorge Aparicio.
 
 [`stm32f3`]: https://crates.io/crates/stm32f3
+
 [`stm32f30x-hal`]: https://github.com/japaric/stm32f30x-hal
+
 [`embedded-hal`]: https://github.com/japaric/embedded-hal
 
 ## Getting Started
@@ -88,7 +90,7 @@ You can find a list [here, in the docs][chip-features].
 #### Note
 
 1. This features are mutually exclusive. Only one feature / chip variant can be
-chosen.
+   chosen.
 2. You **have** to choose exactly **one** feature to build this crate at all.
 
 [chip-features]: https://docs.rs/stm32f3xx-hal/latest/stm32f3xx_hal/#target-chip-selection


### PR DESCRIPTION
Some dependencies break the build on 1.60. The lowest version that succeeded the builds was 1.65, due to `let..else` statements in `usb-device` 0.3.2. See #368 for updating the MSRV since that check now fails.